### PR TITLE
ci: add GitHub Actions pipeline (typecheck, lint, test, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsc --noEmit
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx biome check .
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      DISABLE_REDIS: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres?schema=public"
+      DISABLE_REDIS: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/docs/afm.md
+++ b/docs/afm.md
@@ -265,10 +265,13 @@ Descoberto no scan A.7 (hooks locais — sem CI no repo hoje) e confirmado na en
 
 **Atualizado em 2026-07-06 (ADR-0011)**: os repositórios fake escritos à mão (`src/test/repositories/`) foram substituídos por **`prisma-mock`** — client fake gerado do `schema.prisma`, plugado no seam do driver via `vi.mock` em `src/test/setup.ts` (`setupFiles` do vitest). Os models de produção rodam intactos nos testes; só os gateways continuam com fake manual (`src/test/gateways/`). Isolamento por teste: `resetPrismaMock()` de `src/test/prisma/` (o `$clear()` da lib é bugado — ver comentário no seam). Racional e alternativas em `docs/research/001-teste-prisma-sem-banco-real.md`.
 
+**Atualizado em 2026-08-20**: CI formal chegou (`.github/workflows/ci.yml`), gatilho `pull_request`/`push` em `develop`/`main`. Quatro jobs paralelos: `typecheck` (`npx tsc --noEmit`), `lint` (`npx biome check .` — sem `--write`, diferente do hook local, porque CI precisa falhar em vez de corrigir silenciosamente), `test` (`npm test`, `DISABLE_REDIS=true` pra não poluir log com retry de conexão — testes não dependem de Postgres/Redis real, ver nota 2026-07-04), `build` (`npm run build` contra um serviço `postgres:16` real, porque `prisma migrate deploy` — parte do script `build` desde #206 — exige um banco alcançável). O DoD abaixo deixa de ser "o agente roda manualmente" e passa a ser **verificado automaticamente em todo PR**; a checagem manual continua valendo como sinal antecipado antes do push.
+
 - [ ] Testes novos cobrem o comportamento adicionado/modificado, e rodam verde.
-- [ ] Suíte inteira roda verde (`yarn test`).
-- [ ] Type-check passa (`npx tsc --noEmit`).
-- [ ] Lint passa sem warnings novos (`yarn lint`) — já gateado por `.husky/pre-commit`.
+- [ ] Suíte inteira roda verde (`yarn test`) — gateado por CI (job `test`).
+- [ ] Type-check passa (`npx tsc --noEmit`) — gateado por CI (job `typecheck`).
+- [ ] Lint passa sem warnings novos (`yarn lint`) — gateado por `.husky/pre-commit` localmente e por CI (job `lint`) no PR.
+- [ ] Build de produção passa (`npm run build`) — gateado por CI (job `build`).
 - [ ] Nenhum `any`/`unknown`/`@ts-ignore` novo sem justificativa.
 - [ ] Nenhum arquivo tocado passou de 300 linhas (ou exceção documentada).
 - [ ] Commit referencia US/RF e explica o *porquê*, segue Conventional Commits.
@@ -279,7 +282,7 @@ Descoberto no scan A.7 (hooks locais — sem CI no repo hoje) e confirmado na en
 
 1. `yarn test` (vitest, sem dependência de Docker/Postgres — ver nota de 2026-07-04 acima).
 
-Confirmado na entrevista: mantém só o test runner no pre-push (não adicionar type-check/build nesse hook — ficam no DoD de merge, § 6).
+Confirmado na entrevista: mantém só o test runner no pre-push (não adicionar type-check/build nesse hook — ficam no DoD de merge, § 6). Type-check/lint/build continuam fora do pre-push por serem mais lentos; a partir de 2026-08-20 rodam em paralelo no CI a cada PR, então o hook local segue leve de propósito — CI é a rede de segurança, não o hook.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "next-app-template",
 			"version": "0.0.1",
+			"hasInstallScript": true,
 			"dependencies": {
 				"@hookform/resolvers": "^5.2.0",
 				"@prisma/client": "^6.5.0",
@@ -715,9 +716,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -735,9 +733,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -755,9 +750,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -775,9 +767,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1086,6 +1075,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
 			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1107,6 +1097,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
 			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1723,9 +1714,6 @@
 			"cpu": [
 				"arm"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1741,9 +1729,6 @@
 			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1761,9 +1746,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1779,9 +1761,6 @@
 			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
 			"cpu": [
 				"riscv64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1799,9 +1778,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1817,9 +1793,6 @@
 			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1837,9 +1810,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1856,9 +1826,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1874,9 +1841,6 @@
 			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
 			"cpu": [
 				"arm"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1900,9 +1864,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1924,9 +1885,6 @@
 			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
 			"cpu": [
 				"ppc64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1950,9 +1908,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1974,9 +1929,6 @@
 			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
 			"cpu": [
 				"s390x"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2000,9 +1952,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2025,9 +1974,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2049,9 +1995,6 @@
 			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2854,6 +2797,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
 			"integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -2913,9 +2857,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2931,9 +2872,6 @@
 			"integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2951,9 +2889,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2969,9 +2904,6 @@
 			"integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3836,6 +3768,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3852,6 +3785,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3868,6 +3802,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3884,6 +3819,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3900,6 +3836,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3916,9 +3853,7 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3935,9 +3870,7 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3954,9 +3887,7 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3973,9 +3904,7 @@
 			"cpu": [
 				"s390x"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3992,9 +3921,7 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4011,9 +3938,7 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4030,6 +3955,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4046,6 +3972,7 @@
 			"cpu": [
 				"wasm32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -4061,6 +3988,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
 			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -4074,6 +4002,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4090,6 +4019,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4333,9 +4263,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4353,9 +4280,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4373,9 +4297,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4393,9 +4314,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4630,6 +4548,7 @@
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
 			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -4806,7 +4725,7 @@
 			"version": "20.19.43",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
 			"integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -6796,6 +6715,25 @@
 			},
 			"funding": {
 				"url": "https://ko-fi.com/dangreen"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+			"integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@simple-libs/stream-utils": "^1.2.0",
+				"meow": "^13.0.0"
+			},
+			"bin": {
+				"conventional-commits-parser": "dist/cli/index.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/git-raw-commits/node_modules/meow": {
@@ -8918,7 +8856,7 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
 			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
@@ -9054,6 +8992,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9074,6 +9013,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9094,6 +9034,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9114,6 +9055,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9134,6 +9076,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9154,9 +9097,7 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9177,9 +9118,7 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9200,9 +9139,7 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9223,9 +9160,7 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"musl"
-			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9246,6 +9181,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9266,6 +9202,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12466,7 +12403,7 @@
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unified": {
@@ -13058,7 +12995,7 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
 			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"


### PR DESCRIPTION
## Contexto

Não havia CI no repo — todo o DoD de merge (`docs/afm.md` § 6: type-check, lint, testes, build) dependia dos hooks locais do Husky rodados manualmente por quem fizesse push, sem gate nenhum sobre o PR em si. Confirmado enquanto comparava as regras deste projeto com outro (`seolevel`) que já roda CI completo.

## O que mudou

- `.github/workflows/ci.yml`: 4 jobs paralelos, gatilho em `pull_request`/`push` pra `develop`/`main`, `concurrency` cancelando run anterior do mesmo ref.
  - `typecheck` — `npx tsc --noEmit`.
  - `lint` — `npx biome check .` (sem `--write`).
  - `test` — `npm test` (vitest, com `DISABLE_REDIS=true`).
  - `build` — `npm run build` contra um serviço `postgres:16`, já que `prisma migrate deploy` (parte do script `build` desde #206) exige banco alcançável.
- `docs/afm.md` § 6: nota datada registrando que o DoD agora é verificado automaticamente por CI, não só manualmente.

## Decisões de design

- **`lint` roda `biome check` sem `--write`, diferente do script `lint` do `package.json`** (que usa `--write`, pensado pro hook local). Em CI o objetivo é falhar em violação, não corrigir silenciosamente e passar verde — por isso chamei o binário direto em vez do script existente.
- **Só o job `build` sobe um serviço Postgres.** A suíte de testes não precisa (mocka Prisma inteiro via `prisma-mock`, confirmado em `src/test/setup.ts`/`src/test/prisma/`) — só `prisma migrate deploy` no build precisa de banco real. Evita subir um serviço desnecessário nos outros 3 jobs.
- **`DISABLE_REDIS=true` no `test` e no `build`.** Nenhum dos dois precisa de Redis de verdade (o gateway de view counter cai pra implementação in-memory quando essa flag está ligada — `src/server/infra/container/gateways.ts`); sem isso o log de teste fica poluído com `ECONNREFUSED` do ioredis tentando conectar (confirmado localmente).
- **Node 20**, pra bater com `ARG NODE_VERSION=20-alpine` do `Dockerfile` de produção.
- Não abri `docs/features/023-.../` pra isso — não bate nenhum critério do `afm.md` § 2.1 (não é nova camada da aplicação, não tem boundary externo novo do produto, é 1 arquivo + 1 nota de doc).

## Como testar

Validado localmente antes de abrir o PR (não só "deveria funcionar"):
- `npx tsc --noEmit` limpo.
- `npx biome check .` limpo (371 arquivos).
- `npm test` — 377/377 passando.
- `npm run build` — rodado de ponta a ponta contra um `postgres:16` real em Docker (`prisma migrate deploy` aplicou as 18 migrations + `next build` completo, 22 rotas). Já removi o container de verificação.

Pra revisar rodando: abrir este PR já dispara os 4 jobs — os checks na aba "Checks" mostram o mesmo resultado.

## Checklist

- [x] `npx tsc --noEmit` limpo
- [x] `yarn test` verde
- [x] `yarn build` verde (se a mudança toca rota/build)
- [x] `/docs` atualizado se a mudança é load-bearing (regra dura, ADR, gotcha, spec/plan/tasks)
- [x] Sem segredo no diff (`git diff main... | grep -nE "(token|secret|api[_-]?key|password|bearer)\s*[:=]\s*['\"][^'\"]+"` vazio)

## Fora de escopo / débito conhecido

- **Branch protection no GitHub** (exigir os checks de CI antes de merge) não está configurada por este PR — é uma ação de settings do repo, fora do escopo de um PR de código; fica pra você ligar depois que este pipeline provar estabilidade em alguns PRs.
- **Cache de dependências entre jobs** (`actions/setup-node` já cacheia `~/.npm` via `cache: npm`, mas não há cache de `node_modules` compartilhado entre os 4 jobs) — cada job faz `npm ci` do zero (~20s aqui localmente). Não otimizei além disso; se o tempo de CI incomodar, dá pra revisitar.
- **Vulnerabilidades do `npm audit`** (82 reportadas pelo GitHub no push, 3 críticas) são pré-existentes no `package-lock.json` — não são deste PR e não tentei resolver aqui.