### PR TITLE
fix(auth): stop session-refresh double-fire and infinite /auth/login reload loop

### DIFF
--- a/src/app/(smal)/auth/refresh/page.client.tsx
+++ b/src/app/(smal)/auth/refresh/page.client.tsx
@@ -2,24 +2,17 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
-import { trpc } from "@/app/_trpc/client";
+import { refreshTokens } from "@/context/trpc/session";
 
 const SessionRefresher = () => {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const redirect = searchParams.get("redirect") || "/";
 
-	const { mutate: refreshSession } = trpc.auth.refreshSession.useMutation({
-		onSuccess: () => {
-			router.push(redirect);
-		},
-		onError: () => {
-			router.push("/auth/login");
-		},
-	});
-
 	useEffect(() => {
-		refreshSession();
+		refreshTokens()
+			.then(() => router.push(redirect))
+			.catch(() => router.push("/auth/login"));
 	}, [redirect]);
 
 	return null;

--- a/src/context/trpc/__test__/session.ts
+++ b/src/context/trpc/__test__/session.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { refreshTokens, setTRPCClientInstance } from "../session";
+
+describe("refreshTokens", () => {
+	beforeEach(() => {
+		vi.stubGlobal("window", {});
+		setTRPCClientInstance(null as never);
+	});
+
+	test("throws when no client instance was set up yet", async () => {
+		await expect(refreshTokens()).rejects.toThrowError("No refresh setup");
+	});
+
+	test("dedupes concurrent calls into a single network request (guards against React Strict Mode double-invoking the refresh effect, which used to make the second call look like refresh-token reuse and revoke the session)", async () => {
+		let resolveMutate: () => void;
+		const mutate = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveMutate = resolve;
+				}),
+		);
+		setTRPCClientInstance({
+			auth: { refreshSession: { mutate } },
+		} as never);
+
+		const first = refreshTokens();
+		const second = refreshTokens();
+
+		resolveMutate!();
+		await Promise.all([first, second]);
+
+		expect(mutate).toHaveBeenCalledTimes(1);
+	});
+
+	test("allows a new refresh after the previous one has settled", async () => {
+		const mutate = vi.fn().mockResolvedValue(undefined);
+		setTRPCClientInstance({
+			auth: { refreshSession: { mutate } },
+		} as never);
+
+		await refreshTokens();
+		await refreshTokens();
+
+		expect(mutate).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/context/trpc/__test__/sessionRefreshLink.ts
+++ b/src/context/trpc/__test__/sessionRefreshLink.ts
@@ -42,7 +42,7 @@ const fakeOp = {
 
 describe("sessionRefreshLink", () => {
 	beforeEach(() => {
-		vi.stubGlobal("window", { location: { href: "" } });
+		vi.stubGlobal("window", { location: { href: "", pathname: "" } });
 		vi.mocked(refreshTokens).mockReset();
 	});
 
@@ -154,6 +154,28 @@ describe("sessionRefreshLink", () => {
 
 		expect(window.location.href).toBe("");
 		expect(errorSpy).toHaveBeenCalledWith(invalidCredentialsError);
+	});
+
+	test("does not reload the page when INVALID_TOKEN fires while already on /auth/login (avoids the infinite reload loop when a stale cookie keeps being resent)", () => {
+		vi.stubGlobal("window", {
+			location: { href: "", pathname: "/auth/login" },
+		});
+		const invalidTokenError = errorWith(
+			"UNAUTHORIZED",
+			SessionErrorCode.INVALID_TOKEN,
+		);
+		const next = vi
+			.fn()
+			.mockReturnValue(
+				fakeObservable((observer) => observer.error(invalidTokenError)),
+			);
+
+		const errorSpy = vi.fn();
+		const link = sessionRefreshLink({})({ op: fakeOp, next });
+		link.subscribe({ next: vi.fn(), error: errorSpy, complete: vi.fn() });
+
+		expect(window.location.href).toBe("");
+		expect(errorSpy).toHaveBeenCalledWith(invalidTokenError);
 	});
 
 	test("redirects to /auth/verify on USER_NOT_VERIFIED without swallowing the error", () => {

--- a/src/context/trpc/sessionRefreshLink.ts
+++ b/src/context/trpc/sessionRefreshLink.ts
@@ -6,6 +6,8 @@ import { SessionErrorCode } from "@/shared/error/session";
 import { refreshTokens } from "./session";
 
 const redirectTo = (path: string): void => {
+	if (window.location.pathname === path) return;
+
 	window.location.href = path;
 };
 

--- a/src/server/__test__/createContext.ts
+++ b/src/server/__test__/createContext.ts
@@ -1,4 +1,6 @@
+import { TRPCError } from "@trpc/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { SessionErrorCode } from "@/shared/error/session";
 import { createTRPCContext } from "../createContext";
 
 const readUserAndSessionByAccessTokenMock = vi.hoisted(() => vi.fn());
@@ -70,5 +72,40 @@ describe("createTRPCContext", () => {
 		});
 
 		expect(ctx.user).toBeUndefined();
+	});
+
+	test("degrades to an anonymous context and clears stale cookies when the access token is invalid, instead of throwing", async () => {
+		readUserAndSessionByAccessTokenMock.mockRejectedValue(
+			new TRPCError({
+				code: "UNAUTHORIZED",
+				message: SessionErrorCode.INVALID_TOKEN,
+			}),
+		);
+
+		const ctx = await createTRPCContext({
+			headers: new Headers({
+				cookie: "accessToken=stale-token; refreshToken=stale-refresh",
+			}),
+		});
+
+		expect(ctx.user).toBeUndefined();
+		expect(ctx.resCookies.pending).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: "accessToken", value: "" }),
+				expect.objectContaining({ name: "refreshToken", value: "" }),
+			]),
+		);
+	});
+
+	test("does not swallow errors unrelated to an invalid token", async () => {
+		readUserAndSessionByAccessTokenMock.mockRejectedValue(
+			new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "db down" }),
+		);
+
+		await expect(
+			createTRPCContext({
+				headers: new Headers({ cookie: "accessToken=some-token" }),
+			}),
+		).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
 	});
 });

--- a/src/server/createContext.ts
+++ b/src/server/createContext.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import { parseCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import { env } from "@/lib/env";
 import { domain_readUserAndSessionByAccessToken } from "./features/auth/domain/readUserAndSessionByAccessToken";
@@ -54,10 +55,22 @@ const createTRPCContext = async ({
 	if (visitorId) ctx.visitorId = visitorId;
 	if (!accessToken) return ctx;
 
-	const user = await domain_readUserAndSessionByAccessToken({
-		ctx,
-		input: { accessToken },
-	});
+	let user: IUserWithSession | null;
+
+	try {
+		user = await domain_readUserAndSessionByAccessToken({
+			ctx,
+			input: { accessToken },
+		});
+	} catch (error) {
+		if (error instanceof TRPCError && error.code === "UNAUTHORIZED") {
+			ctx.resCookies.clear("accessToken");
+			ctx.resCookies.clear("refreshToken");
+			return ctx;
+		}
+
+		throw error;
+	}
 
 	if (!user) return ctx;
 

--- a/src/server/features/auth/procedures/__test__/refreshSession.ts
+++ b/src/server/features/auth/procedures/__test__/refreshSession.ts
@@ -68,6 +68,43 @@ describe("Refresh Session Controller Unitary Testing", () => {
 		);
 	});
 
+	test("Should clear accessToken/refreshToken cookies when the refresh token is invalid or reused, so the client stops resending a dead cookie", async () => {
+		ctx.refreshToken = "invalid-token";
+
+		await AuthRouter.createCaller(ctx)
+			.refreshSession()
+			.catch(() => undefined);
+
+		expect(ctx.resCookies.pending).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: "accessToken", value: "" }),
+				expect.objectContaining({ name: "refreshToken", value: "" }),
+			]),
+		);
+	});
+
+	test("Should clear cookies when a rotated-out refresh token is reused (e.g. a duplicate refresh call racing the first one)", async () => {
+		const originalRefreshToken = ctx.user.session.refreshToken;
+		ctx.refreshToken = originalRefreshToken;
+
+		await AuthRouter.createCaller(ctx).refreshSession();
+
+		ctx.refreshToken = originalRefreshToken;
+
+		await AuthRouter.createCaller(ctx)
+			.refreshSession()
+			.catch(() => undefined);
+
+		expect(ctx.resCookies.pending.at(-2)).toMatchObject({
+			name: "accessToken",
+			value: "",
+		});
+		expect(ctx.resCookies.pending.at(-1)).toMatchObject({
+			name: "refreshToken",
+			value: "",
+		});
+	});
+
 	test("Should enforce the refresh rate limit", async () => {
 		ctx.refreshToken = "invalid-token";
 

--- a/src/server/features/auth/procedures/refreshSession.ts
+++ b/src/server/features/auth/procedures/refreshSession.ts
@@ -23,6 +23,10 @@ const procedure_refreshSession = t.procedure
 		const session = await domain_readSessionByRefreshToken({
 			ctx,
 			input: { refreshToken },
+		}).catch((error) => {
+			ctx.resCookies.clear("accessToken");
+			ctx.resCookies.clear("refreshToken");
+			throw error;
 		});
 
 		const refreshedSession = await domain_refreshSession({


### PR DESCRIPTION
## Contexto

Enquanto rodava `next dev` localmente, editar um post disparou o seguinte encadeamento (visto no log do dev server):

1. `/post/edit/[id]` teve a sessão expirar → redirect pra `/auth/refresh?redirect=...`.
2. `SessionRefresher` (`src/app/(smal)/auth/refresh/page.client.tsx`) disparava `trpc.auth.refreshSession.useMutation` direto num `useEffect([redirect])` — sem guard. Em dev, o Strict Mode do React invoca esse efeito duas vezes, então `refreshSession` era chamado duas vezes quase simultaneamente.
3. A primeira chamada tinha sucesso (rotaciona o refresh token). A segunda chamada, usando o refresh token já superado, era lida por `domain_readSessionByRefreshToken` como **reuse de token rotacionado** — exatamente a lógica de reuse-detection do hardening RF-01, pensada pra pegar token roubado sendo reaproveitado por um atacante. Só que aqui era o próprio navegador do usuário, e a sessão inteira era deletada como se fosse um ataque.
4. O `accessToken` cookie (recém-setado pela primeira chamada, mas já apontando pra uma sessão deletada) nunca era limpo — só `logoutUserFromSession` limpa cookie.
5. `createTRPCContext` (`src/server/createContext.ts`) lançava `INVALID_TOKEN` de forma síncrona na criação do contexto sempre que via esse cookie. Isso: (a) derrubava o RSC de `/post/edit/[id]` com uma exceção não tratada (o `onError` de `createDynamicCaller` só cobre erros de procedure, não de criação de contexto), e (b) fazia `sessionRefreshLink` redirecionar pra `/auth/login` via `window.location.href` incondicional.
6. Como o cookie nunca era limpo e o redirect não checava se já estava em `/auth/login`, cada reload de `/auth/login` disparava `session.me` de novo, recebia `INVALID_TOKEN` de novo, e recarregava a página de novo — loop infinito de full page reload.

## O que mudou

- **`src/app/(smal)/auth/refresh/page.client.tsx`** — `SessionRefresher` agora usa o helper `refreshTokens()` (já existente, com guard `isRefreshing`/`refreshPromise`) em vez de chamar a mutation direto. Elimina o disparo duplo na raiz.
- **`src/server/createContext.ts`** — quando o access token é inválido, a criação do contexto degrada pra contexto anônimo (em vez de lançar) e limpa os cookies `accessToken`/`refreshToken` stale. Isso já era o comportamento esperado pelo teste existente `"keeps context anonymous when token lookup returns no user"` — só que a função de domínio nunca retornava `null` de fato, sempre lançava.
- **`src/server/features/auth/procedures/refreshSession.ts`** — limpa os cookies quando o refresh token é inválido ou reuso é detectado (defesa em profundidade, mesmo com o guard do item 1).
- **`src/context/trpc/sessionRefreshLink.ts`** — `redirectTo` vira no-op se já está no path de destino, pra nenhum caso residual reabrir o loop de reload.

## Decisões de design

- Optei por **não** mexer no contrato de `domain_readUserAndSessionByAccessToken` (continua lançando `INVALID_TOKEN`) — só passei a capturar isso no call site de `createContext.ts`, que é a camada de transporte, não domínio. Menor blast radius, e o único outro caller de produção é esse mesmo arquivo.
- Limpar os dois cookies juntos (não só o `accessToken`) segue o mesmo padrão já usado em `logoutUserFromSession` — se a sessão não existe mais, não faz sentido tentar preservar metade do estado de auth.

## Como testar

- `npx tsc --noEmit` limpo.
- `yarn test --run` — 313/313 verdes (suite completa, incluindo os testes novos).
- Testes novos/atualizados:
  - `src/server/__test__/createContext.ts` — contexto fica anônimo + limpa cookies quando o access token é inválido; não engole erros não relacionados.
  - `src/server/features/auth/procedures/__test__/refreshSession.ts` — cookies são limpos quando o refresh token é inválido ou reuso é detectado (cenário de disparo duplo).
  - `src/context/trpc/__test__/session.ts` (novo arquivo) — `refreshTokens()` deduplica chamadas concorrentes numa única chamada de rede.
  - `src/context/trpc/__test__/sessionRefreshLink.ts` — não recarrega a página quando `INVALID_TOKEN` dispara já estando em `/auth/login`.

## Checklist

- [x] `tsc --noEmit` limpo
- [x] `yarn test` verde (suite completa)
- [x] `yarn lint` limpo
- [x] Teste de regressão pra cada um dos dois bugs

## Fora de escopo

- Não mexi na violação pré-existente de regra dura 15 (`domain/readUserAndSessionByAccessToken.ts` importa `TRPCError`) — já catalogada como forward-only em `docs/afm.md § 3.1`, fora do escopo deste fix.