### PR TITLE
docs(learn): add 5 digests on structured logging

### DIFF
--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Error models — acervo de leitura (bearboo)</title>
+<title>Error models &amp; observabilidade — acervo de leitura (bearboo)</title>
 <style>
   body{margin:0;background:#0d1117;color:#e6edf3;
     font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
@@ -88,7 +88,7 @@
 </head>
 <body>
 <l-doc>
-<l-head badge="Acervo · 19 resumos" title="Error models &amp; boundary design — o acervo do bearboo" authors="Digests moldados ao bearboo (pilar 5-a: cadeia causal · e a decisão DSL vs. helper de boundary)" src="Gerados via /learn:digest — cada um conferido contra a fonte"></l-head>
+<l-head badge="Acervo · 24 resumos" title="Error models, boundary design &amp; observabilidade — o acervo do bearboo" authors="Digests moldados ao bearboo (pilar 5-a: cadeia causal · DSL vs. helper de boundary · structured logging)" src="Gerados via /learn:digest — cada um conferido contra a fonte"></l-head>
 
 <l-note kind="info" title="Como ler">Cada resumo tem: Conceito → Como funciona → Dados concretos → 🎯 Aplicar no bearboo → Cuidado → Recall (cards com resposta colapsável pra você se testar) → TL;DR. Ordem sugerida de leitura abaixo — mas cada um se sustenta sozinho.</l-note>
 
@@ -134,9 +134,28 @@
 </ol>
 </l-sec>
 
+<l-sec n="D" title="Coleção 3 — structured logging (a decisão do boundaryLog)">
+<p>Batch motivado pela Fase 9 do roadmap ("logs estruturados") e pela pergunta: "o <code>logBoundaryError</code> hoje achata <code>level/kind/code/path</code> numa string do <code>console</code> — como parar de achatar?". Os 5 resumos respondem por três eixos: <strong>o padrão</strong> (canonical line / evento largo), <strong>os níveis</strong> (quantos merecem existir) e <strong>o transporte/como</strong> (stdout + JSON + context binding). Fio costurado: <strong>emitir 1 evento estruturado por request no <code>withAppErrors</code>, com <code>requestId</code> ligado no <code>ctx</code> — que vira o <code>trace_id</code> da Fase 11.</strong></p>
+<p><em>Eixo Padrão — a forma do evento:</em></p>
+<ol>
+<li><strong><a href="resumo-20-brandur-canonical-log-lines.html">Canonical Log Lines</a></strong> (Brandur/Stripe) — 1 linha larga por request, emitida no fim; o <code>withAppErrors</code> já é o ensure block. <em>Comece aqui.</em></li>
+<li><strong><a href="resumo-21-majors-structured-events.html">Logs vs Structured Events</a></strong> (Majors) — pare de pensar "log", pense "evento"; blob no início do request = o <code>ctx</code> do tRPC.</li>
+</ol>
+<p><em>Eixo Níveis — quantos merecem existir:</em></p>
+<ol start="3">
+<li><strong><a href="resumo-22-cheney-log-levels.html">Let's talk about logging</a></strong> (Cheney) — só info+debug; o teu <code>kind: bug|recoverable</code> já encarna o argumento. Provoca o <code>ErrorLevel</code> de 4 valores.</li>
+</ol>
+<p><em>Eixo Transporte/how-to — o onde e o como:</em></p>
+<ol start="4">
+<li><strong><a href="resumo-23-twelve-factor-logs.html">Factor XI — Logs</a></strong> (12-Factor) — stdout unbuffered, o app não gerencia arquivo; valida o <code>console.*</code> no "onde", Docker/Vercel roteiam.</li>
+<li><strong><a href="resumo-24-structlog-best-practices.html">Logging Best Practices</a></strong> (structlog) — JSON em prod / pretty em dev + context binding; a spec do logger gateway, espelhando o mailer transport.</li>
+</ol>
+</l-sec>
+
 <l-tldr>
 <li><strong>Coleção 1 (docs 1-10):</strong> error models — o debate throw vs. Result, onde o ErrorRegistry cai, e o blueprint do error tracer (5-a).</li>
 <li><strong>Coleção 2 (docs 11-19):</strong> DSL vs. helper de boundary — veredito: é um <em>adapter/anti-corruption layer in-process</em>, não uma DSL; extraia a tradução (32→1), não um framework.</li>
+<li><strong>Coleção 3 (docs 20-24):</strong> structured logging — pare de achatar o <code>boundaryLog</code> em string; emita 1 evento estruturado por request no <code>withAppErrors</code>, stdout+JSON, <code>requestId</code> no <code>ctx</code> (ponte pro trace da Fase 11).</li>
 <li>Cada resumo conecta a fonte ao bearboo na seção 🎯 e tem cards de recall pra auto-teste.</li>
 </l-tldr>
 </l-doc>

--- a/docs/learn/resumo-20-brandur-canonical-log-lines.html
+++ b/docs/learn/resumo-20-brandur-canonical-log-lines.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Canonical Log Lines — Brandur/Stripe (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  pre{background:#161b22;border:1px solid #2b3340;border-radius:8px;padding:14px 16px;overflow:auto;margin:0 0 16px;
+    font:13px/1.55 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#cbd5e1}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Logging · canonical line" title="Canonical Log Lines" authors="Brandur Leach (2016, escrito no blog da Stripe)" src="brandur.org/canonical-log-lines" href="https://brandur.org/canonical-log-lines"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Retenção-durável. É o primeiro da coleção 3 (structured logging). Lente: o <code>boundaryLog</code> do bearboo loga <em>por erro</em>; este doc mostra o padrão oposto — <em>uma linha larga por request</em>. Recall no fim.</l-note>
+
+<l-sec n="1" title="O conceito — uma linha gorda por unidade de trabalho">
+<p>Uma <strong>canonical log line</strong> é, nas palavras do autor, "<strong>uma linha de log grande (provavelmente em logfmt) emitida no fim de um request</strong>", carregando todos os campos importantes daquele request num só lugar. Em vez de N linhas magras espalhadas pelo código ("entrou aqui", "chamou aquilo"), você emite <strong>1 linha larga</strong> por unidade de trabalho.</p>
+<p>Brandur a posiciona como um <strong>"tier intermediário de analytics"</strong>: fica entre as <em>métricas</em> (rápidas, mas só respondem o que foi pré-medido) e os <em>traces/logs crus</em> (respondem qualquer coisa, mas com péssima relação sinal/ruído). O canonical line é o meio-termo — bom equilíbrio entre facilidade de acesso e flexibilidade de query.</p>
+</l-sec>
+
+<l-sec n="2" title="Como funciona — emitida no fim, preenchida ao longo do caminho">
+<p>O detalhe de implementação que faz o padrão funcionar: a linha é <strong>emitida no fim do request</strong>. Isso permite que cada middleware/etapa do processamento <strong>vá populando campos</strong> ao longo do request antes da emissão final. Como todos os campos-chave estão juntos numa linha, você responde quase qualquer pergunta operacional com <strong>uma única query</strong> — "quantos requests do userXYZ via TLS 1.0?" — coisa que a métrica pré-agregada não consegue.</p>
+<p>Campos típicos que Brandur lista na linha canônica:</p>
+<ul>
+<li>HTTP verb, path, IP de origem, user agent;</li>
+<li>request IDs, status da resposta;</li>
+<li><strong>error ID e mensagem de erro</strong>;</li>
+<li>API key, OAuth app e scope;</li>
+<li>user ID e email;</li>
+<li>nome do serviço, git revision, número de release;</li>
+<li>informação de timing e dados de rate limit.</li>
+</ul>
+</l-sec>
+
+<l-sec n="3" title="Dados concretos — armazenamento em duas pontas">
+<p>Na Stripe, as linhas iam pra dois destinos com papéis distintos:</p>
+<l-data>
+<l-row k="Splunk" v="curto prazo"></l-row>
+<l-row k="Redshift" v="90+ dias"></l-row>
+</l-data>
+<p><strong>Splunk</strong> — agregação em tempo real, query rápida, ideal durante incidentes; caro e com retenção limitada pelo volume de dados. <strong>Redshift</strong> (data warehouse) — escala, baixo custo, retenção estendida (90+ dias) e correlação cruzada entre fontes de dados. Os mesmos registros alimentavam também superfícies de produto, como o Developer Dashboard.</p>
+<p>Tradeoffs que o próprio autor admite: menos conveniente que um dashboard pré-pronto; menos completo que os traces crus; mas o <strong>equilíbrio ótimo</strong> entre acessibilidade e flexibilidade de query.</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — o middleware withAppErrors É o ensure block">
+<p><strong>Hoje o bearboo loga por erro, não por request.</strong> O <code>logBoundaryError</code> (<code>src/shared/error/boundaryLog.ts</code>) só dispara quando algo falha, e emite uma <em>string</em> no formato <code>[kind on path] detail</code> (ex.: <code>[bug on post.readBySlug] session.access_token_invalid</code>). Isso é o oposto do canonical line: você só tem sinal quando dá erro, e o sinal é prosa, não campos.</p>
+<p><strong>O padrão de Brandur mapeia quase 1:1 no teu stack tRPC.</strong> O <code>withAppErrors</code> (<code>createRouter.ts</code>) já é um middleware que <em>envolve todo procedure</em> e inspeciona <code>result.ok</code> — ou seja, ele já roda no <strong>fim de cada chamada</strong>, com sucesso ou erro. É literalmente o "ensure block" onde a linha canônica seria emitida. A evolução natural:</p>
+<pre>const withAppErrors = t.middleware(async ({ next, path, ctx }) =&gt; {
+  const start = Date.now();
+  const result = await next();
+
+  // canonical log line: UMA por chamada, sucesso ou erro
+  logger.log({
+    path,                         // já disponível no middleware
+    ok: result.ok,
+    durationMs: Date.now() - start,
+    userId: ctx.user?.id ?? null,
+    kind: result.ok ? "ok" : classifyBoundaryError(result.error).kind,
+    code: result.ok ? null : /* appError.code */,
+    // requestId: ctx.requestId  ← próximo passo (ponte pro trace, Fase 11)
+  });
+
+  if (!result.ok) { /* tradução existente */ }
+  return result;
+});</pre>
+<p><strong>Campos que você já tem</strong>: <code>path</code> (do middleware), <code>kind</code> e <code>code</code> (do <code>classifyBoundaryError</code>, ADR-0018), <code>level</code> (do catálogo). Faltam só <code>durationMs</code>, <code>userId</code> e um <code>requestId</code> — este último é a ponte pro <code>resumo-09</code> (Dapper) e pra Fase 11.</p>
+</l-apply>
+
+<l-note kind="warn" title="Regra 13 mora aqui">A lista de Brandur inclui <strong>user email e API key</strong> na linha. No bearboo, a regra dura 13 (tokens/segredos não vazam, agora cobrindo <code>docs/sessions/</code>) manda o contrário: <strong>nunca</strong> ponha token de sessão, senha ou email cru no campo. Carregue <code>userId</code> (opaco), não email. A canonical line é ótima — mas a régua de PII é sua, não da Stripe.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="O que é uma canonical log line?" src="Brandur §definição">Uma linha larga por request, emitida no fim.</l-card>
+<l-card q="Entre quais dois tiers ela fica?" src="Brandur §conceito">Entre métricas e logs/traces crus.</l-card>
+<l-card q="Por que emitir no FIM do request?" src="Brandur §como funciona">Pra middlewares preencherem campos ao longo do caminho.</l-card>
+<l-card q="Qual seam do bearboo é o 'ensure block'?" src="Aplicar no contexto">O middleware withAppErrors no createRouter.</l-card>
+<l-card q="Que campo da lista da Stripe a regra 13 barra?" src="Cuidado">Email/API key crus — use userId opaco.</l-card>
+<l-card q="Splunk vs Redshift, papel de cada um?" src="Brandur §dados">Splunk curto/incidente; Redshift 90+ dias.</l-card>
+</l-sec>
+
+<l-tldr>
+<li><strong>Canonical log line = 1 linha larga por request</strong>, emitida no fim, com todos os campos juntos → responde qualquer pergunta numa query só.</li>
+<li>É o <strong>tier intermediário</strong> entre métrica (rígida) e trace cru (ruidoso).</li>
+<li>No bearboo, o <code>withAppErrors</code> já é o ensure block: dá pra emitir 1 registro por chamada com <code>path/kind/code/duration/userId</code> — quase tudo já existe.</li>
+<li><strong>Regra 13</strong>: carregue <code>userId</code>, nunca email/token cru, por mais que a lista original inclua.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-21-majors-structured-events.html
+++ b/docs/learn/resumo-21-majors-structured-events.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Logs vs Structured Events — Charity Majors (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  pre{background:#161b22;border:1px solid #2b3340;border-radius:8px;padding:14px 16px;overflow:auto;margin:0 0 16px;
+    font:13px/1.55 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#cbd5e1}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Logging · observabilidade" title="Logs vs Structured Events" authors="Charity Majors (2019)" src="charity.wtf/2019/02/05/logs-vs-structured-events" href="https://charity.wtf/2019/02/05/logs-vs-structured-events/"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Retenção-durável. Complementa o resumo-20 (canonical line) pelo ângulo conceitual: <em>por que</em> parar de chamar isso de "log". Lente: o teu <code>level</code> no catálogo é um dos "artefatos de antigamente" que ela questiona.</l-note>
+
+<l-sec n="1" title="O conceito — para de pensar como log, pensa como evento">
+<p>A tese central de Majors: substitua as linhas de log tradicionais por <strong>eventos estruturados arbitrariamente largos que descrevem o request e seu contexto — um evento por request por serviço</strong>. E o conselho explícito: "<strong>don't think of them as log files any more. Think of them as events.</strong>"</p>
+<p>Por que a terminologia importa? Porque chamar de "log" te tenta a aplicar as práticas velhas: "<strong>The more you think of structured events as logs, the more tempted you may be to apply the old set of best practices. So just don't think of them as logs at all.</strong>" A palavra carrega bagagem que não serve mais pra sistemas modernos.</p>
+</l-sec>
+
+<l-sec n="2" title="Como funciona — um blob vazio que você preenche">
+<p>Em vez de espalhar <code>print</code>/<code>log</code> pelo código ("shotgun spray"), a receita é: <strong>inicializar um blob vazio no começo</strong>, quando o request entra no serviço, e ir <strong>acumulando todo detalhe interessante</strong> (tempos de query, chamadas HTTP, identificadores de usuário) nesse blob ao longo da vida do request. Quando o request sai — ou dá erro — você escreve o evento único.</p>
+<p>Isso tem <strong>implicações de performance radicalmente diferentes</strong> do spray anterior: "<strong>the incremental cost of capturing more detail about the request per service is nearly zero</strong>". Some o risco clássico de acidentalmente colocar um <code>print</code> dentro de um loop.</p>
+</l-sec>
+
+<l-sec n="3" title="Os alvos — níveis de log e a agregação no write-time">
+<p>Majors chama <strong>log levels</strong> de "<strong>confusing and unnecessary artifact of yesteryear</strong>". A filtragem por severidade deixa de ser necessária porque você não está afogado em ruído linha-a-linha — o evento já é estruturado e consultável.</p>
+<p>As falhas do logging tradicional que ela enumera:</p>
+<ul>
+<li><strong>regexps multi-linha</strong> tentando achar o mesmo request ID ou user ID entre linhas;</li>
+<li><strong>"bullshit percentiles"</strong> computados no write-time, tirando média de um monte de outras médias;</li>
+<li>ficar <strong>pulando de dashboard pra log</strong> tentando correlacionar um spike com outro só no olho.</li>
+</ul>
+<p>O que sistemas distribuídos exigem no lugar: "<strong>computation — not just string search</strong>". Perguntas na hora, com math, percentis, breakdowns e group-by, sobre os <strong>requests crus, sem pré-agregação</strong>. E a frase-síntese: "<strong>Just gather the detail you need to ask the questions when you need them, and store it in a single source of truth. It's that simple.</strong>"</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — o blob é o ctx, e cuidado com o teu level">
+<p><strong>O "blob vazio no começo do request" já tem casa no teu stack.</strong> O <code>ctx</code> do tRPC nasce no <code>createContext</code> e atravessa todas as camadas de middleware (<code>publicProcedure</code> → <code>protectedProcedure</code> → <code>verifiedProcedure</code> → <code>roleProcedure</code>). É exatamente o "blob" de Majors: dá pra anexar um objeto de evento ao <code>ctx</code>, cada camada acrescenta o que sabe, e o <code>withAppErrors</code> emite no fim (é o resumo-20 por outro ângulo).</p>
+<p><strong>O ponto que cutuca o teu desenho:</strong> o bearboo tem um <code>ErrorLevel = "fatal" | "error" | "warn" | "info"</code> no catálogo (ADR-0018), e o <code>logBoundaryError</code> hoje faz um <code>switch (level)</code> pra escolher <code>console.error/warn/info</code>. Majors chamaria esse <em>level-como-filtro</em> de artefato de antigamente. Mas há uma distinção importante que salva parte do teu desenho:</p>
+<ul>
+<li>O <code>level</code> do bearboo <strong>não é</strong> um nível de <em>logging</em> (verbosidade de saída) — é <strong>metadata de classificação</strong> do erro no catálogo. Isso é dado do evento, não filtro de escrita.</li>
+<li>A leitura fiel de Majors: mantenha o <code>level</code> como <strong>campo do evento</strong> (queryável: "me dá tudo com <code>level=error</code>"), e pare de usá-lo como <em>switch de qual console chamar</em>. O evento sai sempre; a severidade é uma coluna, não um portão.</li>
+</ul>
+<p>Isso conversa direto com o próximo resumo (Cheney), que ataca a proliferação de níveis pelo lado prático.</p>
+</l-apply>
+
+<l-note kind="warn" title="Escopo: ela fala de sistema distribuído">Majors escreve pensando em <strong>múltiplos serviços</strong> ("um evento por request <em>por serviço</em>", correlação distribuída). O bearboo é um <strong>monólito</strong> — muito do ganho de high-cardinality/observability 2.0 dela só aparece com escala e vários serviços. Pegue o <em>princípio</em> (evento largo, single source of truth, level-como-campo), não a infra (Honeycomb, sampling dinâmico) — isso é Fase 11+, não agora.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="O conselho de framing de Majors?" src="Majors §conceito">Não pense como logs — pense como eventos.</l-card>
+<l-card q="Quantos eventos por request por serviço?" src="Majors §conceito">Um só, arbitrariamente largo.</l-card>
+<l-card q="Como se constrói o evento durante o request?" src="Majors §como funciona">Blob vazio no início, acumula até o fim.</l-card>
+<l-card q="Como ela chama os log levels?" src="Majors §alvos">Artefato confuso e desnecessário de antigamente.</l-card>
+<l-card q="No bearboo, o 'blob' de Majors é o quê?" src="Aplicar no contexto">O ctx do tRPC, atravessando os middlewares.</l-card>
+<l-card q="O que fazer com o level do bearboo?" src="Aplicar no contexto">Mantê-lo como campo queryável, não switch.</l-card>
+<l-card q="Por que o custo incremental de mais detalhe é ~zero?" src="Majors §como funciona">Um evento por request, não spray no loop.</l-card>
+</l-sec>
+
+<l-tldr>
+<li><strong>Structured event ≠ log</strong>: um evento largo por request por serviço, não linhas espalhadas. Reframe deliberado pra fugir das práticas velhas.</li>
+<li>Receita: <strong>blob vazio no início</strong>, acumula contexto, emite no fim. Custo incremental ~zero.</li>
+<li>Ela mata o <strong>log level como filtro</strong> — no bearboo, mantenha o <code>level</code> como <em>campo do evento</em>, não como switch de <code>console.*</code>.</li>
+<li>Escopo dela é distribuído; o bearboo é monólito — pegue o princípio (evento largo, single source of truth), a infra de observability é Fase 11+.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-22-cheney-log-levels.html
+++ b/docs/learn/resumo-22-cheney-log-levels.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Let's talk about logging — Dave Cheney (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  pre{background:#161b22;border:1px solid #2b3340;border-radius:8px;padding:14px 16px;overflow:auto;margin:0 0 16px;
+    font:13px/1.55 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#cbd5e1}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Logging · níveis" title="Let's talk about logging" authors="Dave Cheney (2015)" src="dave.cheney.net/2015/11/05/lets-talk-about-logging" href="https://dave.cheney.net/2015/11/05/lets-talk-about-logging"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Retenção-durável + contraponto. Este é o doc que bate <em>direto</em> na tua tabela <code>ErrorLevel = fatal|error|warn|info</code>. Cheney é opinativo e minimalista — leia como provocação calibrada, não dogma.</l-note>
+
+<l-sec n="1" title="O conceito — só existem duas coisas dignas de log">
+<p>A tese de Cheney: há só <strong>duas coisas que valem logar</strong>:</p>
+<ol>
+<li>"<strong>Things that developers care about when they are developing or debugging software</strong>" → nível <strong>debug</strong>;</li>
+<li>"<strong>Things that users care about when using your software</strong>" → nível <strong>info</strong>.</li>
+</ol>
+<p>Todo o resto — warning, error, fatal — ele desmonta um a um. A crítica de fundo: "<strong>All logging libraries are bad because they offer too many features; a bewildering array of choice that dazzles the programmer</strong>" e distrai de pensar com clareza sobre o que comunicar ao futuro leitor dos logs.</p>
+</l-sec>
+
+<l-sec n="2" title="Como funciona — por que warning e error caem">
+<p><strong>Warning morre primeiro.</strong> "<strong>Nobody reads warnings, because by definition nothing went wrong.</strong>" E colocar o nível em warning é "uma admissão de que você provavelmente está logando erros em nível warning". Ou seja, o nível é redundante — você usaria info ou error no lugar.</p>
+<p><strong>Error não deveria existir como nível de log.</strong> O argumento: se você <em>logou</em> um erro, você o <em>tratou</em> — então "não é mais apropriado logá-lo como erro". A regra crua: "<strong>You should never be logging anything at error level because you should either handle the error, or pass it back to the caller.</strong>" (Ele distingue isso de logar <em>sobre</em> um erro informalmente: usar <code>info</code> pra anotar "não consegui abrir o arquivo foo, seguindo com plano B" é apropriado.)</p>
+<p><strong>Fatal só em <code>main.main</code>.</strong> Bibliotecas não devem usar, porque <code>Fatal</code> chama <code>os.Exit(1)</code>, que impede a limpeza de <code>defer</code> — "semanticamente equivalente a panic". Cleanup pertence ao topo da aplicação.</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — o kind bug-vs-recuperável JÁ é o Cheney">
+<p><strong>Aqui está a descoberta boa: o teu modelo de erro já implementa metade do argumento de Cheney sem saber.</strong> O <code>classifyBoundaryError</code> (ADR-0018) divide todo erro no boundary em <code>kind: "recoverable" | "bug"</code>. Traduz Cheney direto:</p>
+<ul>
+<li><strong>recoverable</strong> = o erro que você <em>tratou</em> (é um <code>AppError</code> catalogado, traduzido no boundary). Cheney diria: isso não é "error level" — é info sobre o fluxo esperado.</li>
+<li><strong>bug</strong> = o throw inesperado que <em>ninguém tratou</em>. Esse é o único que merece barulho. É o "error" real — e no teu <code>logBoundaryError</code> ele já é o único que carrega o stack completo (<code>console.error(line, error)</code>).</li>
+</ul>
+<p><strong>Onde Cheney te cutuca:</strong> o teu <code>ErrorLevel</code> tem <strong>quatro</strong> valores (<code>fatal|error|warn|info</code>). Pelo argumento dele, pergunte de cada um "quem age nisso?":</p>
+<table>
+<tr><th>level do bearboo</th><th>Cheney perguntaria</th></tr>
+<tr><td><code>info</code></td><td>OK — coisa que o usuário/operador se importa.</td></tr>
+<tr><td><code>warn</code></td><td>"Ninguém lê warning." Vale mesmo?</td></tr>
+<tr><td><code>error</code></td><td>Se é recoverable, você tratou → não é error.</td></tr>
+<tr><td><code>fatal</code></td><td>Só faz sentido no topo (o teu boundary é o topo — aqui talvez sobreviva).</td></tr>
+</table>
+<p>Isso <strong>não</strong> quer dizer "colapse pra 2 níveis já". Quer dizer: quando você desenhar a impl do logger, o <code>kind</code> (bug vs recuperável) provavelmente carrega mais sinal operacional do que o <code>level</code> de 4 valores. O <code>bug</code> é o teu "loud"; o resto é contexto. Vale revisitar se <code>warn</code> e <code>fatal</code> ganham o próprio lugar ou se são <code>info</code>/<code>bug</code> disfarçados.</p>
+</l-apply>
+
+<l-note kind="warn" title="Opinião forte, contexto Go/2015">Cheney escreve pra <strong>bibliotecas Go em 2015</strong>, antes do structured logging virar padrão (o <code>slog</code> nem existia). É deliberadamente extremo — muita gente discorda (ver a discussão no Hacker News linkada na busca). Não trate como lei; trate como o teste "<strong>quem age nesse nível?</strong>" aplicado a cada valor do teu enum. O valor pro bearboo é a pergunta, não o "só 2 níveis".</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="As duas únicas coisas que Cheney loga?" src="Cheney §conceito">Debug (dev) e info (usuário).</l-card>
+<l-card q="Por que ele rejeita warning?" src="Cheney §warning">Ninguém lê — por definição nada deu errado.</l-card>
+<l-card q="Por que nada em error level?" src="Cheney §error">Ou você trata o erro, ou repassa ao caller.</l-card>
+<l-card q="Onde Fatal pode aparecer?" src="Cheney §fatal">Só em main.main, no topo da app.</l-card>
+<l-card q="Que campo do bearboo já encarna o argumento?" src="Aplicar no contexto">O kind bug-vs-recoverable (ADR-0018).</l-card>
+<l-card q="Qual level do bearboo Cheney mais questiona?" src="Aplicar no contexto">warn — 'ninguém lê warning'.</l-card>
+</l-sec>
+
+<l-tldr>
+<li>Cheney: <strong>só debug + info</strong> valem. Warning ("ninguém lê"), error ("você já tratou") e fatal (só no topo) não merecem nível próprio.</li>
+<li>O teu <strong><code>kind: bug | recoverable</code> já é esse argumento</strong>: recoverable = tratado (info), bug = o único "loud" (com stack).</li>
+<li>Provocação calibrada pro teu <code>ErrorLevel</code> de 4 valores: pergunte "quem age nisso?" — <code>warn</code>/<code>fatal</code> podem ser <code>info</code>/<code>bug</code> disfarçados.</li>
+<li>Contexto Go/2015, opinião extrema — pegue a <em>pergunta</em>, não a receita literal.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-23-twelve-factor-logs.html
+++ b/docs/learn/resumo-23-twelve-factor-logs.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Factor XI: Logs — Twelve-Factor App (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  pre{background:#161b22;border:1px solid #2b3340;border-radius:8px;padding:14px 16px;overflow:auto;margin:0 0 16px;
+    font:13px/1.55 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#cbd5e1}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Logging · transporte" title="Factor XI — Logs (Treat logs as event streams)" authors="The Twelve-Factor App (Adam Wiggins, 2011)" src="12factor.net/logs" href="https://12factor.net/logs"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Retenção-durável. Curto e prescritivo — decide o <strong>"onde"</strong> do teu logger (não o formato). Lente: o bearboo roda em Docker (compose) e é candidato a Vercel; este fator diz por que a impl deve escrever em <code>stdout</code>, não em arquivo.</l-note>
+
+<l-sec n="1" title="O conceito — log é um fluxo de eventos, não um arquivo">
+<p>A definição do fator: "<strong>Logs are the stream of aggregated, time-ordered events collected from the output streams of all running processes and backing services.</strong>" Na forma crua, tipicamente <strong>um evento por linha</strong> (backtraces de exceção podem ocupar várias linhas).</p>
+<p>A virada mental: log não é um <em>arquivo</em> que você abre e gerencia — é um <strong>fluxo contínuo de eventos</strong> que o processo <em>emite</em> e alguém <em>lá fora</em> coleta.</p>
+</l-sec>
+
+<l-sec n="2" title="Como funciona — o app não gerencia log, ponto">
+<p>A regra dura do fator: "<strong>A twelve-factor app never concerns itself with routing or storage of its output stream. It should not attempt to write to or manage logfiles.</strong>"</p>
+<p>O que o processo faz é uma coisa só: "<strong>Each running process writes its event stream, unbuffered, to <code>stdout</code>.</strong>" Note o <strong>unbuffered</strong> — sai na hora, sem segurar em buffer.</p>
+<p>O resto é responsabilidade do <strong>ambiente de execução</strong>: em produção, ele captura o stream de cada processo, combina com os outros streams da aplicação, e roteia pros destinos finais. "<strong>These archival destinations are not visible to or configurable by the app, and instead are completely managed by the execution environment.</strong>" Destinos típicos: um sistema de análise (Splunk) ou de data warehousing (Hadoop/Hive), habilitando busca de eventos, gráficos de tendência e alertas por threshold.</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — o gateway escreve em stdout, e pronto">
+<p><strong>Isto resolve uma decisão de design da impl do teu logger de uma frase:</strong> a implementação de baixo do gateway <em>não</em> abre arquivo, <em>não</em> rotaciona, <em>não</em> configura destino. Ela faz <code>process.stdout.write(JSON.stringify(record) + "\n")</code> e acabou. Isso valida que o teu <code>console.*</code> atual no <code>logBoundaryError</code> não é um placeholder envergonhado — escrever pro stdout é <em>exatamente</em> o que o 12-factor manda; o que falta é só o <strong>formato</strong> (objeto em vez de string) e o <strong>unbuffered</strong>.</p>
+<p><strong>Encaixa no teu ambiente concreto:</strong></p>
+<ul>
+<li><strong>Docker</strong> (o teu <code>docker-compose.yml</code>): o daemon já captura <code>stdout</code>/<code>stderr</code> de cada container via logging driver. Você não gerencia arquivo — o Docker faz.</li>
+<li><strong>Vercel</strong> (candidato de deploy, Fase 10): funções capturam <code>stdout</code> e mostram em <code>vercel logs</code>. Mesmo contrato.</li>
+</ul>
+<p>Isso também <strong>fecha a porta</strong> pra uma tentação comum: adicionar uma lib que escreve em <code>./logs/app.log</code> com rotação. O 12-factor diz explicitamente pra <em>não</em> fazer isso — seria o app se metendo em roteamento/storage que é do ambiente. Se um dia precisar de arquivo, é o Docker/infra que decide, via driver — nenhuma linha de código do bearboo muda.</p>
+</l-apply>
+
+<l-note kind="warn" title="Este fator é sobre o 'onde', não o 'o quê'">O 12-factor cuida do <strong>transporte</strong> (stdout, unbuffered, ambiente roteia). Ele diz "um evento por linha" mas <strong>não</strong> exige JSON nem define os campos — isso é o resumo-20 (canonical line), resumo-21 (evento largo) e resumo-24 (structlog). Não confunda: seguir o 12-factor com <code>console.log("string")</code> ainda é log ruim (não estruturado). Você precisa <em>dos dois</em>: stdout (aqui) + estrutura (os outros).</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="Log é o quê, segundo o fator XI?" src="12factor §definição">Um fluxo de eventos ordenados no tempo.</l-card>
+<l-card q="O que o app NUNCA deve fazer com logs?" src="12factor §regra">Rotear, armazenar ou gerenciar logfiles.</l-card>
+<l-card q="Pra onde o processo escreve, e como?" src="12factor §processo">Para stdout, unbuffered.</l-card>
+<l-card q="Quem roteia o stream pro destino final?" src="12factor §ambiente">O ambiente de execução, não o app.</l-card>
+<l-card q="Como a impl do logger do bearboo deve emitir?" src="Aplicar no contexto">process.stdout.write, sem gerenciar arquivo.</l-card>
+<l-card q="Este fator define o formato (JSON) do log?" src="Cuidado">Não — só o transporte; formato são os outros docs.</l-card>
+</l-sec>
+
+<l-tldr>
+<li><strong>Log = fluxo de eventos</strong>, um por linha; o app <strong>nunca</strong> gerencia arquivo nem roteamento.</li>
+<li>Processo escreve <strong>unbuffered no <code>stdout</code></strong>; o ambiente (Docker/Vercel) captura e roteia.</li>
+<li>No bearboo: a impl do gateway faz <code>process.stdout.write(JSON)</code> e nada mais — <code>console.*</code> já estava certo no "onde", falta o formato.</li>
+<li>Este fator é o <strong>"onde"</strong>; estrutura/campos/JSON vêm dos resumos 20, 21 e 24.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>

--- a/docs/learn/resumo-24-structlog-best-practices.html
+++ b/docs/learn/resumo-24-structlog-best-practices.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Logging Best Practices — structlog (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  pre{background:#161b22;border:1px solid #2b3340;border-radius:8px;padding:14px 16px;overflow:auto;margin:0 0 16px;
+    font:13px/1.55 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#cbd5e1}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head badge="Logging · how-to" title="Logging Best Practices" authors="structlog (documentação)" src="structlog.org/en/stable/logging-best-practices.html" href="https://www.structlog.org/en/stable/logging-best-practices.html"></l-head>
+
+<l-note kind="info" title="Método deste resumo">Retenção-durável + receita. É o lado <strong>prático</strong> da coleção: os três anteriores dão o conceito, este dá o <em>como</em>. Lente: vira a spec da impl do teu <code>logger</code> gateway (o padrão console/JSON que espelha o teu mailer transport).</l-note>
+
+<l-sec n="1" title="O conceito — JSON em produção, bonito no terminal">
+<p>A recomendação central: em produção, "<strong>you should emit structured output (like JSON) which is a lot easier to parse by log aggregators</strong>". O motivo prático: "<strong>log aggregators can render JSON much better than multiline strings</strong>" — o que melhora a análise de erro.</p>
+<p>E o par de dev: usar "<strong>pretty printing when we run in a terminal session</strong>", mas emitir JSON quando roda em container/produção. Ou seja, <strong>mesma informação, dois renderers</strong>, escolhidos pelo ambiente.</p>
+</l-sec>
+
+<l-sec n="2" title="Como funciona — stdout + context binding">
+<p><strong>Transporte (ecoa o 12-factor):</strong> "<strong>A simple but powerful approach is to log to unbuffered standard out and let other tools take care of the rest.</strong>" O ambiente cuida do roteamento — terminal em dev, systemd/syslogd em produção, agregador do Kubernetes num cluster.</p>
+<p><strong>Context binding (a técnica que amarra tudo):</strong> a doc destaca a capacidade do structlog de "<strong>bind data to loggers incrementally</strong>" combinada com "<strong>loggers que são locais ao contexto de execução corrente</strong>", pra reduzir a saída a <strong>uma única entrada de log por request</strong> — seguindo, nas palavras deles, o conceito de "<strong>Canonical Log Lines</strong>" (o resumo-20!). Você <em>liga</em> um valor (ex: request ID) uma vez, e ele acompanha automaticamente toda entrada seguinte daquele contexto.</p>
+<p>Recomendações concretas de destino: soluções centralizadas (ELK, Graylog) pra logs parseados, indexados e buscáveis; o formato <strong>GELF</strong> (Graylog Extended Log Format) é apontado como "an obvious choice" pra usar junto do structlog.</p>
+</l-sec>
+
+<l-sec n="3" title="O que a página NÃO cobre">
+<p>Pra fidelidade — dois pontos que <em>não</em> estão nesta página específica (não invente que estão):</p>
+<ul>
+<li><strong>Dados sensíveis / PII:</strong> não abordado aqui. (A régua vem da tua regra 13, não deste doc.)</li>
+<li><strong>Performance:</strong> sem números ou guia de performance nesta página.</li>
+</ul>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo — a spec do gateway logger, campo a campo">
+<p><strong>Este doc desenha a impl que faltava.</strong> O padrão "JSON em prod, pretty em dev, escolhido pelo ambiente" é <em>exatamente</em> o padrão de <strong>transport</strong> que o teu mailer já usa (<code>mailer/transports/console.ts</code> vs. o real). O logger gateway nasce igual:</p>
+<pre>interface Logger { log(record: LogRecord): void }
+
+// impl escolhida pelo ambiente (como o mailer transport):
+//   dev  → prettyLogger  (legível no terminal)
+//   prod → jsonLogger    (process.stdout.write(JSON.stringify(record)+"\n"))
+
+type LogRecord = {
+  level: ErrorLevel;         // já existe (catálogo)
+  kind: "ok" | "recoverable" | "bug";  // já existe (ADR-0018)
+  code: ErrorCode | null;    // já existe
+  path: string | null;       // do middleware
+  requestId?: string;        // context binding ↓
+};</pre>
+<p><strong>Context binding = o teu <code>ctx</code> de novo (fecha o arco da coleção).</strong> A técnica do structlog — ligar um <code>requestId</code> uma vez e ele acompanhar toda entrada do request — é o mesmo "blob no ctx" que Majors descreve (resumo-21) e a canonical line que Brandur emite (resumo-20). No tRPC: gera um <code>requestId</code> no <code>createContext</code>, guarda no <code>ctx</code>, e o <code>withAppErrors</code> o inclui no record. Um valor, ligado uma vez, presente em tudo — e é ele que vira o <code>trace_id</code> quando a Fase 11 trouxer OTel.</p>
+<p><strong>Testabilidade (regra 1):</strong> como o logger é uma interface, o teste injeta um <code>fakeLogger</code> que empurra os records num array e asserta os campos — sem tocar <code>stdout</code>. Mesmo padrão adapter+fake do <code>rateLimit</code>/<code>slug</code>/<code>mediaStorage</code>.</p>
+</l-apply>
+
+<l-note kind="warn" title="É doc de uma lib Python">structlog é <strong>Python</strong>; o bearboo é TS/Node. Os <em>conceitos</em> (JSON-em-prod/pretty-em-dev, stdout, context binding, um-record-por-request) transferem direto, mas a <strong>API</strong> não. O equivalente no ecossistema Node seria pino (bindings, transports) — mas isso é decisão de impl (dep vs hand-rolled) que fica pro plan da feature, não pra este resumo.</l-note>
+
+<l-sec n="Recall" title="Recall">
+<l-card q="Formato em produção vs no terminal?" src="structlog §output">JSON em prod, pretty printing no terminal.</l-card>
+<l-card q="Abordagem simples de transporte?" src="structlog §stdout">Logar unbuffered no stdout, ferramentas cuidam do resto.</l-card>
+<l-card q="O que é context binding?" src="structlog §binding">Ligar dados ao logger incrementalmente, por contexto.</l-card>
+<l-card q="Context binding leva a quantas entradas por request?" src="structlog §binding">Uma só — segue as Canonical Log Lines.</l-card>
+<l-card q="A página cobre PII/dados sensíveis?" src="structlog §não-coberto">Não — a régua vem da regra 13.</l-card>
+<l-card q="Que padrão do bearboo o logger gateway espelha?" src="Aplicar no contexto">O mailer transport (console vs real).</l-card>
+</l-sec>
+
+<l-tldr>
+<li><strong>JSON em produção</strong> (agregador parseia melhor), <strong>pretty no terminal</strong> (dev) — mesma info, dois renderers pelo ambiente.</li>
+<li><strong>stdout unbuffered</strong>, ferramentas roteiam (ecoa o 12-factor); destinos: ELK/Graylog, formato GELF.</li>
+<li><strong>Context binding</strong>: liga <code>requestId</code> uma vez → uma entrada por request (= canonical line). No bearboo é o <code>ctx</code> do tRPC.</li>
+<li>Vira a <strong>spec do logger gateway</strong>: interface + impl console/JSON, espelhando o mailer transport, testável com fake (regra 1). Doc é Python — pegue o conceito, não a API.</li>
+</l-tldr>
+</l-doc>
+</body>
+</html>


### PR DESCRIPTION
## What

Add 5 digests to the `docs/learn/` acervo (`resumo-20..24`), continuing the collection with canonical sources on **structured logging**, each molded to bearboo's `boundaryLog` seam.

| # | Source | Angle for bearboo |
| --- | --- | --- |
| 20 | Brandur/Stripe — Canonical Log Lines | `withAppErrors` is already the ensure block: one wide event per request |
| 21 | Charity Majors — Logs vs Structured Events | the "blob" is the tRPC `ctx`; `level` as a field, not a switch |
| 22 | Dave Cheney — Let's talk about logging | the `kind: bug\|recoverable` split already embodies the argument |
| 23 | 12-Factor — Logs | the "where": stdout unbuffered, Docker/Vercel route |
| 24 | structlog — Logging Best Practices | the gateway spec: JSON/pretty + context binding |

Also updates `index.html` (badge 19→24, new "Coleção 3" section).

## Why

Grounding for the Fase 9 roadmap item "logs estruturados". The study surfaced that three of bearboo's existing error-handling decisions (the `kind` bug-vs-recoverable split, the `level` catalog field, the `withAppErrors` middleware) already anticipate the literature — the feature is to *stop flattening*, not build from scratch.

## Fidelity

Each digest was checked claim-by-claim against the fetched source (learn plugin invariant: no invented facts). Points the sources do **not** cover (e.g. PII/performance in structlog) are marked as such rather than filled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)