### PR TITLE
fix: clarify /post/mine description for site-wide vs own-scope view

### DIFF
--- a/src/app/(half)/post/mine/page.client.tsx
+++ b/src/app/(half)/post/mine/page.client.tsx
@@ -4,12 +4,36 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { trpc } from "@/app/_trpc/client";
-import { Card, CardContent, CardTitle } from "@/components/ui/card";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardTitle,
+} from "@/components/ui/card";
 import { useAuth } from "@/context/auth";
 import { IPostStatus } from "@/server/models/post";
 
 const selectClassName =
 	"flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring md:text-sm";
+
+const MyPostsDescription = () => {
+	const { session } = useAuth();
+
+	if (!session) {
+		return null;
+	}
+
+	return session.user.role === "AUTHOR" ? (
+		<CardDescription>
+			All your posts, including drafts and archived ones
+		</CardDescription>
+	) : (
+		<CardDescription>
+			All posts site-wide ({session.user.role.toLowerCase()} view), including
+			drafts and archived ones
+		</CardDescription>
+	);
+};
 
 const MyPostsPanel = () => {
 	const router = useRouter();
@@ -115,4 +139,4 @@ const MyPostsPanel = () => {
 	);
 };
 
-export { MyPostsPanel };
+export { MyPostsDescription, MyPostsPanel };

--- a/src/app/(half)/post/mine/page.tsx
+++ b/src/app/(half)/post/mine/page.tsx
@@ -1,20 +1,12 @@
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
-import { MyPostsPanel } from "./page.client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MyPostsDescription, MyPostsPanel } from "./page.client";
 
 const Page = () => {
 	return (
 		<Card className="border-0 shadow-none">
 			<CardHeader>
 				<CardTitle>My Posts</CardTitle>
-				<CardDescription>
-					All your posts, including drafts and archived ones
-				</CardDescription>
+				<MyPostsDescription />
 			</CardHeader>
 			<CardContent>
 				<MyPostsPanel />


### PR DESCRIPTION
## Contexto

Reportado como bug: usuário via posts de outras pessoas ("Ana Souza") na aba **My Posts**.

Investigação: **não é bug de filtro**. `feature/013-role-based-permissions/spec.md` (linha 18) documenta explicitamente que `/post/mine` mostra **todos os posts do site** para `ADMIN`/`EDITOR`, e só os do próprio usuário para `AUTHOR` — decisão que fechou uma pendência da feature 012. O backend (`readOwn` procedure → domain → `readOwnPosts` model) já aplica isso corretamente, coberto por testes de regressão ("should never include another user's posts" / "should return every user's posts for an admin/editor"), 117/117 verdes.

O problema real é só de **copy**: o header da página sempre dizia "My Posts" / "All your posts..." mesmo quando o usuário logado é Admin/Editor vendo o site inteiro — sem nenhuma indicação de que a visão é site-wide.

## O que mudou

- `src/app/(half)/post/mine/page.client.tsx`: novo componente `MyPostsDescription`, que lê `session.user.role` e mostra:
  - `AUTHOR` → "All your posts, including drafts and archived ones" (texto original).
  - `ADMIN`/`EDITOR` → "All posts site-wide (admin/editor view), including drafts and archived ones".
- `src/app/(half)/post/mine/page.tsx`: troca a `CardDescription` estática (server component, sem acesso a `session`) pelo novo componente client-side.

## Fora de escopo

- Nenhuma mudança de query/filtro — comportamento de dados idêntico ao já testado.
- Reverter a visão site-wide para Admin/Editor não foi feito (contrariaria a decisão registrada em `013-role-based-permissions`); se isso for o que realmente se quer, é uma decisão de produto separada.

## Como testar

1. Logar como `AUTHOR` → `/post/mine` mostra só os próprios posts, descrição sem menção a "site-wide".
2. Logar como `ADMIN`/`EDITOR` → `/post/mine` mostra posts de todos os usuários, descrição indica "site-wide (admin/editor view)".

## Checklist

- [x] `npx tsc --noEmit` limpo
- [x] `yarn lint` limpo
- [x] `yarn test` (post feature) 117/117 verdes — nenhuma mudança de lógica de backend
- [x] Verificado que rota `/post/mine` responde 200 no dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)