### PR TITLE
chore: establish branch-based git workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Contexto
+
+<!-- Qual fase do roadmap / RF / US isso atende, e por que essa mudança existe.
+     Se existe docs/features/NNN-slug/, linka aqui (spec.md tem o problema, plan.md tem as decisões). -->
+
+## O que mudou
+
+<!-- Lista objetiva do que foi adicionado/alterado/removido. Área por área, não arquivo por arquivo
+     (o diff já mostra os arquivos) — o que muda de comportamento observável. -->
+
+## Decisões de design
+
+<!-- Só o que NÃO é óbvio olhando o diff: trade-offs, alternativas rejeitadas e por quê,
+     desvios de padrão existente. Se não houve decisão não-trivial, escreva "nenhuma". -->
+
+## Como testar
+
+<!-- Passos pra revisar rodando localmente: comandos, URLs, dados/fixtures necessários,
+     o que observar pra confirmar que funciona. -->
+
+## Checklist
+
+- [ ] `npx tsc --noEmit` limpo
+- [ ] `yarn test` verde
+- [ ] `yarn build` verde (se a mudança toca rota/build)
+- [ ] `/docs` atualizado se a mudança é load-bearing (regra dura, ADR, gotcha, spec/plan/tasks)
+- [ ] Sem segredo no diff (`git diff main... | grep -nE "(token|secret|api[_-]?key|password|bearer)\s*[:=]\s*['\"][^'\"]+"` vazio)
+
+## Fora de escopo / débito conhecido
+
+<!-- O que foi deliberadamente deixado de fora nesta rodada, e por quê. -->

--- a/docs/.afm-log/events/2026-07.md
+++ b/docs/.afm-log/events/2026-07.md
@@ -235,3 +235,4 @@
 - [2026-07-14T16:11:01Z] feature-spec | s=5d247c | edit em docs/features/015-seo-metadata/spec.md
 - [2026-07-14T16:11:13Z] feature-spec | s=5d247c | edit em docs/features/015-seo-metadata/spec.md
 - [2026-07-14T16:11:17Z] feature-plan | s=5d247c | edit em docs/features/015-seo-metadata/plan.md
+- [2026-07-14T17:00:13Z] rule | s=6081a9 | edit em docs/afm.md

--- a/docs/afm.md
+++ b/docs/afm.md
@@ -176,8 +176,10 @@ Toda regra abaixo tem **gatilho executável** que o agente roda no teclado — p
     *Verificação:* `rg -n "from.*@prisma/client|new PrismaClient|@/server/infra/drivers/prisma" src/server/features/*/domain/*.ts src/server/features/*/procedures/*.ts` retorna 0. **Compliant hoje.**
 31. **Route handler (`src/app/api/**/route.ts`) é fino.** Delega pro tRPC handler; nenhuma regra de negócio inline.
     *Verificação:* `find src/app/api -name route.ts | xargs wc -l` — todos < 80 linhas. **Compliant hoje** (único route: `src/app/api/trpc/[trpc]/route.ts`).
+32. **Nenhum commit direto em `main`/`develop`.** Todo trabalho de código acontece num branch de feature criado a partir de `develop` (nome em inglês, ex. `feature/016-search-content`), commits seguindo `.commitlintrc` (Conventional Commits, em inglês). PR contra `develop` usando `.github/pull_request_template.md`; só o dono aprova/faz merge no GitHub. `main` só recebe merge de `develop` em release/deploy, nunca commit ou merge de feature branch direto. Branch protection no GitHub (`main`/`develop`, PR obrigatório) é camada extra — o enforcement primário é este check antes de commitar.
+    *Verificação:* `git rev-parse --abbrev-ref HEAD` não é `main` nem `develop`. Se for, cria/troca pra branch de feature antes de qualquer `git commit`.
 
-{{Adicione regras duras específicas do projeto aqui — numere a partir de 32.}}
+{{Adicione regras duras específicas do projeto aqui — numere a partir de 33.}}
 
 ---
 


### PR DESCRIPTION
## Contexto

Até agora os commits iam direto em `main`, sem branch de feature e sem PR — sem histórico de tasks/tickets, isso deixava a revisão dependendo de reconstruir contexto do diff sozinho.

A partir de agora: `main` = produção, `develop` = integração, toda feature nasce em branch própria e vira PR contra `develop`. Como não há tracker de tasks, a descrição do PR precisa carregar sozinha o contexto suficiente pra revisão (ver template novo).

## O que mudou

- Criado o branch `develop` a partir do `main` atual e publicado no remoto (`origin/develop`). O branch remoto antigo `origin/dev` (parado desde nov/2025, ~186 commits divergentes de `main` — de antes da adoção do AFM) foi deixado intocado para decisão futura.
- Branch protection configurada no GitHub para `main` e `develop`: exige PR antes de merge, bloqueia force-push e deleção. `enforce_admins` ficou desligado de propósito — GitHub não permite auto-aprovar o próprio PR, então travar admins também travaria o dono de fazer merge sozinho num repo solo.
- Novo `.github/pull_request_template.md`: contexto, o que mudou, decisões de design, como testar, checklist, fora de escopo — pensado pra compensar a ausência de tasks/tickets.
- Nova regra dura 32 em `docs/afm.md` § 3: nenhum commit direto em `main`/`develop`; gatilho executável é checar `git rev-parse --abbrev-ref HEAD` antes de cada commit. Essa é a aplicação primária do fluxo (o enforcement do GitHub é camada extra, já que `enforce_admins` está desligado).

## Decisões de design

- `commitlint` + hook `commit-msg` já existiam no repo (`.commitlintrc`, husky) — não precisou de tooling novo, só passou a valer o hábito de escrever em inglês.
- Não mudei o "default branch" do GitHub (continua `main`) — PRs de feature vão sempre explicitamente contra `develop` via `--base develop`, sem depender do default do repo.
- `origin/dev` antigo não foi tocado (nem deletado, nem renomeado) — está muito divergente e pode ter histórico relevante; fica pra você decidir o que fazer com ele.

## Como testar

- `git branch -a` mostra `develop` local e remoto.
- `gh api repos/SemIdea/bearboo/branches/main/protection` e `.../develop/protection` retornam `required_pull_request_reviews` não-nulo.
- Tentar `git push origin main` ou `git push origin develop` direto (sem PR) deve ser rejeitado pelo GitHub.
- Abrir `.github/pull_request_template.md` e conferir que é o texto usado nesta própria PR.

## Checklist

- [x] `npx tsc --noEmit` limpo (nada de código tocado)
- [x] `yarn test` verde (259/259, corre no pre-push hook)
- [ ] `yarn build` — não aplicável, mudança é só docs/config
- [x] `/docs` atualizado (`docs/afm.md` regra 32)
- [x] Sem segredo no diff

## Fora de escopo / débito conhecido

- Decidir o destino do `origin/dev` antigo (arquivar/deletar) — não mexi, fica pra você.
- CI automatizado (rodar lint/test/build como GitHub Actions status check) não existe ainda — a proteção de branch hoje só exige PR, não exige checks verdes. Se quiser, é um follow-up natural.