### PR TITLE
docs: commit session logs, event log and error-models learn digests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ public/uploads/*
 !public/uploads/.gitkeep
 
 todo.md
+.env*
+!.env.example

--- a/docs/.afm-log/events/2026-07.md
+++ b/docs/.afm-log/events/2026-07.md
@@ -403,3 +403,10 @@
 - [2026-07-27T03:55:59Z] feature-tasks | s=5d247c | edit em docs/features/022-error-registry/tasks.md
 - [2026-07-27T03:55:59Z] deliverable | s=5d247c | 022-error-registry
 - [2026-07-27T03:56:08Z] feature-tasks | s=5d247c | edit em docs/features/022-error-registry/tasks.md
+- [2026-07-27T03:57:22Z] task | s=5d247c | commit
+- [2026-07-27T04:00:16Z] task | s=5d247c | commit
+- [2026-07-30T02:57:06Z] task | s=5d247c | commit
+- [2026-07-30T03:10:39Z] failure | s=5d247c | sig=typecheck-exit-code-2-src-context-trpc-test-sessio | npx tsc --noEmit 2>&1
+- [2026-07-30T03:15:22Z] ach | s=5d247c | edit em docs/ach.md
+- [2026-07-30T03:15:39Z] adr | s=5d247c | edit em docs/adr/0017-error-registry-domain-error-namespaced.md
+- [2026-07-30T03:16:42Z] task | s=5d247c | commit

--- a/docs/.afm-log/events/2026-08.md
+++ b/docs/.afm-log/events/2026-08.md
@@ -1,0 +1,33 @@
+# Eventos 2026-08 — ledger append-only (AFM substrato de captura)
+
+- [2026-08-20T03:38:35Z] task | s=5d247c | commit
+- [2026-08-20T03:45:37Z] task | s=5d247c | commit
+- [2026-08-21T01:46:07Z] doc | s=5d247c | edit em docs/learn/resumo-01-error-model-joe-duffy.html
+- [2026-08-21T01:47:12Z] doc | s=5d247c | edit em docs/learn/resumo-01-error-model-joe-duffy.html
+- [2026-08-21T01:48:02Z] doc | s=5d247c | edit em docs/learn/resumo-02-epic-treatise-error-models.html
+- [2026-08-21T01:48:56Z] doc | s=5d247c | edit em docs/learn/resumo-02-epic-treatise-error-models.html
+- [2026-08-21T01:49:25Z] doc | s=5d247c | edit em docs/learn/resumo-03-second-error-model-convergence.html
+- [2026-08-21T01:50:11Z] doc | s=5d247c | edit em docs/learn/resumo-03-second-error-model-convergence.html
+- [2026-08-21T01:50:49Z] doc | s=5d247c | edit em docs/learn/resumo-04-railway-oriented-programming.html
+- [2026-08-21T01:51:39Z] doc | s=5d247c | edit em docs/learn/resumo-04-railway-oriented-programming.html
+- [2026-08-21T01:52:48Z] doc | s=5d247c | edit em docs/learn/resumo-05-wadler-monads-exception.html
+- [2026-08-21T01:53:44Z] doc | s=5d247c | edit em docs/learn/resumo-05-wadler-monads-exception.html
+- [2026-08-21T01:54:41Z] doc | s=5d247c | edit em docs/learn/resumo-06-orthogonal-defect-classification.html
+- [2026-08-21T01:55:28Z] doc | s=5d247c | edit em docs/learn/resumo-06-orthogonal-defect-classification.html
+- [2026-08-21T01:56:16Z] doc | s=5d247c | edit em docs/learn/resumo-07-handlers-algebraic-effects.html
+- [2026-08-21T01:57:02Z] doc | s=5d247c | edit em docs/learn/resumo-07-handlers-algebraic-effects.html
+- [2026-08-21T01:57:49Z] doc | s=5d247c | edit em docs/learn/resumo-08-koka-algebraic-effects-types.html
+- [2026-08-21T01:58:46Z] doc | s=5d247c | edit em docs/learn/resumo-08-koka-algebraic-effects-types.html
+- [2026-08-21T01:59:42Z] doc | s=5d247c | edit em docs/learn/resumo-09-dapper-distributed-tracing.html
+- [2026-08-21T02:00:39Z] doc | s=5d247c | edit em docs/learn/resumo-09-dapper-distributed-tracing.html
+- [2026-08-21T02:01:31Z] doc | s=5d247c | edit em docs/learn/resumo-10-causal-inference-root-cause.html
+- [2026-08-21T02:02:26Z] doc | s=5d247c | edit em docs/learn/resumo-10-causal-inference-root-cause.html
+- [2026-08-22T01:51:43Z] task | s=5d247c | commit
+- [2026-08-22T01:55:28Z] task | s=5d247c | commit
+- [2026-08-22T01:56:57Z] task | s=5d247c | commit
+- [2026-08-22T01:59:16Z] task | s=5d247c | commit
+- [2026-08-22T02:00:16Z] task | s=5d247c | commit
+- [2026-08-22T02:02:01Z] task | s=5d247c | commit
+- [2026-08-22T02:03:34Z] task | s=5d247c | commit
+- [2026-08-22T02:04:26Z] task | s=5d247c | commit
+- [2026-08-22T04:31:32Z] task | s=5d247c | commit

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Error models — acervo de leitura (bearboo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Acervo · 10 resumos" title="Error models — do ErrorRegistry ao error tracer" authors="Digests moldados ao bearboo (pilar 5-a: cadeia causal in-request)" src="Gerados via /learn:digest — cada um conferido contra a fonte"></l-head>
+
+<l-note kind="info" title="Como ler">Cada resumo tem: Conceito → Como funciona → Dados concretos → 🎯 Aplicar no bearboo → Cuidado → Recall (cards com resposta colapsável pra você se testar) → TL;DR. Ordem sugerida de leitura abaixo — mas cada um se sustenta sozinho.</l-note>
+
+<l-sec n="A" title="Ordem sugerida — a genealogia da ideia">
+<p>Li nesta ordem, os quatro primeiros formam um arco fechado (o debate throw vs. Result), e os dois últimos apontam pro seu tracer:</p>
+<ol>
+<li><strong><a href="resumo-01-error-model-joe-duffy.html">The Error Model</a></strong> (Duffy) — bug vs. erro recuperável. A distinção-mãe. <em>Comece aqui.</em></li>
+<li><strong><a href="resumo-02-epic-treatise-error-models.html">An epic treatise on error models</a></strong> (Gandhi) — os 5 eixos + a "Thesis 3" (erro carrega filhos). <em>A planta do seu tracer.</em></li>
+<li><strong><a href="resumo-03-second-error-model-convergence.html">The Second Great Error Model Convergence</a></strong> (matklad) — enum vs. tipo universal; onde seu ErrorRegistry cai.</li>
+<li><strong><a href="resumo-04-railway-oriented-programming.html">Railway Oriented Programming</a></strong> (Wlaschin) — o Result que a ADR-0017 rejeitou, e por quê.</li>
+<li><strong><a href="resumo-05-wadler-monads-exception.html">Monads for FP — a exception monad</a></strong> (Wadler) — a teoria embaixo do ROP; <code>throw</code>/<code>catch</code> já é isso.</li>
+<li><strong><a href="resumo-06-orthogonal-defect-classification.html">Orthogonal Defect Classification</a></strong> (Chillarege) — erro como dado mensurável; distribuição = assinatura.</li>
+<li><strong><a href="resumo-07-handlers-algebraic-effects.html">Handlers of Algebraic Effects</a></strong> (Plotkin &amp; Pretnar) — exception é caso particular de effect; "resume".</li>
+<li><strong><a href="resumo-08-koka-algebraic-effects-types.html">Algebraic Effects (Koka)</a></strong> (Leijen) — efeito no tipo; <code>to-maybe</code> dissolve throw vs. Result.</li>
+<li><strong><a href="resumo-09-dapper-distributed-tracing.html">Dapper</a></strong> (Sigelman et al.) — <em>o blueprint do seu tracer 5-a, menos a rede.</em></li>
+<li><strong><a href="resumo-10-causal-inference-root-cause.html">Causal Inference / Root Cause</a></strong> (IJETCSIT) — o teto: inferir a raiz. E por que o monólito tem isso de graça.</li>
+</ol>
+</l-sec>
+
+<l-sec n="B" title="O fio que costura tudo (pro seu caso)">
+<p>Se ler os 10 e quiser guardar <strong>uma</strong> linha: seu <code>ErrorRegistry</code> já resolveu "erro é dado tipado no boundary" (docs 1-3, 5, 8). O <strong>error tracer (5-a)</strong> que você quer é adicionar ao <code>DomainError</code> a <em>cadeia</em> — o campo <code>cause</code> tipado, preservado no boundary e navegável (docs 2, 9) — mais dois campos de metadata, <code>severity</code> e <code>retryable</code> (docs 2, 6). E a boa notícia dos docs 9-10: num monólito, "root cause" é o <code>cause</code> mais profundo — de graça, sem o ML que o mundo distribuído precisa.</p>
+</l-sec>
+
+<l-tldr>
+<li>10 resumos, ordem de leitura acima. Cada um conecta a fonte ao bearboo na seção 🎯.</li>
+<li>Arco 1-5: o debate de error handling e onde seu desenho cai. Docs 6-8: taxonomia + o futuro (effects). Docs 9-10: o tracer.</li>
+<li>Próximo passo concreto que emerge: <code>DomainError</code> com <code>cause</code> tipado + <code>severity</code>/<code>retryable</code>, cadeia serializada no boundary com um <code>requestId</code> do <code>ctx</code>.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-01-error-model-joe-duffy.html
+++ b/docs/learn/resumo-01-error-model-joe-duffy.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The Error Model — Joe Duffy (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Pilar 1 · Error models" title="The Error Model" authors="Joe Duffy (2016)" src="joeduffyblog.com — retrospectiva do Midori (Microsoft Research)" href="https://joeduffyblog.com/2016/02/07/the-error-model/"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Retenção-durável + entendimento/transferência. Ensaio longo, leitor sênior de prática mas novato na teoria — foco em fixar as <strong>distinções conceituais</strong> e ligar cada uma ao seu ErrorRegistry. Recall no fim.</l-note>
+
+<l-sec n="1" title="O conceito central">
+<p>Existe <strong>uma decisão de design que quase toda linguagem erra</strong>: tratar <strong>bug</strong> e <strong>erro recuperável</strong> como a mesma coisa, com o mesmo mecanismo. Duffy chama a separação dos dois de "paramount" (fundamental). São categorias com naturezas opostas:</p>
+<ul>
+<li><strong>Bug</strong> — condição que o programador <em>não previu</em> e que viola uma suposição do próprio código: null dereference, índice fora do array, invariante quebrado. Não dá pra "tratar" — o estado já é inconsistente. Resposta: <strong>abandonment</strong> (fail-fast) — derruba o processo na hora, sem rodar cleanup do usuário.</li>
+<li><strong>Erro recuperável</strong> — situação <em>esperada</em> do mundo: arquivo não existe, rede caiu, input inválido, credencial errada. Faz parte do contrato da função. Resposta: <strong>exceptions estaticamente checadas</strong>, que o chamador é obrigado a considerar.</li>
+</ul>
+<p>A tese: use <strong>mecanismos diferentes</strong> porque as duas coisas <em>são</em> diferentes. Misturar (o que exceptions unchecked e error codes fazem) é a raiz da fragilidade.</p>
+</l-sec>
+
+<l-sec n="2" title="Como funciona — os dois mecanismos">
+<p><strong>Abandonment (para bugs):</strong> mata o processo imediatamente. Só é prático porque o Midori era uma <strong>rede de processos pequenos, baratos e isolados</strong> — perder um é administrável, não corrompe estado compartilhado de um monólito. "Isolation is critical." Sem isolamento, fail-fast é inviável (você derrubaria o mundo).</p>
+<p><strong>Checked exceptions feitas certo (para erros recuperáveis):</strong> três diferenças do Java, que é onde checked exceptions ganharam má fama:</p>
+<l-steps>
+<li><strong>O erro faz parte da assinatura da função</strong> — como um tipo. Aparece na doc, no tooltip do IDE. Você <em>vê</em> o que pode falhar olhando a assinatura.</li>
+<li><strong>Um único tipo de exception</strong> — sem a proliferação de <code>throws A, B, C</code> do Java que faz todo mundo desistir e engolir erro.</li>
+<li><strong>Análise local e modular</strong> — o compilador checa por função, não faz prova global de teorema (isso seria lento demais; ver §4).</li>
+</l-steps>
+<p>Descoberta empírica que talvez seja a mais surpreendente: quando forçados a classificar, <strong>~90%+ dos usos de exception no .NET/Java viraram, na verdade, <em>precondições</em></strong> — ou seja, eram bugs disfarçados de erro recuperável (um <code>ArgumentNullException</code> não é "o mundo falhou", é "o chamador tem um bug"). Viraram contratos <code>requires</code>, não exceptions.</p>
+</l-sec>
+
+<l-sec n="3" title="Por que os dois modelos populares falham">
+<p><strong>Error codes (C/Go):</strong></p>
+<ul>
+<li>Fáceis de <em>ignorar por acidente</em> — o valor de retorno some silenciosamente. A anedota concreta: ao portar o Microsoft Speech Server, descobriram que <strong>80% dos requests em chinês de Taiwan (<code>zh-tw</code>) falhavam em silêncio</strong> por um <code>HRESULT</code> engolido.</li>
+<li>Custo de performance "peanut butter": os <code>if</code> de checagem ficam <em>espalhados</em> ("smeared") por todo o código quente, confundindo o otimizador e queimando registradores com valores de retorno extras.</li>
+</ul>
+<p><strong>Unchecked exceptions (Java/C#):</strong></p>
+<ul>
+<li><strong>Invisíveis</strong> — nada na assinatura diz que a função lança. Controle de fluxo oculto.</li>
+<li>Impossível raciocinar localmente sobre o estado durante a propagação — qualquer linha pode desviar pro topo.</li>
+<li>Exceptions assíncronas (.NET) tornam operações não-atômicas.</li>
+</ul>
+</l-sec>
+
+<l-sec n="4" title="Dados concretos citados">
+<l-data>
+<l-row k="Usos de exception que eram, na verdade, precondições" v="~90%+"></l-row>
+<l-row k="Requests zh-tw falhando em silêncio (HRESULT engolido)" v="80%"></l-row>
+<l-row k="Assertions por função (guideline NASA citado)" v="≥ 2"></l-row>
+<l-row k="Tempo de prova global no módulo core (por que rejeitaram theorem-proving)" v="> 1 dia"></l-row>
+</l-data>
+<p>Benefício de perf das exceptions feitas certo: tiram o código e os dados de erro do hot path, o que <strong>melhora I-cache e TLB</strong> — o caminho de sucesso fica mais denso. É o argumento inverso do "exception é lenta": lenta é a versão unchecked com stack unwinding caro; o modelo dele paga o custo só no caminho de erro.</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo (e no seu pilar 5-a)">
+<p><strong>Seu ErrorRegistry já está do lado certo da linha — mas só metade dela.</strong> O <code>DomainError</code> com <code>code</code> namespaced é a materialização de "erro recuperável faz parte do contrato": <code>auth.invalid_credentials</code> é uma situação esperada do mundo, tipada, que a procedure é obrigada a traduzir. Isso é a metade "recuperável" do modelo de Duffy.</p>
+<p><strong>O que você ainda NÃO tem é a outra metade: a distinção bug vs. erro recuperável.</strong> Hoje no bearboo, um <code>throw new DomainError(...)</code> e um null dereference acidental num domain caem no <em>mesmo</em> caminho: viram um <code>TRPCError</code> genérico no boundary. Duffy diria que são categorias diferentes — o segundo é um <em>bug</em> e deveria ser <strong>abandonment</strong> (falhar alto, logar, não fingir que é um erro de negócio tratável). Um request tRPC é o seu "processo pequeno e isolado" — dá pra aplicar fail-fast por request sem derrubar o servidor.</p>
+<p><strong>Gancho direto pro error tracer (5-a):</strong> a lição operacional é que o <code>cause</code> só é útil se a cadeia distinguir "erro de domínio esperado" de "bug que vazou". Quando você for construir o tracer, a primeira classificação de cada elo da cadeia deveria ser <em>bug vs. recoverable</em> — porque isso decide se o elo é ruído esperado (log info) ou sinal de defeito (log error + alertar). Sem essa distinção o tracer vira um firehose.</p>
+<p><strong>Regra que quase se escreve sozinha:</strong> a descoberta dos "90% que eram precondições" sugere auditar seu catálogo — quantos dos seus códigos de erro são de fato "o mundo falhou" (rede, not_found, credencial) vs. "o chamador passou algo que nunca deveria" (que talvez devesse ser validação no boundary / precondição, não um DomainError)?</p>
+</l-apply>
+
+<l-note kind="warn" title="Cuidado ao transportar isso">Midori tinha suporte de linguagem (checked exceptions no compilador, non-null types, <code>requires</code>/<code>ensures</code>). TypeScript não tem checked exceptions — seu "obrigar o chamador a tratar" hoje é convenção + o padrão do <code>catch (DomainError)</code>, não garantia do compilador. O <code>Result&lt;T,E&gt;</code> (pilar 3) é justamente a forma de <em>recuperar</em> o "checado estaticamente" em linguagens sem checked exceptions — daí a ADR-0017 ter considerado e rejeitado ele. Leia o pilar 3 logo depois deste pra fechar esse arco.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="Qual é a distinção central do Error Model?" src="Duffy §core thesis" href="https://joeduffyblog.com/2016/02/07/the-error-model/">Bug vs. erro recuperável — mecanismos diferentes.</l-card>
+<l-card q="Como cada categoria é tratada no Midori?" src="Duffy §bugs/§recoverable">Bug → abandonment (fail-fast); recuperável → checked exceptions.</l-card>
+<l-card q="O que torna abandonment prático?" src="Duffy §isolation">Processos pequenos e isolados.</l-card>
+<l-card q="As 3 diferenças das checked exceptions do Midori pro Java?" src="Duffy §checked done right">Na assinatura; tipo único; análise local.</l-card>
+<l-card q="Quantos usos de exception no .NET/Java eram na verdade precondições?" src="Duffy §checked done right">~90%+ (eram bugs, não erros).</l-card>
+<l-card q="Por que error codes falham na prática (a anedota)?" src="Duffy §error codes">Ignorados em silêncio — 80% dos requests zh-tw falhando.</l-card>
+<l-card q="No bearboo, que metade do modelo ainda falta?" src="Aplicar no contexto">Distinguir bug (abandonment) de DomainError (recuperável).</l-card>
+</l-sec>
+
+<l-tldr>
+<li>Toda linguagem popular comete o mesmo erro: trata bug e erro recuperável igual. Separá-los é o ponto inteiro.</li>
+<li><strong>Bug → fail-fast/abandonment</strong> (só viável com processos isolados). <strong>Recuperável → checked exception na assinatura.</strong></li>
+<li>Seu <code>DomainError</code> já é "erro recuperável tipado no contrato" — mas o bearboo ainda não separa bug de erro recuperável, e é aí que mora o próximo passo (e a classificação-base do seu error tracer).</li>
+<li>~90% dos "erros" no .NET/Java eram precondições disfarçadas — vale auditar seu catálogo com essa lente.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-02-epic-treatise-error-models.html
+++ b/docs/learn/resumo-02-epic-treatise-error-models.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>An epic treatise on error models — Varun Gandhi (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Pilar 1 · Error models" title="An epic treatise on error models for systems programming languages" authors="Varun Gandhi (typesanitizer)" src="typesanitizer.com — ensaio de design de linguagens" href="https://typesanitizer.com/blog/errors.html"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Entendimento/transferência. Este é o <strong>mapa do espaço inteiro</strong> — não decora, serve pra você situar seu desenho. Foco nos eixos de classificação (o vocabulário que faltava) e na parte de metadata/cadeia causal (seu pilar 5-a).</l-note>
+
+<l-sec n="1" title="O conceito central — erro não é uma coisa, é um espaço de design">
+<p>Onde o Duffy dá uma <em>tese</em> (bug vs. recuperável), este ensaio dá os <strong>eixos ortogonais</strong> pra classificar qualquer abordagem de erro. Esse é o vocabulário que você disse que faltava. As cinco dimensões:</p>
+<l-data>
+<l-row k="Exaustividade" v="conjunto fechado vs. aberto/evolutivo"></l-row>
+<l-row k="Recuperabilidade" v="universal vs. CONTEXTUAL"></l-row>
+<l-row k="Propagação" v="explícita (marcada) vs. implícita (silenciosa)"></l-row>
+<l-row k="Estrutura" v="tipada/estruturada vs. string/genérica"></l-row>
+<l-row k="Fail-fast vs. fail-slow" v="panic vs. valor representável"></l-row>
+</l-data>
+<p>A sacada mais importante e contraintuitiva: <strong>"se um erro é recuperável ou não é, às vezes, contextual"</strong>. O mesmo erro é fatal num lugar e tratável em outro — logo, a decisão bug-vs-recuperável do Duffy nem sempre é propriedade do erro, é propriedade do <em>call site</em>. Isso complica (de forma honesta) o modelo do doc 1.</p>
+</l-sec>
+
+<l-sec n="2" title="Onde cada estratégia cai nos eixos">
+<table>
+<thead><tr><th>Estratégia</th><th>Propagação</th><th>Estrutura</th><th>Exaustividade</th></tr></thead>
+<tbody>
+<tr><td>Error codes (C)</td><td>implícita/manual</td><td>não-estruturada</td><td>—</td></tr>
+<tr><td>Exceptions (Java/Py)</td><td>implícita</td><td>metadata em string</td><td>não-exaustiva</td></tr>
+<tr><td>Result/Either (Rust/Swift)</td><td>explícita (<code>?</code>/<code>try</code>)</td><td>estruturada</td><td>checável</td></tr>
+<tr><td>Panic/recover (Go/Rust)</td><td>coarse, no boundary</td><td>—</td><td>—</td></tr>
+<tr><td>Condition system (Lisp)</td><td>resumível sem unwinding</td><td>estruturada</td><td>—</td></tr>
+</tbody>
+</table>
+<p>Crítica-chave à string: <strong>enfiar metadata em string quebra pela Lei de Hyrum</strong> — assim que um cliente faz parse da sua mensagem de erro, mudar o texto vira breaking change. (É <em>exatamente</em> o anti-padrão que a regra 15 do bearboo eliminou: o front que fazia <code>switch(error.message)</code>.)</p>
+</l-sec>
+
+<l-sec n="3" title="Thesis 3 — erros precisam CARREGAR metadata (o coração do seu 5-a)">
+<p>A tese mais relevante pra você: <strong>um erro precisa carregar metadata estruturada</strong> — stack trace, severidade, caminho de validação, se é retryable — e, crucialmente, <strong>zero-ou-mais <code>AnyError</code> filhos</strong> (igual ao <code>error</code> wrapping do Go). Isso <em>é</em> a cadeia causal: um erro que embrulha o erro que o causou, recursivamente.</p>
+<ul>
+<li><strong><code>AnyError</code> + <code>AnyErrorContext</code></strong>: par (valor do erro, contexto key-value + call traces).</li>
+<li><strong>Call traces</strong>: stack traces, <em>error return traces</em> (estilo Zig — a rota de <em>retorno</em> do erro, não a de chamada), async stack traces.</li>
+<li><strong>Case refinement</strong>: dá pra refinar <code>NotRepresentable</code> em <code>TooSmall</code>/<code>TooLarge</code> <em>sem</em> quebrar quem só conhecia o caso genérico. Compatibilidade pra frente sem perder granularidade.</li>
+<li><strong>Unerasure</strong>: recuperar o erro fino a partir da representação grossa.</li>
+</ul>
+<p>Aplicação prática citada (Kleppmann): só vale retry após erro <em>transiente</em> (deadlock, falha de isolamento, rede) — após erro <em>permanente</em> (constraint violation) retry é inútil. Ou seja: o metadata "retryable" precisa estar no tipo do erro, não na sua cabeça.</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — o desenho do seu error tracer sai quase inteiro daqui">
+<p>Este ensaio é praticamente a <strong>spec do que você chamou de "error tracer pica"</strong>, no escopo 5-a. A estrutura <code>AnyError</code> = { erro, contexto, filhos[] } é o modelo de dados exato de uma cadeia causal dentro de um request. Hoje seu <code>DomainError</code> tem <code>code</code> + <code>httpCode</code> + <code>message</code>, e você já passa <code>cause</code> no <code>TRPCError</code> — mas o <code>cause</code> é usado só pra debug, não é <em>estruturado</em> nem navegável.</p>
+<p><strong>Evolução concreta sugerida pelo texto:</strong></p>
+<l-steps>
+<li>Dar ao <code>DomainError</code> um campo <code>cause?: DomainError | Error</code> tipado (você já aceita <code>cause</code>; falta <em>tipá-lo</em> e <em>preservá-lo</em> na tradução do boundary em vez de descartar).</li>
+<li>Adicionar metadata no catálogo além de <code>httpCode</code>/<code>message</code>: <strong><code>retryable: boolean</code></strong> e <strong><code>severity</code></strong> — os dois campos que o texto (e o Kleppmann) dizem ser os que mais faltam.</li>
+<li>No boundary, em vez de <code>new TRPCError({..., cause: error})</code> e parar, <strong>preservar a cadeia</strong>: o <code>cause</code> do DomainError vira um elo, e o tracer caminha <code>error.cause.cause...</code> — a "error return trace" estilo Zig.</li>
+<li><strong>Case refinement</strong> te dá o caminho pra evoluir <code>post.not_found</code> em subcasos sem quebrar consumidores — resposta direta a uma dor real de catálogo que cresce.</li>
+</l-steps>
+<p>A regra 15 que você já tem é a versão "propagação explícita + estruturada" dos eixos §1. Você já está no quadrante certo. O 5-a é adicionar as colunas <em>context</em> e <em>children</em> à sua tabela.</p>
+</l-apply>
+
+<l-note kind="warn" title="Cuidado">O ensaio propõe uma linguagem hipotética (Everr) com suporte de compilador (<code>@exhaustive</code>, <code>union+</code>, unerasure). Muito disso <strong>não tem equivalente direto em TS</strong>. Pegue os <em>conceitos</em> (metadata estruturada, filhos, retryable) e não tente reproduzir o sistema de tipos. O que é 100% portável é o modelo de dados <code>AnyError</code> = valor + contexto + filhos.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="Quais os 5 eixos pra classificar abordagens de erro?" src="Treatise §axes" href="https://typesanitizer.com/blog/errors.html">Exaustividade, recuperabilidade, propagação, estrutura, fail-fast/slow.</l-card>
+<l-card q="A tese contraintuitiva sobre recuperabilidade?" src="Treatise §recovery">É contextual — depende do call site, não só do erro.</l-card>
+<l-card q="Por que meter metadata em string é ruim?" src="Treatise §structured">Lei de Hyrum — clientes fazem parse, mudar vira breaking.</l-card>
+<l-card q="O que a Thesis 3 diz que um erro precisa carregar?" src="Treatise §thesis 3">Metadata + zero-ou-mais erros filhos (a cadeia causal).</l-card>
+<l-card q="Quando vale retry (Kleppmann)?" src="Treatise §db/rpc">Só após erro transiente; permanente não.</l-card>
+<l-card q="Que 2 campos de metadata faltam no seu catálogo hoje?" src="Aplicar no contexto">retryable e severity.</l-card>
+</l-sec>
+
+<l-tldr>
+<li>O valor deste texto é o <strong>vocabulário</strong>: 5 eixos ortogonais que te deixam nomear e situar qualquer desenho de erro — inclusive o seu.</li>
+<li>Recuperável-ou-não é <strong>contextual</strong> — refina (e complica honestamente) o modelo bug/recuperável do Duffy.</li>
+<li><strong>Thesis 3 = a spec do seu error tracer:</strong> erro carrega contexto + filhos. É o <code>cause</code> que você já tem, mas estruturado e navegável.</li>
+<li>Próximos campos concretos no catálogo do bearboo: <code>retryable</code> e <code>severity</code>. Próxima estrutura: <code>cause</code> tipado e preservado no boundary.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-03-second-error-model-convergence.html
+++ b/docs/learn/resumo-03-second-error-model-convergence.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The Second Great Error Model Convergence — matklad (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Pilar 1 · Error models" title="The Second Great Error Model Convergence" authors="Alex Kladov (matklad), 2025" src="matklad.github.io — estado da arte atual" href="https://matklad.github.io/2025/12/29/second-error-model-convergence.html"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Varredura + entendimento. Texto curto e recente — serve pra você saber pra onde o campo <em>convergiu</em> e julgar se o seu ErrorRegistry está alinhado com o consenso de 2025. Conecta direto às suas rubricas (enum vs union).</l-note>
+
+<l-sec n="1" title="O conceito — duas convergências históricas">
+<p><strong>Primeira convergência:</strong> C++, Java, JS, Python, C# todos chegaram no mesmo <code>throw</code>/<code>catch</code>/<code>finally</code>. Característica: <em>sem marcador no call site</em> (você não vê que a função pode falhar) e <em>bug e erro operacional tratados igual</em> — exatamente o pecado que o Duffy (doc 1) ataca.</p>
+<p><strong>Segunda convergência (a atual):</strong> Go, Rust, Swift, Zig, Kotlin, Dart convergindo em <strong>"errors as values"</strong> — erro é um valor que você retorna, não um fluxo oculto que você lança. Duas marcas registradas:</p>
+<ul>
+<li><strong>Marcador visível no call site:</strong> <code>make_widget()?</code> (Rust), <code>widget, err := makeWidget()</code> (Go). Você <em>vê</em> onde pode falhar.</li>
+<li><strong>Caminho de panic separado</strong> pra bugs: Rust/Go dão unwind recuperável via lib; Swift/Zig abortam. É a distinção bug/recuperável do Duffy virando <em>feature de linguagem</em> mainstream.</li>
+</ul>
+</l-sec>
+
+<l-sec n="2" title="A tensão central — enum vs. tipo universal">
+<p>O coração do texto, e é <em>a sua decisão de design</em>:</p>
+<l-data>
+<l-row k="Camada baixa quer" v="enum exaustivo (sum type)"></l-row>
+<l-row k="Camada alta quer" v="abstração sem enfiar tipos específicos por todo lado"></l-row>
+</l-data>
+<ul>
+<li><strong>Sum type (Rust enum):</strong> exaustividade total, mas <em>composabilidade ruim</em> entre subsistemas — pra juntar erros de módulos diferentes você sofre.</li>
+<li><strong>Tipo universal (Go <code>error</code>, Swift):</strong> flexível e componível, mas <em>perde a garantia em compile-time</em>.</li>
+</ul>
+<p>Argumento decisivo — o <strong>problema "N para N+1" do Java</strong>: com throws exaustivo, adicionar uma terceira variante força atualizar a cadeia inteira. Os modelos value-oriented modernos lidam só com <strong>"0 para 1"</strong> (ou o erro está no tipo, ou não está). O autor confessa que o <em>meio-termo é mal servido</em> por todas as linguagens, e acha o Zig interessante (compilação closed-world + inferência entre funções infere o enum de erro pra você).</p>
+<p>História que espelha a sua ADR: o ecossistema Rust <strong>começou com enums e migrou pra tipos universais</strong> (libs <code>failure</code>, depois <code>anyhow</code>) — porque exaustividade não escala pra cima na aplicação.</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — onde seu ErrorRegistry cai nessa régua">
+<p>Seu <code>ErrorRegistry</code> é um <strong>híbrido raro e, acho, bem posicionado</strong> no meio-termo que o matklad diz ser mal servido:</p>
+<ul>
+<li><code>type ErrorCode = keyof typeof Errors</code> te dá um <strong>union fechado e exaustivo</strong> (o lado "sum type": typo no code quebra o build, você tem autocomplete do catálogo inteiro).</li>
+<li>Mas <code>DomainError</code> é <strong>um único tipo</strong> carregando esse code (o lado "universal": você não threada <code>AuthError | PostError | ...</code> por toda assinatura — passa <code>DomainError</code> e pronto).</li>
+</ul>
+<p>Ou seja: você comprou a exaustividade do enum <em>sem</em> pagar o custo de composabilidade do sum type, porque o namespacing (<code>auth.</code>, <code>post.</code>) faz a fusão dos subsistemas ser um spread de objetos, não uma união de tipos aninhados. É <strong>exatamente a fuga do problema "N para N+1"</strong>: adicionar um erro é "0 para 1" (uma entrada no objeto do domínio), não propagação em cadeia. A ADR-0017 chegou nisso por instinto de engenharia; o matklad te dá a <em>teoria</em> de por que foi a escolha certa.</p>
+<p><strong>Onde você está desalinhado com o consenso (de propósito, e tudo bem):</strong> "errors as values" quer marcador no call site. TS não tem <code>?</code>-operator nem checked exceptions, então o bearboo usa <code>throw DomainError</code> + <code>catch</code> no boundary — o modelo da <em>primeira</em> convergência. Foi decisão consciente da ADR (call depth raso → ROP não compensa). Este texto valida que essa é uma escolha de <em>ergonomia</em>, não de correção — você abriu mão do marcador visível em troca de menos cerimônia, sabendo do trade.</p>
+</l-apply>
+
+<l-note kind="warn" title="Cuidado">O autor <strong>não dá receita definitiva</strong> — ele mesmo diz que o meio-termo é mal resolvido e que ficaria tentado a padronizar Java em <code>throws Exception</code> grosso. Não leia isso como "migre pra Result". Leia como: "seu híbrido é uma resposta legítima a um problema que nem as linguagens modernas fecharam".</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="O que é a 'segunda convergência'?" src="matklad §convergence" href="https://matklad.github.io/2025/12/29/second-error-model-convergence.html">Errors as values (Go/Rust/Swift/Zig).</l-card>
+<l-card q="As 2 marcas da segunda convergência?" src="matklad §call-site">Marcador no call site + caminho de panic separado pra bugs.</l-card>
+<l-card q="A tensão central de modelar tipos de erro?" src="matklad §types">Enum exaustivo (baixo) vs. tipo universal componível (alto).</l-card>
+<l-card q="O problema 'N para N+1' do Java?" src="matklad §types">Nova variante força atualizar a cadeia inteira de throws.</l-card>
+<l-card q="Como seu ErrorRegistry escapa desse problema?" src="Aplicar no contexto">Union fechado + tipo único DomainError; adicionar erro é '0 para 1'.</l-card>
+</l-sec>
+
+<l-tldr>
+<li>O campo convergiu duas vezes: exceptions (antiga) → <strong>errors as values</strong> (atual, Go/Rust/Swift/Zig), com marcador no call site + panic separado pra bugs.</li>
+<li>Tensão eterna: <strong>enum exaustivo</strong> (garantia, mas não compõe) vs. <strong>tipo universal</strong> (compõe, mas sem garantia). O meio é mal servido.</li>
+<li>Seu <code>ErrorRegistry</code> ocupa esse meio bem: <strong>union fechado + <code>DomainError</code> único</strong> = exaustividade sem o custo de composição. A teoria por trás do acerto da ADR-0017.</li>
+<li>Você abriu mão do "marcador no call site" (fica na 1ª convergência) conscientemente — trade de ergonomia, não erro.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-04-railway-oriented-programming.html
+++ b/docs/learn/resumo-04-railway-oriented-programming.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Railway Oriented Programming — Scott Wlaschin (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Pilar 3 · Result/Either" title="Railway Oriented Programming" authors="Scott Wlaschin" src="fsharpforfunandprofit.com — a explicação canônica do Result como pipeline" href="https://fsharpforfunandprofit.com/rop/"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Entendimento por contraste. Este é <strong>o caminho que você NÃO escolheu</strong> (ADR-0017 rejeitou <code>Result&lt;T,E&gt;</code>). Ler pra entender exatamente o que abriu mão — e o que a decisão custou/economizou.</l-note>
+
+<l-sec n="1" title="O conceito — a metáfora do trilho">
+<p>Toda função de negócio tem dois resultados possíveis: sucesso ou falha. Modele isso como <strong>dois trilhos paralelos</strong>. Uma função é um <strong>desvio (switch)</strong>: entra no trilho de sucesso, pode sair no de falha. O tipo que carrega isso é o <code>Result</code> (a.k.a. <code>Either</code>): <code>Success of 'a | Failure of 'error</code>.</p>
+<p>Detalhe importante que o Wlaschin faz certo e que muita gente esquece: o lado de falha carrega um <strong>tipo de erro rico, não uma string</strong> (<code>Either [error] (value, [error])</code> na versão dele). Isso é o mesmo princípio da regra 15 — erro é dado estruturado, não texto.</p>
+</l-sec>
+
+<l-sec n="2" title="Como funciona — composição e short-circuit">
+<p>O ganho não é o tipo, é a <strong>composição</strong>. Você encadeia funções que retornam <code>Result</code> e o encadeamento cuida do desvio automaticamente:</p>
+<ul>
+<li><strong>Short-circuit:</strong> uma vez no trilho de falha, você <em>fica</em> nele — as operações seguintes não rodam, o erro propaga até o fim intocado. É o equivalente funcional do "exception pula pro catch", mas explícito e sem exceptions.</li>
+<li><strong>Adaptadores</strong> pra plugar funções de tipos diferentes no pipeline:
+<l-data>
+<l-row k="bind (>>=)" v="pluga função de 1-trilho→2-trilhos (que pode falhar)"></l-row>
+<l-row k="map (fmap)" v="pluga função de 1-trilho→1-trilho (não falha) no pipeline"></l-row>
+<l-row k="tee" v="pluga função de efeito colateral (log, save) sem quebrar o trilho"></l-row>
+</l-data>
+</li>
+</ul>
+<p>Resultado: um pipeline <code>validate >> canonicalize >> updateDb >> sendEmail</code> onde qualquer passo que falhe curto-circuita o resto, e o tipo de retorno <em>diz</em> que pode falhar. Erro vira valor explícito na assinatura — o oposto da exception invisível (docs 1 e 3).</p>
+</l-sec>
+
+<l-sec n="3" title="O aviso do próprio autor">
+<p>Wlaschin literalmente escreve: <strong>"please don't take it to extremes!"</strong> — não use ROP em todo lugar. O custo é <strong>cerimônia</strong>: <em>toda</em> função no pipeline precisa retornar <code>Result</code>, e você paga <code>bind</code>/<code>map</code> em cada junção. Ele também nota, com honestidade teórica, que "one bind does not a monad make" — ROP é a versão pragmática, não a teoria monádica completa (essa é o doc 5, Wadler).</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — por que a ADR-0017 rejeitou isso (e estava certa)">
+<p>O argumento da rejeição, agora que você viu ROP funcionando, fica cristalino. <strong>ROP paga por si quando o pipeline é PROFUNDO</strong> — muitas funções encadeadas, onde propagar erro manualmente por cada camada seria doloroso e o <code>bind</code> automático economiza. É o "Railway Oriented Programming (evitar poluir camadas intermediárias)" que a própria ADR cita.</p>
+<p><strong>No bearboo o call depth é raso: domain → 1 procedure.</strong> Não há pipeline de 6 estágios pra encadear — há uma função de domínio que lança e uma procedure que pega. Nesse formato, o <code>bind</code> não economiza nada (não há intermediários pra poluir), e você pagaria a cerimônia (todo domain retornando <code>Result</code>, toda procedure fazendo pattern-match) <em>sem</em> o benefício. <code>throw DomainError</code> + <code>catch</code> no boundary é menos código pro mesmo efeito. A decisão foi <strong>"o argumento do ROP não se aplica com força aqui"</strong> — e é literalmente isso.</p>
+<p><strong>Mas — atenção pro seu pilar 5-a:</strong> tem uma coisa que o ROP te daria de graça e que o throw <em>não</em> dá. No trilho de falha, o erro é um <em>valor que você constrói e pode enriquecer a cada bind</em> — acumular contexto ("falhou em updateDb, durante canonicalize, no request X") é natural, porque o erro passa de mão em mão explicitamente. Com <code>throw</code>, você ganha o stack trace de graça mas perde esse enriquecimento estruturado — o erro sobe opaco até o <code>catch</code>. <strong>É por isso que o seu error tracer (5-a) precisa reintroduzir manualmente, via <code>cause</code>, o que o Result daria automático.</strong> Você não escolheu ROP, então a acumulação de contexto causal vira trabalho explícito seu — que é exatamente o projeto do tracer.</p>
+</l-apply>
+
+<l-note kind="warn" title="Cuidado ao reavaliar">Não conclua "então eu deveria ter usado Result". A ADR pesou certo pro <em>call depth atual</em>. O gatilho pra reconsiderar seria: se surgir um fluxo de domínio genuinamente profundo (ex. uma saga de publicação com 5+ passos que podem falhar e precisam de rollback/contexto acumulado), aí o ROP <em>localizado nesse fluxo</em> passaria a compensar. É decisão por-fluxo, não global.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="O que é um 'switch' na metáfora do trilho?" src="Wlaschin §metaphor" href="https://fsharpforfunandprofit.com/rop/">Uma função que entra no trilho de sucesso e pode sair no de falha.</l-card>
+<l-card q="O que 'bind' faz?" src="Wlaschin §adapters">Pluga função que-pode-falhar (1→2 trilhos) no pipeline.</l-card>
+<l-card q="Diferença bind vs map?" src="Wlaschin §adapters">map é pra função que NÃO falha (1→1 trilho).</l-card>
+<l-card q="Quando ROP compensa?" src="Wlaschin §warning + Aplicar">Pipeline profundo; NÃO quando o call depth é raso.</l-card>
+<l-card q="Por que a ADR-0017 rejeitou Result no bearboo?" src="Aplicar no contexto">Call depth raso (domain→1 procedure) — bind não economiza nada.</l-card>
+<l-card q="O que o throw te faz perder vs. Result, e que o 5-a reintroduz?" src="Aplicar no contexto">Acumulação estruturada de contexto causal (vira o cause manual).</l-card>
+</l-sec>
+
+<l-tldr>
+<li><strong>Result/Either = erro como valor num pipeline de dois trilhos</strong>; <code>bind</code>/<code>map</code>/<code>tee</code> compõem, e a falha curto-circuita o resto.</li>
+<li>O ganho é <strong>composição em pipelines profundos</strong>. O custo é cerimônia (tudo retorna Result). O próprio autor avisa: não exagere.</li>
+<li>ADR-0017 rejeitou por <strong>call depth raso</strong> no bearboo — o benefício do bind não materializa, só o custo. Decisão correta pro formato atual.</li>
+<li>Nuance pro 5-a: Result acumularia contexto causal de graça; com <code>throw</code> você ganha stack trace mas precisa reintroduzir a cadeia via <code>cause</code> — <strong>que é o seu projeto de tracer</strong>.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-05-wadler-monads-exception.html
+++ b/docs/learn/resumo-05-wadler-monads-exception.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Monads for Functional Programming (a exception monad) — Wadler (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Pilar 3 · fundamento teórico" title="Monads for Functional Programming — a exception monad" authors="Philip Wadler (Båstad 1995; orig. Marktoberdorf 1992)" src="cs.tufts.edu (PDF aberto) — irmão livre do 'Essence of FP', POPL'92; mesma exception monad" href="https://www.cs.tufts.edu/comp/150PLD/Papers/MonadsForFunctionalProgramming.pdf"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Profundo. Este é o <strong>alicerce teórico do doc 4</strong>: o <code>bind</code> do Railway é o <code>★</code> da <em>exception monad</em> do Wadler. Você não precisa de teoria de categorias (o próprio Wadler diz isso) — precisa ver <em>onde o encanamento de erro se esconde</em>. Uso a notação exata do paper.</l-note>
+
+<l-sec n="1" title="O problema — o encanamento soterra o algoritmo">
+<p>Wadler abre com a tese: linguagem funcional pura tem "all flow of data made explicit" — uma bênção (modularidade máxima) e uma maldição (<em>"the essence of an algorithm can become buried under the plumbing"</em>). O exemplo concreto é um avaliador de expressões:</p>
+<p><code>data Term = Con Int | Div Term Term</code> · <code>eval :: Term → Int</code>. Direto: <code>eval (Con a) = a</code>; <code>eval (Div t u) = eval t ÷ eval u</code>. (Ex.: <code>eval answer = 42</code>.)</p>
+<p>Agora <strong>adicione tratamento de erro</strong> (divisão por zero). Sem monad, você é forçado a modificar <em>cada chamada recursiva</em> pra checar-e-propagar:</p>
+<pre><code>eval (Div t u) = case eval t of
+    Raise e → Raise e          -- propaga
+    Return a → case eval u of
+        Raise e → Raise e      -- propaga de novo
+        Return b → if b == 0 then Raise "divide by zero"
+                             else Return (a ÷ b)</code></pre>
+<p>Wadler chama isso de "straightforward, but tedious". <strong>Essa repetição de "checar o resultado e re-propagar Raise" é exatamente o encanamento que a regra 15 do bearboo eliminou no boundary — e é o mesmo que o ROP elimina com o bind.</strong></p>
+</l-sec>
+
+<l-sec n="2" title="A monad em termos simples — unit e bind">
+<p>Uma <em>monad</em> é uma tripla <code>(M, unit, ★)</code>: um construtor de tipo <code>M</code> e duas operações que satisfazem três leis (§3 do paper). Uma função normal <code>a → b</code> vira <code>a → M b</code> — "recebe <code>a</code>, retorna <code>b</code> <em>com um efeito possível capturado por M</em>" (o efeito pode ser: lançar exception, estado, output…).</p>
+<l-data>
+<l-row k="unit :: a → M a" v="embrulha um valor puro numa computação que não faz mais nada"></l-row>
+<l-row k="(★) :: M a → (a → M b) → M b" v="bind: sequencia — 'faz m, liga o resultado a `a`, faz n'"></l-row>
+</l-data>
+<p>A leitura de <code>m ★ λa. n</code> é literalmente o <code>let a = m in n</code> — "compute m, dê o nome <code>a</code> ao resultado, compute n". O <code>bind</code> do doc 4 é <em>este</em> <code>★</code>. Com ele, o avaliador vira:</p>
+<pre><code>eval (Con a) = unit a
+eval (Div t u) = eval t ★ λa. eval u ★ λb. unit (a ÷ b)</code></pre>
+</l-sec>
+
+<l-sec n="3" title="A exception monad — onde o encanamento se esconde">
+<p>A definição exata (§2.7 do paper):</p>
+<pre><code>data M a = Raise Exception | Return a
+type Exception = String
+
+unit a  = Return a
+m ★ k   = case m of
+            Raise e  → Raise e     -- ← toda a propagação mora AQUI
+            Return a → k a
+raise e = Raise e</code></pre>
+<p><strong>Esta é a sacada inteira.</strong> Aquele <code>case … Raise e → Raise e</code> que estava repetido em <em>cada</em> chamada recursiva do §1 agora existe <strong>uma vez só, dentro do <code>★</code></strong>. O curto-circuito do trilho de falha do ROP (doc 4) é literalmente esta linha. E pra adicionar erro ao avaliador monádico, Wadler diz: "just replace <code>unit (a ÷ b)</code> by <code>if b == 0 then raise "divide by zero" else unit (a ÷ b)</code>" — <strong>uma mudança local</strong>, o resto do texto do programa não muda.</p>
+<p>O ponto que amarra tudo: a <em>mesma</em> estrutura de programa serve pra exception, estado (<code>M a = State → (a, State)</code>) e output (<code>M a = (Output, a)</code>) — você só troca a definição de <code>M</code>/<code>unit</code>/<code>★</code>. O encanamento específico de cada efeito fica escondido no <code>★</code>.</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — o que isso diz sobre o seu desenho">
+<p><strong>1. Você já usa a exception monad — sem chamar assim.</strong> Quando um domain faz <code>throw new DomainError(...)</code> e o boundary faz <code>catch (DomainError) → TRPCError</code>, o runtime do JS está fazendo o papel do <code>★</code>: propagando o "Raise" automaticamente por você. O <code>throw</code> nativo <em>é</em> a exception monad embutida na linguagem — por isso a ADR-0017 não precisou de <code>Result</code> pra ter propagação automática. O JS te dá o <code>★</code> de graça via <code>throw</code>/<code>catch</code>.</p>
+<p><strong>2. Isso explica por que a regra 15 é a mesma ideia num nível diferente.</strong> O encanamento tedioso do §1 (re-propagar erro em cada nível) é o que você <em>não</em> quer espalhar. A regra 15 diz "não traduza erro em toda camada, traduza uma vez no boundary" — é o mesmo princípio de "o encanamento mora num lugar só" que motiva a monad.</p>
+<p><strong>3. Gancho pro 5-a — a limitação que o tracer precisa vencer.</strong> A exception monad do Wadler <em>descarta</em> a cadeia: <code>Raise e → Raise e</code> re-propaga o erro <em>intocado</em>. Ele não acumula "por onde passou". É a mesma perda que o doc 4 apontou no <code>throw</code>. Se você quisesse a cadeia causal, precisaria de uma variante onde o <code>★</code> <em>enriquece</em> o erro ao re-propagar (algo como <code>Raise e → Raise (wrap contexto e)</code>). <strong>Seu error tracer é, em essência, uma exception monad com um <code>★</code> que embrulha em vez de repassar.</strong> Ver isso na forma mínima do Wadler deixa o design do tracer nítido: é uma linha — a linha da propagação — que você quer mudar.</p>
+</l-apply>
+
+<l-note kind="warn" title="Cuidado">Não precisa de teoria de categorias nem de reescrever nada em Haskell — Wadler é explícito que "no knowledge of category theory is required". O valor pra você é <em>conceitual</em>: reconhecer que <code>throw</code>/<code>catch</code> já é a exception monad, e que o encanamento de propagação é um ponto único e substituível. As "três leis da monad" (§3, não mostradas aqui) importam pra provar que o <code>bind</code> se comporta — não pro seu dia a dia.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="Qual o problema que a monad resolve (a frase do Wadler)?" src="Wadler §2" href="https://www.cs.tufts.edu/comp/150PLD/Papers/MonadsForFunctionalProgramming.pdf">O algoritmo fica soterrado sob o encanamento (plumbing).</l-card>
+<l-card q="O que unit faz?" src="Wadler §2.5/2.7">Embrulha um valor puro: unit a = Return a.</l-card>
+<l-card q="O que o bind (★) faz na exception monad?" src="Wadler §2.7">case: Raise→re-propaga; Return a→aplica k a.</l-card>
+<l-card q="Onde mora TODA a propagação de erro na exception monad?" src="Wadler §2.7">Numa linha dentro do ★ (Raise e → Raise e).</l-card>
+<l-card q="No bearboo, o que faz o papel do ★?" src="Aplicar no contexto">O throw/catch nativo do JS — a exception monad embutida.</l-card>
+<l-card q="O que seu error tracer muda, em termos de Wadler?" src="Aplicar no contexto">A linha da propagação: ★ que embrulha o erro em vez de repassá-lo.</l-card>
+</l-sec>
+
+<l-tldr>
+<li>Monad resolve o "encanamento soterra o algoritmo": <code>unit</code> embrulha um valor, <code>★</code> (bind) sequencia — e <strong>esconde a propagação num lugar só</strong>.</li>
+<li>Na <strong>exception monad</strong> (<code>Raise | Return</code>), toda a propagação de erro é <em>uma linha</em> dentro do <code>★</code>. Adicionar erro é uma mudança local; o resto do programa não muda.</li>
+<li>O <code>throw</code>/<code>catch</code> do JS <strong>já é</strong> essa monad embutida — por isso o bearboo tem propagação automática sem <code>Result</code>.</li>
+<li>Pro 5-a: a monad clássica <em>descarta</em> a cadeia (re-propaga intocado). Seu tracer é a variante cujo <code>★</code> <strong>embrulha</strong> o erro ao propagar. O design cabe numa linha.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-06-orthogonal-defect-classification.html
+++ b/docs/learn/resumo-06-orthogonal-defect-classification.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orthogonal Defect Classification — Chillarege et al. (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Pilar 2 · taxonomia de erro" title="Orthogonal Defect Classification — A Concept for In-Process Measurements" authors="Chillarege, Bhandari, Chaar, Halliday, Moebus, Ray, Wong (IBM), IEEE TSE 1992" src="Fontes abertas: Wikipedia + IBM Research; paper original paywalled (IEEE Xplore)" href="https://en.wikipedia.org/wiki/Orthogonal_defect_classification"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Entendimento. Este é o <strong>ancestral acadêmico do seu ErrorRegistry</strong> — a ideia de que erro classificado é <em>dado mensurável</em>, não só uma mensagem. É o pilar mais distante do seu 5-a imediato, mas é o que transforma seu catálogo em <em>sinal</em>.</l-note>
+
+<l-note kind="warn" title="Nota de fidelidade (leia antes)">As fontes abertas que consultei (Wikipedia, IBM Research) confirmam <strong>o conceito, os atributos e o papel do trigger</strong>, mas <em>não enumeram</em> os valores de "defect type" — a Wikipedia diz apenas "sete valores empiricamente estabelecidos". A lista de tipos que dou em §2 é o <strong>conjunto canônico citado pela literatura ODC</strong>, não uma transcrição do paper original (paywalled). Trato como referência, não como citação exata.</l-note>
+
+<l-sec n="1" title="O conceito — o 'orthogonal' e o feedback in-process">
+<p>ODC "turns semantic information in the software defect stream into a measurement on the process". A ideia: em vez de contar bugs (métrica pobre) ou fazer causal analysis caso a caso (caro), você <strong>classifica cada defeito segundo atributos independentes ("ortogonais")</strong> e olha a <em>distribuição</em>. A distribuição vira uma <strong>assinatura do processo</strong>: onde estão os defeitos te diz em que fase o produto está e se sua verificação está funcionando — feedback <em>durante</em> o desenvolvimento, sem métrica externa.</p>
+<p>"Orthogonal" = os atributos são independentes; podem ser aplicados sozinhos ou combinados pra iluminar aspectos diferentes do processo.</p>
+</l-sec>
+
+<l-sec n="2" title="Os 8 atributos e o trigger">
+<p>Cada defeito recebe atributos capturados em <strong>dois momentos</strong>:</p>
+<l-data>
+<l-row k="Na ABERTURA do defeito" v="Activity · Trigger · Impact"></l-row>
+<l-row k="No FECHAMENTO do defeito" v="Target · Type · Qualifier · Source · Age"></l-row>
+</l-data>
+<p><strong>Trigger</strong> — "the force that surfaced the fault to create the failure" (o que <em>expôs</em> o bug). A distribuição de triggers mede a <strong>eficácia da verificação</strong>: se um tipo de trigger só aparece tarde, sua inspeção/teste está deixando passar aquela classe de condição.</p>
+<p><strong>Type</strong> — a natureza do conserto. Conjunto canônico (≈7-8 valores empíricos; ver nota de fidelidade): <code>Function</code>, <code>Interface</code>, <code>Checking</code>, <code>Assignment</code>, <code>Algorithm</code>, <code>Timing/Serialization</code>, <code>Build/Package/Merge</code>, <code>Documentation</code>. A distribuição de <em>type</em> ao longo do tempo mede <strong>progresso</strong>: cedo domina Function (design), tarde domina Assignment/Checking (código).</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — seu ErrorRegistry como fonte de sinal">
+<p>ODC é sobre <em>defeitos de desenvolvimento</em> (bugs achados em review/teste), então não mapeia 1:1 no seu catálogo de <em>erros de runtime</em>. Mas a <strong>ideia transferível é forte</strong>: erro classificado com atributos ortogonais é <em>dado mensurável</em>, e a distribuição é uma assinatura.</p>
+<p>Seu <code>ErrorRegistry</code> já tem o esqueleto disso. Cada <code>DomainError</code> tem um <code>code</code> namespaced — isso já é uma classificação. O que ODC sugere é <strong>adicionar atributos ortogonais ao catálogo</strong> e depois olhar a <em>distribuição em produção</em>:</p>
+<l-steps>
+<li><strong>Domínio</strong> (você já tem: <code>auth</code>, <code>post</code>, <code>session</code>…) — a distribuição por domínio te diz onde a dor está concentrada.</li>
+<li><strong>Type-like</strong>: o erro é <code>validation</code> / <code>authz</code> / <code>not_found</code> / <code>conflict</code> / <code>infra</code>? Um atributo ortogonal ao domínio — cruzar os dois é a "orthogonal" do ODC.</li>
+<li><strong>Trigger-like</strong>: o que expôs? (endpoint, role do usuário, tipo de request). Distribuição de trigger = onde sua validação de boundary está deixando passar.</li>
+<li><strong>Severity/retryable</strong> (que o doc 2 já pediu) — fecha o conjunto.</li>
+</l-steps>
+<p>Aí o mesmo <code>errorFormatter</code>/boundary que hoje traduz <code>DomainError → TRPCError</code> pode <em>emitir</em> essa classificação pra um contador. <strong>Você ganha "analytics de erro" de graça</strong> — quais domínios/tipos dominam, se mudou depois de um deploy. É o mesmo salto conceitual do ODC: de "quantos erros" pra "que <em>forma</em> tem a distribuição de erros". E conecta com o seu roadmap de analytics (Fase de analytics já existe no projeto).</p>
+<p><strong>Ligação com o 5-a:</strong> o tracer te dá a <em>cadeia</em> de um erro; o ODC te dá a <em>distribuição</em> de muitos. Juntos: "erros de <code>post.*</code> disparados por <code>role=editor</code> quase sempre têm na cadeia um <code>session.*</code> na raiz" — isso é diagnóstico de processo, não de um request. É o teto do que essa linha de trabalho alcança.</p>
+</l-apply>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="O que 'orthogonal' significa em ODC?" src="Wikipedia §def" href="https://en.wikipedia.org/wiki/Orthogonal_defect_classification">Atributos independentes, aplicáveis sozinhos ou combinados.</l-card>
+<l-card q="Qual a ideia central de ODC?" src="Wikipedia §def">Distribuição de defeitos classificados = assinatura do processo (feedback in-process).</l-card>
+<l-card q="O que é um 'trigger'?" src="Wikipedia §trigger">A força que expôs o fault e criou a failure.</l-card>
+<l-card q="A distribuição de trigger mede o quê?" src="Wikipedia §trigger">A eficácia/completude da verificação (inspeção/teste).</l-card>
+<l-card q="Como transportar ODC pro bearboo?" src="Aplicar no contexto">Atributos ortogonais no catálogo + olhar a distribuição em produção.</l-card>
+</l-sec>
+
+<l-tldr>
+<li>ODC: classifique cada defeito por <strong>atributos ortogonais</strong> e olhe a <em>distribuição</em> — ela é a assinatura do processo (feedback durante o dev, não post-mortem).</li>
+<li>8 atributos em 2 momentos: abertura (Activity/Trigger/Impact), fechamento (Target/Type/Qualifier/Source/Age). <strong>Trigger</strong> mede se sua verificação pega os bugs cedo.</li>
+<li>Transferível pro bearboo: dê ao <code>ErrorRegistry</code> atributos ortogonais (domínio × type × trigger × severity) e emita a classificação no boundary → <strong>analytics de erro de graça</strong>.</li>
+<li>Tracer (5-a) = cadeia de <em>um</em> erro; ODC = distribuição de <em>muitos</em>. Juntos viram diagnóstico de processo.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-07-handlers-algebraic-effects.html
+++ b/docs/learn/resumo-07-handlers-algebraic-effects.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Handlers of Algebraic Effects — Plotkin & Pretnar (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Pilar 4 · algebraic effects" title="Handlers of Algebraic Effects" authors="Gordon Plotkin & Matija Pretnar (ESOP 2009)" src="homepages.inf.ed.ac.uk (PDF aberto) — o paper que generaliza exception handling" href="https://homepages.inf.ed.ac.uk/gdp/publications/Effect_Handlers.pdf"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Conceitual, pula o formalismo. O paper é teoria de categorias/equational theory densa; o que importa pra você é <strong>uma ideia</strong> que reenquadra tudo que veio antes: exception é um caso particular de algo maior. Os trechos de sintaxe abaixo são <em>ilustrativos</em> (estilo moderno, ex. Koka/Eff), não notação do paper de 2009.</l-note>
+
+<l-sec n="1" title="O conceito — operação abstrata + interpretação separada">
+<p>Um <strong>algebraic effect</strong> trata operações com efeito colateral (<code>raise</code>, <code>get</code>, <code>put</code>, <code>log</code>) como <strong>operações abstratas</strong>: seu código <em>chama</em> a operação sem saber como ela é implementada. Quem decide o significado é um <strong>handler</strong>, depois, por fora. Separa-se <em>declaração</em> do efeito de <em>interpretação</em> dele.</p>
+<pre><code>effect Log { operation log(msg): void }
+
+program() { log("start"); doWork(); log("done") }
+
+handle program() with ConsoleHandler   // imprime
+handle program() with NoOpHandler       // descarta
+handle program() with CollectHandler    // acumula numa lista</code></pre>
+<p>O <em>mesmo</em> texto de programa, três significados. (Note o parentesco com a monad do doc 5: lá você troca a definição de <code>M</code>/<code>★</code>; aqui você troca o handler. Effects são a evolução dessa ideia.)</p>
+</l-sec>
+
+<l-sec n="2" title="A sacada — o handler pode RETOMAR (resume)">
+<p>Aqui está o que faz effects serem "try/catch com esteroides". Um <code>catch</code> tradicional <strong>só aborta</strong>: pegou a exception, o <code>try</code> morreu, você não volta. Um <strong>effect handler pode retomar</strong> a computação no ponto exato da operação, entregando um resultado:</p>
+<pre><code>// try/catch: para, nunca retoma
+try { x = risky() } catch (e) { handle(e) }
+
+// handler: intercepta, decide, e RETOMA de onde parou
+handle { x = operation() } with { op → resume(valorCalculado) }</code></pre>
+<p>Isso destranca backtracking, retry, non-determinism — dá pra <em>retomar múltiplas vezes</em>. E leva à tese que reorganiza os docs 1–5:</p>
+<l-note kind="info" title="A tese unificadora">Exception handling é o caso particular de effect handling <strong>onde o handler escolhe NÃO retomar</strong>. <code>throw</code> = "efeito sem caminho de retomada". Todos os efeitos (estado, IO, exception, async) viram instâncias de um mesmo mecanismo.</l-note>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — o que isso ilumina (e o que NÃO fazer)">
+<p><strong>Honestidade primeiro:</strong> TS não tem algebraic effects nativos, e isto <em>não</em> é um próximo passo prático pro bearboo. O valor aqui é <strong>enxergar o teto do espaço de design</strong> — pra você saber que existe e por que não está indo lá agora.</p>
+<p><strong>A conexão que vale ouro pro seu 5-a — "resume" é o retryable levado ao limite.</strong> Lembra do <code>retryable</code> dos docs 2 e 6? Num mundo de effect handlers, um erro transiente não seria um <code>throw</code> que aborta e obriga o chamador a re-executar tudo — seria uma <em>operação</em> que o handler <strong>retoma</strong> com o resultado do retry, sem desmontar a pilha. O "erro recuperável" do Duffy (doc 1) atinge sua forma mais pura aqui: recuperável = literalmente <em>retomável no ponto da falha</em>. Seu <code>DomainError</code> com <code>throw</code> está no extremo oposto (nunca retoma) — o que é ok, mas agora você sabe que "recuperável" tem gradações, e a sua é a mais grossa.</p>
+<p><strong>Onde isso já vaza pro seu stack, disfarçado:</strong> <code>async/await</code> e generators do JS <em>são</em> uma forma limitada de continuation/efeito (async é o efeito mais domesticado da lista). Você não vai escrever handlers algébricos, mas reconhecer que <code>await</code> é "um efeito cujo handler retoma quando a promise resolve" te dá o modelo mental certo. Se um dia o TS ganhar algo como effect types (há propostas), a releitura desta ideia vira prática.</p>
+</l-apply>
+
+<l-note kind="warn" title="Cuidado">Não tente emular effect handlers com generators/callbacks no bearboo — seria complexidade sem retorno pro call depth raso que a ADR-0017 já diagnosticou. Este doc é <strong>mapa, não rota</strong>: serve pra você situar o <code>throw</code>/<code>catch</code> como o canto "não-retomável" de um espaço maior, e entender que "recuperável" é um espectro.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="O que separa um algebraic effect?" src="Plotkin & Pretnar §conceito" href="https://homepages.inf.ed.ac.uk/gdp/publications/Effect_Handlers.pdf">Declaração da operação × interpretação (feita pelo handler).</l-card>
+<l-card q="A diferença crucial entre effect handler e try/catch?" src="§handlers">O handler pode RETOMAR a computação; o catch só aborta.</l-card>
+<l-card q="Exception é um caso particular de quê?" src="§tese">De effect handling — onde o handler escolhe não retomar.</l-card>
+<l-card q="Como isso reenquadra 'erro recuperável' (Duffy)?" src="Aplicar no contexto">Recuperável no limite = retomável no ponto da falha.</l-card>
+<l-card q="O que no JS já é um efeito com handler-que-retoma?" src="Aplicar no contexto">async/await (retoma quando a promise resolve).</l-card>
+</l-sec>
+
+<l-tldr>
+<li>Algebraic effect = operação abstrata; <strong>handler</strong> dá a interpretação, por fora, e o mesmo código serve a vários handlers.</li>
+<li>Diferença nuclear pro try/catch: o handler <strong>pode retomar</strong> a computação (retry, backtracking, non-determinism).</li>
+<li>Tese unificadora: <strong>exception = effect handler que não retoma</strong>. Reorganiza docs 1–5 num só mecanismo.</li>
+<li>Pro bearboo: <strong>mapa, não rota</strong>. Ilumina que "recuperável" é um espectro e que seu <code>throw</code> é o extremo grosso — mas não é próximo passo prático em TS.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-08-koka-algebraic-effects-types.html
+++ b/docs/learn/resumo-08-koka-algebraic-effects-types.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Algebraic Effects for Functional Programming (Koka) — Leijen (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Pilar 4 · effects no sistema de tipos" title="Algebraic Effects for Functional Programming (Koka)" authors="Daan Leijen (Microsoft Research Tech Report, 2016)" src="microsoft.com (PDF aberto) — a versão prática/tipada dos effects" href="https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Profundo, mas focado no que é DISTINTO do doc 7: enquanto o Plotkin dá o mecanismo, o Leijen dá o <strong>sistema de tipos que rastreia efeitos</strong> e compila pra JavaScript. Uso a notação real do Koka do paper.</l-note>
+
+<l-sec n="1" title="A ideia central — o efeito vive no TIPO da função">
+<p>Em Koka, o tipo de uma função é <code>τ → ε τ'</code>: recebe <code>τ</code>, devolve <code>τ'</code>, <strong>e pode ter o efeito <code>ε</code></strong>. O efeito é rastreado por <em>row types</em> (rótulos com escopo). Consequências diretas e visíveis:</p>
+<l-data>
+<l-row k="zerodiv : (int,int) → ⟨⟩ int" v="efeito VAZIO ⟨⟩ = função TOTAL, não pode dar errado"></l-row>
+<l-row k="safediv : (int,int) → exc int" v="o tipo DIZ que pode lançar o efeito exc"></l-row>
+<l-row k="ask-age : () → ⟨async,console⟩ ()" v="o tipo DIZ que é assíncrona e usa console"></l-row>
+</l-data>
+<p>Isto é "checked exceptions" (doc 1) <strong>generalizado e inferido</strong>: em vez de você <em>declarar</em> <code>throws</code> à mão (Java) e sofrer, o compilador <em>infere</em> quais efeitos cada função tem e propaga no tipo. A visibilidade que o Duffy queria — "olhe a assinatura e veja o que pode falhar" — cai de graça, pra <em>todos</em> os efeitos, não só exception.</p>
+</l-sec>
+
+<l-sec n="2" title="Exception como efeito, e o handler que DESCARREGA o efeito">
+<p>Exception não é primitivo — é um efeito definido em biblioteca:</p>
+<pre><code>effect exc { raise(s: string): a }
+
+fun safediv(x, y) { if (y == 0) then raise("divide by zero") else x / y }
+// tipo inferido: (int,int) → exc int   ← o exc apareceu sozinho</code></pre>
+<p>O <code>catch</code> é um handler que <strong>descarrega</strong> o efeito — repare no tipo: entra uma ação com <code>⟨exc|e⟩</code>, sai <code>e</code> (o <code>exc</code> <em>sumiu</em> do tipo depois do catch):</p>
+<pre><code>catch : (action: () → ⟨exc|e⟩ a, h: string → e a) → e a</code></pre>
+<p>Ou seja, o sistema de tipos <em>sabe</em> que depois de tratar, o erro não escapa mais. É a regra 15 do bearboo — "o erro de domínio é traduzido e não vaza além do boundary" — mas <strong>verificada pelo compilador</strong> em vez de por convenção.</p>
+</l-sec>
+
+<l-sec n="3" title="to-maybe — a ponte com o pilar 3 (exception ↔ Result)">
+<p>O exemplo mais importante pra você. Um handler que transforma computação-que-pode-falhar em <code>maybe</code> (= <code>Option</code>/<code>Result</code>):</p>
+<pre><code>fun to-maybe(action) {
+  handle(action) {
+    return x  → Just(x)     // sucesso vira Just
+    raise(s) → Nothing      // falha vira Nothing
+  }
+}   // tipo: (() → ⟨exc|e⟩ a) → e maybe⟨a⟩</code></pre>
+<p><strong>Isto prova que exception e Result são intercambiáveis</strong> — um handler de 3 linhas converte um no outro. Todo o "debate" dos docs 1, 4 e 5 (throw vs. Result) se dissolve: são a <em>mesma coisa</em> vista por handlers diferentes. Você não precisa escolher globalmente; pode ter <code>throw</code> e, num ponto específico, "handleá-lo pra Option" quando quiser o estilo Result ali.</p>
+</l-sec>
+
+<l-sec n="4" title="Como isso roda em JavaScript (a parte prática)">
+<p>Koka compila effect handlers pra plataformas sem controle de pilha (JS, JVM, .NET) via <strong>type-directed selective CPS translation</strong> — só as partes que precisam de continuation viram CPS. E o exemplo canônico deles é <strong>async em NodeJS</strong> (§2.5): <code>readline</code> é modelado como efeito, e o handler registra o <code>resume</code> como callback do event loop. A tese: <strong>async/await é um algebraic effect</strong> — o único que o JS já domesticou com sintaxe própria.</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — o que dá pra roubar sem ter Koka">
+<p><strong>1. A releitura da regra 15.</strong> O <code>catch</code> que descarrega <code>⟨exc|e⟩ → e</code> é o seu boundary formalizado: o <code>DomainError</code> entra, o <code>TRPCError</code> sai, e "o domínio não vaza" vira propriedade de tipo. TS não te dá isso no compilador, mas o modelo mental — "o boundary é o handler que descarrega o efeito de erro do domínio" — é exatamente a sua arquitetura, agora com nome preciso.</p>
+<p><strong>2. <code>to-maybe</code> resolve uma tensão real sua.</strong> A ADR-0017 rejeitou <code>Result</code> globalmente (certo, doc 4). Mas às vezes você quer estilo-Result <em>localmente</em> (ex.: "tenta ler o post; se não existir, sigo com <code>null</code> em vez de propagar"). O <code>to-maybe</code> mostra o padrão: um helper <code>tryDomain(fn): Promise&lt;Result&lt;T, DomainError&gt;&gt;</code> que faz <code>try/catch</code> e converte <em>só naquele call site</em>. Você já fez algo parecido no <code>recordView</code> (o null vs. throw que discutimos). Isto te dá o vocabulário: é um handler <code>to-maybe</code> pontual, não uma migração global.</p>
+<p><strong>3. Async já é seu único efeito tipado.</strong> Toda procedure sua é <code>async</code> — o TS <em>rastreia</em> isso no tipo (<code>Promise&lt;T&gt;</code>). Você já vive num mundo onde <em>um</em> efeito é visível no tipo. Ver que erro <em>poderia</em> ser rastreado do mesmo jeito (se TS tivesse effect rows) explica por que o erro no bearboo é "invisível no tipo" hoje: falta a linha <code>exc</code> que o Koka teria inferido. Seu <code>DomainError</code> compensa isso em runtime; o tracer (5-a) é você reconstruindo à mão a informação que um effect system daria no tipo.</p>
+</l-apply>
+
+<l-note kind="warn" title="Cuidado">Row-typed effects não existem em TS e não há como emular com honestidade (o `fp-ts`/`Effect-TS` chega perto com <code>Effect&lt;A, E, R&gt;</code>, mas é outro paradigma e pesado — fora do escopo da ADR). Leve os <strong>conceitos</strong> (efeito no tipo, handler descarrega, to-maybe converte), não a tecnologia. Se um dia avaliar <code>Effect-TS</code>, volte aqui — é a materialização disto em TS.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="O que o tipo τ → ε τ' de Koka rastreia?" src="Leijen §1/§overview" href="https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf">O efeito ε que a função pode ter (via row types).</l-card>
+<l-card q="O que significa efeito ⟨⟩ (vazio)?" src="Leijen §overview">Função total — não pode dar errado, sem side effect.</l-card>
+<l-card q="O que o handler catch faz ao tipo do efeito?" src="Leijen §2.1">Descarrega exc: de ⟨exc|e⟩ a para e (o exc some).</l-card>
+<l-card q="O que to-maybe demonstra?" src="Leijen §2.1">Exception e Result/Option são intercambiáveis (handler de 3 linhas).</l-card>
+<l-card q="Qual algebraic effect o JS já domesticou?" src="Leijen §2.5">async/await.</l-card>
+<l-card q="No bearboo, o que substitui o 'efeito no tipo' que falta?" src="Aplicar no contexto">O DomainError em runtime; o tracer reconstrói à mão o que o tipo daria.</l-card>
+</l-sec>
+
+<l-tldr>
+<li>Koka rastreia <strong>efeitos no tipo da função</strong> (<code>τ → ε τ'</code>, via row types) — checked exceptions generalizadas e <em>inferidas</em>, pra todo efeito.</li>
+<li>Exception é efeito de biblioteca; o <code>catch</code> <strong>descarrega</strong> o efeito do tipo — a regra 15 verificada pelo compilador.</li>
+<li><strong><code>to-maybe</code> converte exception ↔ Result num handler de 3 linhas</strong> — dissolve o debate throw vs. Result: é escolha local, não global.</li>
+<li>Pro bearboo: roube os conceitos, não a tech. <code>async</code> já é seu efeito tipado; o erro não é — e o tracer (5-a) é você reconstruindo à mão a info que um effect system daria no tipo.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-09-dapper-distributed-tracing.html
+++ b/docs/learn/resumo-09-dapper-distributed-tracing.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Dapper — Sigelman et al. (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Pilar 5 · tracing / causalidade" title="Dapper, a Large-Scale Distributed Systems Tracing Infrastructure" authors="Sigelman, Barroso, Burrows, Stephenson, Plakal, Beaver, Jaspan, Shanbhag (Google, 2010)" src="research.google (PDF aberto) — o paper que fundou distributed tracing" href="https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/36356.pdf"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Este é <em>distributed</em> tracing (pilar 5-b, entre serviços) — mas você quer o 5-a (dentro de um request). A boa notícia: <strong>o modelo de dados do Dapper é EXATAMENTE o que seu tracer 5-a precisa, menos a rede</strong>. Leio focando no que transfere pro seu caso.</l-note>
+
+<l-sec n="1" title="O modelo de dados — trees, spans, annotations">
+<p>Um <strong>trace</strong> é uma <strong>árvore de spans</strong>. Um <strong>span</strong> é a unidade básica de trabalho (um nó da árvore); a aresta liga um span ao seu <strong>parent span</strong> e representa uma <em>relação causal</em>. Cada span tem:</p>
+<l-data>
+<l-row k="span name" v="rótulo legível do trabalho"></l-row>
+<l-row k="span id" v="id do span"></l-row>
+<l-row k="parent id" v="id do span pai (ausente ⇒ é um ROOT span)"></l-row>
+<l-row k="trace id" v="compartilhado por TODOS os spans do mesmo request (64-bit)"></l-row>
+<l-row k="annotations" v="registros com timestamp: start/end, timing, e dados livres"></l-row>
+</l-data>
+<p>Ou seja: <code>parent id</code> reconstrói a <strong>cadeia causal</strong> (quem causou quem) e o <code>trace id</code> agrupa tudo que pertence ao <em>mesmo</em> request. Isto é, ponto por ponto, o modelo <code>AnyError</code> = { erro, contexto, filhos } do doc 2 — só que Google fez pra árvore de RPCs entre máquinas.</p>
+</l-sec>
+
+<l-sec n="2" title="O mecanismo — propagar um contexto pequeno por toda chamada">
+<p>A engenharia central: um <strong>trace context</strong> — "a small and easily copyable container of span attributes such as trace and span ids" — é carregado por <em>toda</em> a computação:</p>
+<ul>
+<li>Guardado em <strong>thread-local storage</strong> enquanto uma thread processa o request.</li>
+<li>Em código assíncrono/deferido, os callbacks <strong>guardam o trace context do criador</strong> e o reassociam quando executam — assim a cadeia sobrevive ao async.</li>
+<li>Entre processos, o <code>span id</code>/<code>trace id</code> viajam junto no RPC.</li>
+</ul>
+<p>É a distinção <strong>annotation-based vs. black-box</strong>: black-box tenta <em>inferir</em> a associação por regressão estatística (sem tocar no código); annotation-based <strong>marca cada registro com um id global</strong> que liga de volta ao request originador. Dapper é annotation-based, escondido em <em>poucas bibliotecas comuns</em> (threading, control-flow, RPC) — daí a <strong>transparência de aplicação</strong>: o dev não instrumenta nada à mão.</p>
+</l-sec>
+
+<l-sec n="3" title="Os 3 objetivos de design (e o sampling)">
+<l-steps>
+<li><strong>Low overhead</strong> — impacto de performance desprezível, senão os times desligam.</li>
+<li><strong>Application-level transparency</strong> — o dev não precisa saber que existe (instrumentação nas libs comuns). O mais difícil e o mais valioso.</li>
+<li><strong>Ubiquidade/escala</strong> — se não é onipresente, você perde justamente o pedaço não-monitorado onde o problema mora.</li>
+</l-steps>
+<p><strong>Sampling:</strong> descoberta surpreendente — <em>"a sample of just one out of thousands of requests provides sufficient information for many common uses"</em>. Para diagnóstico de padrões, você não precisa de todo request; precisa de amostra. (Guarde isso: o tracer que loga 100% dos requests é caro e quase sempre desnecessário.)</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — Dapper é o blueprint do seu tracer 5-a">
+<p>Traduzindo o modelo pro seu escopo (um request tRPC, uma máquina). O mapeamento é quase 1:1:</p>
+<table>
+<thead><tr><th>Dapper (5-b)</th><th>Seu tracer no bearboo (5-a)</th></tr></thead>
+<tbody>
+<tr><td><code>trace id</code></td><td>request id (gere um por request no <code>createContext</code>)</td></tr>
+<tr><td><code>span</code> / <code>parent id</code></td><td>cada <code>DomainError</code> e seu <code>cause</code> — a cadeia que você já tem, agora com id</td></tr>
+<tr><td>root span</td><td>o erro no boundary (<code>TRPCError</code>) — topo da árvore</td></tr>
+<tr><td>annotations</td><td>metadata do erro: <code>code</code>, <code>severity</code>, <code>retryable</code>, timestamp, camada (domain/model)</td></tr>
+<tr><td>trace context em thread-local</td><td>o próprio <code>ctx</code> do tRPC — carregue o request id nele</td></tr>
+<tr><td>transparência via libs comuns</td><td>instrumente no <strong>boundary/errorFormatter</strong>, não em cada domain</td></tr>
+</tbody>
+</table>
+<p><strong>As três lições que evitam você reinventar errado:</strong></p>
+<ol>
+<li><strong>Propague um contexto pequeno, não instrumente tudo.</strong> Igual ao trace context: bote um <code>requestId</code> no <code>ctx</code> uma vez, e o erro só precisa <em>referenciá-lo</em>. Não saia enfiando logging em cada função de domínio (isso viola a sua própria doutrina de camadas).</li>
+<li><strong>Transparência de aplicação é o objetivo de maior valor e o mais difícil.</strong> No seu caso, traduz pra: a captura da cadeia deve morar no boundary (onde a regra 15 já centraliza a tradução), não espalhada. Você já tem o ponto único — o <code>catch (DomainError)</code>. É ali que o span vira registro.</li>
+<li><strong>Sampling.</strong> Quando ligar isso em produção, não persista a árvore de todo request. Erros você quer 100% (são raros); mas se um dia adicionar tracing de <em>sucesso</em> (latência por camada), amostre — 1 em milhares basta pra ver padrões, como o Google achou.</li>
+</ol>
+<p><strong>O passo concreto que sai daqui:</strong> dar ao <code>DomainError</code> um <code>spanId</code> + <code>parentId</code> (ou simplesmente confiar no encadeamento de <code>cause</code>) e um <code>requestId</code> vindo do <code>ctx</code>; no boundary, serializar a cadeia <code>error → cause → cause…</code> como uma árvore de spans num log estruturado. Pronto — você tem "Dapper de um processo".</p>
+</l-apply>
+
+<l-note kind="warn" title="Cuidado">Não puxe OpenTelemetry/Jaeger pra isso <em>ainda</em>. Aquilo é a indústria-força do 5-b (entre serviços), e o bearboo é um monólito Next.js — seria peso e infra sem retorno agora. O <em>modelo</em> do Dapper (span/parent/trace-id/annotation) você implementa com um objeto e um log estruturado. Se o bearboo virar multi-serviço um dia, aí OTel materializa esse mesmo modelo — e você já vai entender a peça.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="O que é um span e o que a aresta pai representa?" src="Dapper §2.1" href="https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/36356.pdf">Unidade de trabalho; a aresta ao parent span = relação causal.</l-card>
+<l-card q="O que o trace id faz?" src="Dapper §2.1">Agrupa todos os spans do mesmo request.</l-card>
+<l-card q="Como o contexto é propagado por async?" src="Dapper §2.2">Callback guarda o trace context do criador e reassocia ao rodar.</l-card>
+<l-card q="Annotation-based vs. black-box?" src="Dapper §2">Annotation marca cada registro com id global; black-box infere por estatística.</l-card>
+<l-card q="Qual o objetivo de design mais valioso e difícil?" src="Dapper §1">Application-level transparency (instrumentar libs comuns, não o dev).</l-card>
+<l-card q="No bearboo, o que é o trace id e onde ele mora?" src="Aplicar no contexto">Um requestId no ctx do tRPC.</l-card>
+<l-card q="Onde o 'span vira registro' no bearboo?" src="Aplicar no contexto">No boundary/catch (DomainError) — o ponto único da regra 15.</l-card>
+</l-sec>
+
+<l-tldr>
+<li>Dapper modela um request como <strong>árvore de spans</strong>: <code>span id</code>+<code>parent id</code> = cadeia causal, <code>trace id</code> agrupa o request, <code>annotations</code> = metadata.</li>
+<li>Mecanismo: <strong>propagar um contexto pequeno</strong> (trace context) por toda chamada, inclusive async — sem instrumentar o dev (transparência via libs comuns).</li>
+<li>Mapeia quase 1:1 no seu 5-a: <code>requestId</code> no <code>ctx</code> = trace id; <code>DomainError.cause</code> = parent span; boundary = onde o span vira log.</li>
+<li>Lições: contexto pequeno &gt; instrumentar tudo · captura no ponto único (boundary) · sampling (1 em milhares basta pra padrões). <strong>Não puxe OTel ainda</strong> — implemente o modelo com um objeto + log estruturado.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-10-causal-inference-root-cause.html
+++ b/docs/learn/resumo-10-causal-inference-root-cause.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Causal Inference in Distributed Tracing (RCA) — resumo</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Pilar 5 · root cause (a ponta)" title="Causal Inference in Distributed Tracing: Automating Root Cause Analysis" authors="IJETCSIT (2024/25) — framework 'TraceCausalNet'" src="Abstract via busca; texto completo bloqueado (HTTP 400 no OJS)" href="https://www.ijetcsit.org/index.php/ijetcsit/article/view/676"></l-head>
+
+<l-note kind="warn" title="Nota de fidelidade (leia antes)">Diferente dos outros 9, <strong>não consegui abrir o texto completo</strong> deste (o servidor retornou 400). O resumo abaixo é baseado no <em>abstract</em> e em fontes que descrevem o mesmo trabalho/linha. Os números (§3) vêm do abstract conforme indexado — trate como "reportado pelo abstract", não como leitura da metodologia completa. Alternativa aberta pra aprofundar: <a href="https://arxiv.org/pdf/2408.13729">arXiv 2408.13729</a> (mesma linha, RCA por causal inference, PDF livre).</l-note>
+
+<l-note kind="info" title="Método deste resumo">Fecho da série. Se o Dapper (doc 9) te dá a <em>cadeia</em>, este te dá o salto final: de muitas cadeias correlacionadas, <strong>inferir a raiz</strong>. É o teto do espectro — aspiracional pra um monólito, mas define pra onde a linha inteira aponta.</l-note>
+
+<l-sec n="1" title="O problema — correlação não é causa">
+<p>Distributed tracing (doc 9) te mostra <em>o que aconteceu junto</em>: quando o request falhou, os serviços A, B e C também mostraram erro/latência. Mas <strong>correlação não é causa</strong> — qual dos três <em>originou</em> a falha e quais só <em>propagaram</em>? Em microserviços com dependências densas, um humano gasta (segundo o abstract) <strong>~47 minutos</strong> vasculhando isso manualmente por incidente. O gap: tracing convencional dá o grafo de quem-tocou-quem, não o veredito de quem-causou.</p>
+</l-sec>
+
+<l-sec n="2" title="O método — grafo causal + ranking por intervenção">
+<p>A abordagem (TraceCausalNet) constrói um <strong>grafo causal</strong> a partir dos dados de trace e ranqueia candidatos a raiz:</p>
+<ul>
+<li><strong>Granger causality</strong>: X "Granger-causa" Y se o passado de X <em>melhora a previsão</em> de Y além do que o passado de Y sozinho consegue. Aplicado às séries temporais dos serviços, revela <strong>direção</strong> de propagação — não só que A e B se mexem juntos, mas que A ajuda a prever B (logo A → B, não B → A). É o mecanismo que separa causa de efeito.</li>
+<li><strong>Interventional impact score</strong>: ranqueia cada candidato a raiz por quanto uma <em>intervenção</em> nele mudaria o resultado (raciocínio contrafactual: "se este serviço estivesse são, o incidente sumiria?"). O topo do ranking é a raiz mais provável.</li>
+<li>Reconstrói <strong>caminhos de propagação de erro</strong> ao longo do grafo, do sintoma (onde você viu) até a origem (onde nasceu).</li>
+</ul>
+</l-sec>
+
+<l-sec n="3" title="Resultados reportados (pelo abstract)">
+<l-data>
+<l-row k="Tempo de diagnóstico manual (baseline)" v="~47 min/incidente"></l-row>
+<l-row k="Tempo médio com o framework" v="~8 min"></l-row>
+<l-row k="Redução" v="83%"></l-row>
+<l-row k="Acurácia top-3 da raiz" v="91%"></l-row>
+<l-row k="Validação" v="6 apps bancárias, ~4 anos, ambiente regulado"></l-row>
+</l-data>
+<p>A leitura: com o grafo causal certo, "top-3 candidatos" acerta a raiz 91% das vezes — ou seja, você não precisa de certeza absoluta, precisa <strong>estreitar de 50 serviços pra 3</strong>. Isso é o suficiente pra colapsar 47 min em 8.</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — o teto, e o que já vale hoje">
+<p><strong>Realismo primeiro:</strong> Granger causality e grafos causais são feitos pra <em>muitos serviços com séries temporais</em>. O bearboo é um monólito — você não tem N serviços pra inferir direção entre eles. <strong>Este paper NÃO é próximo passo de código.</strong> Ele fecha a série mostrando o horizonte.</p>
+<p><strong>Mas há uma transferência conceitual real, em duas escalas:</strong></p>
+<ol>
+<li><strong>Dentro do request (seu 5-a), a causa é de graça — e é a vantagem do monólito.</strong> A dificuldade inteira deste paper é <em>inferir</em> causa a partir de correlação, porque em sistemas distribuídos a direção se perde. No seu tracer 5-a você <strong>não precisa inferir nada</strong>: a cadeia <code>error.cause.cause…</code> <em>já é</em> o grafo causal, com a direção conhecida (o <code>cause</code> aponta pra origem por construção). O que o Google gasta ML pra reconstruir, você tem de graça porque está num processo só. A raiz da cadeia é literalmente o último <code>cause</code>. <strong>Isso reforça que o 5-a bem-feito te dá "root cause" trivial que o mundo 5-b luta pra ter.</strong></li>
+<li><strong>Entre muitos requests (o cruzamento com o doc 6, ODC), aí sim aparece inferência.</strong> Se você agregar as cadeias de muitos erros e perguntar "erros de <code>post.update_forbidden</code> quase sempre têm <code>session.session_expired</code> na raiz?", você está fazendo a versão leve disto — achar o padrão de raiz na distribuição. Não precisa de Granger; um <code>GROUP BY raiz_da_cadeia</code> nos seus logs estruturados já entrega 80% do valor.</li>
+</ol>
+<p><strong>Takeaway acionável:</strong> quando construir o tracer, <strong>marque explicitamente qual elo é a raiz</strong> (o <code>cause</code> mais profundo) em cada cadeia logada. Isso transforma "log de erro" em "log de root cause" sem nenhum ML — e te dá, na escala de um monólito, o que este paper persegue na escala de bancos inteiros.</p>
+</l-apply>
+
+<l-note kind="warn" title="Cuidado (metodológico e de fidelidade)">Dois avisos: (1) não tentei validar a metodologia completa — os números são do abstract; se for citar em algo sério, leia o texto completo ou o arXiv 2408.13729. (2) Granger causality prova <em>precedência preditiva</em>, não causa mecanística — é uma heurística de direção, sujeita a confounders. Num monólito você nem precisa dela (tem a causa por construção); só a mencione se um dia o bearboo virar multi-serviço.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="Por que tracing convencional não dá root cause?" src="abstract §problema" href="https://www.ijetcsit.org/index.php/ijetcsit/article/view/676">Mostra correlação (quem falhou junto), não causa (quem originou).</l-card>
+<l-card q="O que Granger causality captura?" src="abstract §método">Direção: X Granger-causa Y se o passado de X melhora a previsão de Y.</l-card>
+<l-card q="O que o interventional impact score ranqueia?" src="abstract §método">Candidatos a raiz por impacto contrafactual de intervir neles.</l-card>
+<l-card q="Por que 'top-3' já resolve?" src="abstract §resultados">91% de acerto na top-3 estreita de dezenas pra 3 candidatos.</l-card>
+<l-card q="Por que o 5-a do bearboo tem root cause de graça?" src="Aplicar no contexto">A cadeia de cause já é o grafo causal com direção conhecida (monólito).</l-card>
+</l-sec>
+
+<l-tldr>
+<li>Tracing dá correlação; este trabalho infere <strong>causa</strong> — grafo causal via <strong>Granger causality</strong> + ranking por <strong>impacto interventional/contrafactual</strong>.</li>
+<li>Reportado: diagnóstico de ~47 min → ~8 min (83% ↓), 91% de acerto top-3, em 6 apps bancárias/4 anos. (Números do abstract; texto completo não acessado.)</li>
+<li><strong>A grande sacada pro seu 5-a:</strong> o que sistemas distribuídos gastam ML pra reconstruir, seu monólito tem de graça — a cadeia <code>error.cause</code> <em>é</em> o grafo causal, com direção conhecida. Root cause = o <code>cause</code> mais profundo.</li>
+<li>Ação: marque a raiz de cada cadeia no log. "Log de erro" vira "log de root cause" sem ML. NÃO é motivo pra puxar Granger/OTel num monólito.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/sessions/2026-07-29-0001-5d247c.md
+++ b/docs/sessions/2026-07-29-0001-5d247c.md
@@ -1,0 +1,35 @@
+---
+kind: handoff
+tier: episodic
+state: open
+cwd: /home/codork/Documents/Github/bearboo
+created_at: 2026-07-29T00:01:04Z
+---
+
+# Handoff 2026-07-29-0001
+
+> Estado de trabalho pra próxima sessão/agente (episódico, single-use). NÃO é conhecimento normativo — fora dos eixos A1–A7 do diagnose. Consumido pelo reconcile (marca `state: consumed`).
+
+## files_touched
+
+  - .gitignore
+  - docs/.afm-log/events/2026-07.md
+
+## summary (eventos desta sessão)
+
+  - [2026-07-27T03:55:31Z] ust | s=5d247c | edit em docs/ust.md
+  - [2026-07-27T03:55:40Z] feature-spec | s=5d247c | edit em docs/features/022-error-registry/spec.md
+  - [2026-07-27T03:55:45Z] feature-plan | s=5d247c | edit em docs/features/022-error-registry/plan.md
+  - [2026-07-27T03:55:59Z] feature-tasks | s=5d247c | edit em docs/features/022-error-registry/tasks.md
+  - [2026-07-27T03:55:59Z] deliverable | s=5d247c | 022-error-registry
+  - [2026-07-27T03:56:08Z] feature-tasks | s=5d247c | edit em docs/features/022-error-registry/tasks.md
+  - [2026-07-27T03:57:22Z] task | s=5d247c | commit
+  - [2026-07-27T04:00:16Z] task | s=5d247c | commit
+
+## open_questions
+
+  - [preencher — o que ficou em aberto]
+
+## next_steps
+
+  - [preencher — próximo passo concreto / T0NN]

--- a/docs/sessions/2026-07-30-0257-5d247c.md
+++ b/docs/sessions/2026-07-30-0257-5d247c.md
@@ -1,0 +1,35 @@
+---
+kind: handoff
+tier: episodic
+state: open
+cwd: /home/codork/Documents/Github/bearboo
+created_at: 2026-07-30T02:57:55Z
+---
+
+# Handoff 2026-07-30-0257
+
+> Estado de trabalho pra próxima sessão/agente (episódico, single-use). NÃO é conhecimento normativo — fora dos eixos A1–A7 do diagnose. Consumido pelo reconcile (marca `state: consumed`).
+
+## files_touched
+
+  - .gitignore
+  - docs/.afm-log/events/2026-07.md
+
+## summary (eventos desta sessão)
+
+  - [2026-07-27T03:55:40Z] feature-spec | s=5d247c | edit em docs/features/022-error-registry/spec.md
+  - [2026-07-27T03:55:45Z] feature-plan | s=5d247c | edit em docs/features/022-error-registry/plan.md
+  - [2026-07-27T03:55:59Z] feature-tasks | s=5d247c | edit em docs/features/022-error-registry/tasks.md
+  - [2026-07-27T03:55:59Z] deliverable | s=5d247c | 022-error-registry
+  - [2026-07-27T03:56:08Z] feature-tasks | s=5d247c | edit em docs/features/022-error-registry/tasks.md
+  - [2026-07-27T03:57:22Z] task | s=5d247c | commit
+  - [2026-07-27T04:00:16Z] task | s=5d247c | commit
+  - [2026-07-30T02:57:06Z] task | s=5d247c | commit
+
+## open_questions
+
+  - [preencher — o que ficou em aberto]
+
+## next_steps
+
+  - [preencher — próximo passo concreto / T0NN]

--- a/docs/sessions/2026-08-20-0345-5d247c.md
+++ b/docs/sessions/2026-08-20-0345-5d247c.md
@@ -1,0 +1,53 @@
+---
+kind: session
+tier: dual
+state: open
+name: -gitignore
+date: 2026-08-20
+claude_session_id: 5d247c66-a1f6-491d-86cb-2be83b1859e9
+cwd: /home/codork/Documents/Github/bearboo
+created_at: 2026-08-20T03:45:58Z
+reflection:
+---
+
+# Sessão 2026-08-20-0345 — -gitignore
+
+> **Dois tiers no mesmo arquivo.** O bloco de **handoff** é episódico e single-use: `state: open|consumed` governa só ele (consumido pelo reconcile). O resto é **telemetria durável** — fica. Fora dos eixos A1–A7 do diagnose.
+>
+> Este esqueleto é 0-LLM (hook `Stop`). Timeline e `afm_findings` são preenchidos pelo `/afm:reflect` ao fim de um protocolo; sem reflect, a sessão fica só com o mecânico.
+
+## files_touched
+
+  - .gitignore
+  - docs/.afm-log/events/2026-07.md
+
+## summary (eventos desta sessão)
+
+  - [2026-07-27T04:00:16Z] task | s=5d247c | commit
+  - [2026-07-30T02:57:06Z] task | s=5d247c | commit
+  - [2026-07-30T03:10:39Z] failure | s=5d247c | sig=typecheck-exit-code-2-src-context-trpc-test-sessio | npx tsc --noEmit 2>&1
+  - [2026-07-30T03:15:22Z] ach | s=5d247c | edit em docs/ach.md
+  - [2026-07-30T03:15:39Z] adr | s=5d247c | edit em docs/adr/0017-error-registry-domain-error-namespaced.md
+  - [2026-07-30T03:16:42Z] task | s=5d247c | commit
+  - [2026-08-20T03:38:35Z] task | s=5d247c | commit
+  - [2026-08-20T03:45:37Z] task | s=5d247c | commit
+
+## o que foi pedido
+
+  - [reflect — o que o agente entendeu do pedido do user]
+
+## como foi executado
+
+  - [reflect — como o AFM foi usado e onde ele atrapalhou/ajudou]
+
+## afm_findings
+
+  - (nenhum — preenchido por `/afm:promote`/`/afm:reflect` quando um aprendizado generaliza pro plugin)
+
+## open_questions
+
+  - [preencher — o que ficou em aberto]
+
+## next_steps
+
+  - [preencher — próximo passo concreto / T0NN]

--- a/docs/sessions/2026-08-21-0137-5d247c.md
+++ b/docs/sessions/2026-08-21-0137-5d247c.md
@@ -1,0 +1,53 @@
+---
+kind: session
+tier: dual
+state: open
+name: -gitignore
+date: 2026-08-21
+claude_session_id: 5d247c66-a1f6-491d-86cb-2be83b1859e9
+cwd: /home/codork/Documents/Github/bearboo
+created_at: 2026-08-21T01:37:00Z
+reflection:
+---
+
+# Sessão 2026-08-21-0137 — -gitignore
+
+> **Dois tiers no mesmo arquivo.** O bloco de **handoff** é episódico e single-use: `state: open|consumed` governa só ele (consumido pelo reconcile). O resto é **telemetria durável** — fica. Fora dos eixos A1–A7 do diagnose.
+>
+> Este esqueleto é 0-LLM (hook `Stop`). Timeline e `afm_findings` são preenchidos pelo `/afm:reflect` ao fim de um protocolo; sem reflect, a sessão fica só com o mecânico.
+
+## files_touched
+
+  - .gitignore
+  - docs/.afm-log/events/2026-07.md
+
+## summary (eventos desta sessão)
+
+  - [2026-07-27T04:00:16Z] task | s=5d247c | commit
+  - [2026-07-30T02:57:06Z] task | s=5d247c | commit
+  - [2026-07-30T03:10:39Z] failure | s=5d247c | sig=typecheck-exit-code-2-src-context-trpc-test-sessio | npx tsc --noEmit 2>&1
+  - [2026-07-30T03:15:22Z] ach | s=5d247c | edit em docs/ach.md
+  - [2026-07-30T03:15:39Z] adr | s=5d247c | edit em docs/adr/0017-error-registry-domain-error-namespaced.md
+  - [2026-07-30T03:16:42Z] task | s=5d247c | commit
+  - [2026-08-20T03:38:35Z] task | s=5d247c | commit
+  - [2026-08-20T03:45:37Z] task | s=5d247c | commit
+
+## o que foi pedido
+
+  - [reflect — o que o agente entendeu do pedido do user]
+
+## como foi executado
+
+  - [reflect — como o AFM foi usado e onde ele atrapalhou/ajudou]
+
+## afm_findings
+
+  - (nenhum — preenchido por `/afm:promote`/`/afm:reflect` quando um aprendizado generaliza pro plugin)
+
+## open_questions
+
+  - [preencher — o que ficou em aberto]
+
+## next_steps
+
+  - [preencher — próximo passo concreto / T0NN]

--- a/docs/sessions/2026-08-22-0101-5d247c.md
+++ b/docs/sessions/2026-08-22-0101-5d247c.md
@@ -1,0 +1,53 @@
+---
+kind: session
+tier: dual
+state: open
+name: -gitignore
+date: 2026-08-22
+claude_session_id: 5d247c66-a1f6-491d-86cb-2be83b1859e9
+cwd: /home/codork/Documents/Github/bearboo
+created_at: 2026-08-22T01:01:34Z
+reflection:
+---
+
+# Sessão 2026-08-22-0101 — -gitignore
+
+> **Dois tiers no mesmo arquivo.** O bloco de **handoff** é episódico e single-use: `state: open|consumed` governa só ele (consumido pelo reconcile). O resto é **telemetria durável** — fica. Fora dos eixos A1–A7 do diagnose.
+>
+> Este esqueleto é 0-LLM (hook `Stop`). Timeline e `afm_findings` são preenchidos pelo `/afm:reflect` ao fim de um protocolo; sem reflect, a sessão fica só com o mecânico.
+
+## files_touched
+
+  - .gitignore
+  - docs/.afm-log/events/2026-07.md
+
+## summary (eventos desta sessão)
+
+  - [2026-08-21T01:56:16Z] doc | s=5d247c | edit em docs/learn/resumo-07-handlers-algebraic-effects.html
+  - [2026-08-21T01:57:02Z] doc | s=5d247c | edit em docs/learn/resumo-07-handlers-algebraic-effects.html
+  - [2026-08-21T01:57:49Z] doc | s=5d247c | edit em docs/learn/resumo-08-koka-algebraic-effects-types.html
+  - [2026-08-21T01:58:46Z] doc | s=5d247c | edit em docs/learn/resumo-08-koka-algebraic-effects-types.html
+  - [2026-08-21T01:59:42Z] doc | s=5d247c | edit em docs/learn/resumo-09-dapper-distributed-tracing.html
+  - [2026-08-21T02:00:39Z] doc | s=5d247c | edit em docs/learn/resumo-09-dapper-distributed-tracing.html
+  - [2026-08-21T02:01:31Z] doc | s=5d247c | edit em docs/learn/resumo-10-causal-inference-root-cause.html
+  - [2026-08-21T02:02:26Z] doc | s=5d247c | edit em docs/learn/resumo-10-causal-inference-root-cause.html
+
+## o que foi pedido
+
+  - [reflect — o que o agente entendeu do pedido do user]
+
+## como foi executado
+
+  - [reflect — como o AFM foi usado e onde ele atrapalhou/ajudou]
+
+## afm_findings
+
+  - (nenhum — preenchido por `/afm:promote`/`/afm:reflect` quando um aprendizado generaliza pro plugin)
+
+## open_questions
+
+  - [preencher — o que ficou em aberto]
+
+## next_steps
+
+  - [preencher — próximo passo concreto / T0NN]


### PR DESCRIPTION
## What changed and why

Commits working-tree artifacts that had accumulated across recent sessions but were never versioned. All follow patterns already tracked on develop (or are net-new docs) — nothing here belongs to the 023/210 feature branches, so it gets its own branch off develop.

- **`.gitignore`** — broaden env ignore to `.env*` (covers `.env.local` / `.env.production.local`), with `!.env.example` so the committed template stays tracked.
- **AFM substrate** — the `2026-08` event log plus session handoffs from `2026-07-29` to `2026-08-22` (`docs/.afm-log/events/`, `docs/sessions/`). Same tracked pattern as the existing files there.
- **Learn digests** — `docs/learn/` (net-new): the `/learn:digest` output from the error-models study that led to feature 023 / ADR-0018.

## How it works

Three separate commits, one per concern (gitignore fix / AFM process artifacts / learning content), so each is reviewable on its own.

## What to review closely

- The `.afm-log` event log edit is **append-only** (regra 18) — verified zero removed lines.
- `.env.example` stays tracked despite the `.env*` rule (negation added; `git check-ignore` confirms it is not ignored).

## Verification

Docs and config only, no code touched. Secret scan clean. commitlint + lint-staged passed on all three commits.

## Out of scope / known debt

Nothing — this is pure housekeeping of already-generated artifacts.

## Refs

Process/housekeeping. Related: docs/learn digests back feature 023 (#209) and ADR-0018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)