### PR TITLE
docs(afm): translate afm.md to English (STE-spirit)

### DIFF
--- a/docs/afm.md
+++ b/docs/afm.md
@@ -1,301 +1,301 @@
 # AFM — Agent Flow Methodology
 
-> Playbook operacional do agente (humano ou LLM) neste projeto.
-> Mistura **Extreme Programming** (Kent Beck) + **Pragmatic Programmer** (Hunt/Thomas) + práticas específicas do Bearboo.
+> The agent's operational playbook for this project (human or LLM).
+> It mixes **Extreme Programming** (Kent Beck) + **Pragmatic Programmer** (Hunt/Thomas) + Bearboo-specific practices.
 >
-> Esta é a **fonte canônica** de como executar tarefas aqui. Se `CLAUDE.md` e este doc divergirem, este doc vence.
+> This is the **canonical source** for how to run tasks here. If `CLAUDE.md` and this doc disagree, this doc wins.
 >
-> Adoção retroativa via `/afm:refactor` em 2026-06-30 (plugin `afm` v3.1.0-rc.6). Regras herdadas do código legado aplicam forward-only — ver § 3.1.
+> Retroactive adoption via `/afm:refactor` on 2026-06-30 (plugin `afm` v3.1.0-rc.6). Rules inherited from legacy code apply forward-only — see § 3.1.
 
 ---
 
-## 1. Princípios
+## 1. Principles
 
-### 1.1 Herdados de XP
+### 1.1 From XP
 
-- **TDD** — nenhum código novo sem teste que falha antes. Loop: red → green → refactor.
-- **Refactor contínuo** — depois de verde, melhora o design imediatamente. Não acumular dívida.
-- **Simple design (YAGNI/DRY/KISS)** — menor solução que resolve o problema atual; duplicação só após segundo caller (Rule of Three); inline beats abstract.
-- **Integração contínua** — commits pequenos, merge rápido, testes rodam toda vez.
-- **Pair via revisão** — toda mudança passa por revisão (humano ou LLM revisor) antes de ir pra branch principal.
+- **TDD** — no new code without a test that fails first. Loop: red → green → refactor.
+- **Continuous refactor** — after green, improve the design at once. Do not bank debt.
+- **Simple design (YAGNI/DRY/KISS)** — the smallest solution for the current problem; duplication only after the second caller (Rule of Three); inline beats abstract.
+- **Continuous integration** — small commits, fast merge, tests run every time.
+- **Pair via review** — a human or LLM reviewer reviews every change before the main branch.
 
-### 1.2 Herdados de Pragmatic Programmer
+### 1.2 From Pragmatic Programmer
 
-- **DRY** (Don't Repeat Yourself) — cada pedaço de conhecimento existe em um único lugar.
-- **Tracer Bullets** — pra entregar fim-a-fim rápido, começar pela casca que liga todas as camadas, depois engrossar. Melhor que big-bang.
-- **Don't Live with Broken Windows** — erro/test flaky/lint warning conhecido vira tech debt. Ou consertar imediatamente ou abrir ticket nomeado.
-- **Design by Contract** — funções públicas declaram pré-condições e pós-condições via tipos. Entrada inválida falha cedo.
-- **Rubber Duck** — se não consegue explicar a mudança em 2 frases, não começa a implementar.
-- **Prototipe pra aprender, descarte o protótipo** — código de exploração não vai pra branch principal.
+- **DRY** (Don't Repeat Yourself) — each piece of knowledge lives in one place.
+- **Tracer Bullets** — to deliver end-to-end fast, start with the shell that connects all layers, then thicken it. Better than big-bang.
+- **Don't Live with Broken Windows** — a known error/flaky test/lint warning becomes tech debt. Fix it now or open a named ticket.
+- **Design by Contract** — public functions declare preconditions and postconditions via types. Invalid input fails early.
+- **Rubber Duck** — if you cannot explain the change in 2 sentences, do not start.
+- **Prototype to learn, discard the prototype** — exploration code does not reach the main branch.
 
-### 1.3 Específicos deste projeto
+### 1.3 This project
 
-- **Uma responsabilidade por arquivo.** Um arquivo faz **uma** coisa bem. Se o nome tem "e"/"And"/"Manager"/"Utils" vagos, o arquivo tem duas responsabilidades escondidas — parte. Um arquivo é uma unidade de raciocínio; ler ele inteiro deve caber em um diff mental.
-- **Arquivo ≤ 300 linhas.** Limite rígido com exceções estritas (gerado, schema inteiro, fixture grande). Passou disso, divide.
-- **Tipos explícitos nas fronteiras, inferência no resto.** Parâmetros e retornos de funções exportadas: tipos escritos. Variáveis locais, helper interno: deixa o TS inferir.
-- **Zero `any` / `unknown` em helper próprio.** `unknown` só vale na fronteira de dados externos antes de validar com Zod e estreitar.
-- **DRY após o terceiro caller** (Rule of Three). Dois pode ser coincidência; três é padrão. Nunca abstrai antes; nunca deixa duplicação viva depois do terceiro.
-- **KISS vence YAGNI vence DRY.** Duplicação simples > abstração elegante com nota mental. Menos camadas, menos genéricos, menos opções de config.
-- **Comentário é exceção.** Default = zero. Só quando lógica é genuinamente complexa (invariante escondida, workaround pra bug, escolha contraintuitiva). Antes de comentar: renomear, extrair, simplificar.
-- **Doc é playbook que evolui por delta, não rewrite monolítico (ACE).** Atualização de `/docs/` é **append estruturado** na seção certa ou **update-in-place** de um item nomeado — nunca reescreve o doc inteiro.
-- **Ingest é fan-out de cardinalidade, não append singular.** Ao redefinir um termo/conceito/contrato que aparece em vários docs, a atualização toca todas as páginas onde ele vive (`grep -rl "<termo>" docs/`), não só a óbvia.
-- **Promover a doc durável passa pelo negative-filter.** Antes de virar `gotcha`/`learning`/`regra`/`procedure`, todo sinal passa pelo checklist [`rubrics/negative-filters.md`](rubrics/negative-filters.md).
-- **Server Component é o default (Next.js App Router).** `"use client"` só onde há interatividade real (state, evento DOM, hook de browser). Hoje há 14 ocorrências em `src/app/` — revisão, não gatilho mecânico (não há grep que distinga "justificado" de "não justificado").
-- **Migrations Prisma são forward-compatible.** Drop de coluna ou rename destrutivo precisa de fase de leitura dual antes de remover — sem isso, deploy em rolling cria janela de erro. Revisão, não gatilho.
-- **Teste os limites onde a função pode quebrar, não só o caminho feliz.** Todo threshold (`.max()`/`.min()`, comparação numérica, tamanho de arquivo/string), boundary (exatamente no limite vs. um a mais/menos) e caminho de rejeição (`throw`/`ctx.addIssue`/`.reject`) precisa de teste próprio — o teste do caso válido passando não é evidência de que a rejeição funciona. Revisão, não gatilho mecânico: nenhum grep/contagem distingue "pensou nos limites reais" de "teste de rejeição genérico só pra bater a contagem" (mesmo problema do guard anti-Goodhart — um teste `.rejects` qualquer passa sem testar o limite específico). Lição de `021-media-upload` (2026-07-26): o cap de 300 caracteres do `altText`, presente no plan original, sumiu silenciosamente numa reescrita do schema pro shape de `FormData` — nenhum teste cobria essa branch, então nada acusou. Só apareceu quando o dono perguntou "você validou até onde isso quebra?" e a resposta honesta era não. Escrever o teste de boundary depois é o que revelou o bug — não o inverso.
+- **One responsibility per file.** A file does **one** thing well. If the name has a vague "e"/"And"/"Manager"/"Utils", the file hides two responsibilities — split it. A file is a unit of reasoning; you should read it whole in one mental diff.
+- **File ≤ 300 lines.** A hard limit with strict exceptions (generated, whole schema, large fixture). Past that, split.
+- **Explicit types at boundaries, inference elsewhere.** Write types on exported function params and returns. Let TS infer locals and internal helpers.
+- **Zero `any` / `unknown` in your own helper.** `unknown` is valid only at the external-data boundary, before you validate with Zod and narrow.
+- **DRY after the third caller** (Rule of Three). Two can be coincidence; three is a pattern. Never abstract earlier; never leave duplication after the third.
+- **KISS beats YAGNI beats DRY.** Simple duplication > an elegant abstraction with a mental note. Fewer layers, fewer generics, fewer config options.
+- **Comments are the exception.** Default = zero. Only for genuinely complex logic (a hidden invariant, a bug workaround, a counterintuitive choice). Before you comment: rename, extract, simplify.
+- **A doc evolves by delta, not a monolithic rewrite (ACE).** A `/docs/` update is a **structured append** to the right section or an **update-in-place** of a named item — never a full-doc rewrite.
+- **Ingest is a cardinality fan-out, not a single append.** When you redefine a term/concept/contract that appears in several docs, the update touches every page where it lives (`grep -rl "<term>" docs/`), not just the obvious one.
+- **Promoting to a durable doc goes through the negative-filter.** Before it becomes a `gotcha`/`learning`/`rule`/`procedure`, every signal passes the [`rubrics/negative-filters.md`](rubrics/negative-filters.md) checklist.
+- **Server Component is the default (Next.js App Router).** Use `"use client"` only for real interactivity (state, DOM event, browser hook). Today there are 14 uses in `src/app/` — review, not a mechanical trigger (no grep tells "justified" from "not justified").
+- **Prisma migrations are forward-compatible.** A column drop or destructive rename needs a dual-read phase before removal — without it, a rolling deploy opens an error window. Review, not a trigger.
+- **Test the limits where the function can break, not just the happy path.** Every threshold (`.max()`/`.min()`, numeric comparison, file/string size), boundary (exactly at the limit vs. one more/less), and rejection path (`throw`/`ctx.addIssue`/`.reject`) needs its own test — a passing valid case is not evidence that rejection works. Review, not a mechanical trigger: no grep/count tells "thought about the real limits" from "a generic rejection test just to hit the count" (the same anti-Goodhart problem — any `.rejects` test passes without testing the specific limit). Lesson from `021-media-upload` (2026-07-26): the 300-character cap on `altText`, present in the original plan, silently vanished in a schema rewrite for the `FormData` shape — no test covered that branch, so nothing flagged it. It surfaced only when the owner asked "did you validate how far this breaks?" and the honest answer was no. Writing the boundary test afterward is what revealed the bug — not the reverse.
 
-- **Tudo em inglês; `/docs/` em STE-espírito.** Identificadores (models, campos, funções, variáveis), comentários, mensagens de commit **e os `/docs/`** — mais os `.md` de metodologia fora deles (CLAUDE.md/AGENTS.md/README.md) — são escritos em **inglês**. Os `/docs/` seguem **Simplified Technical English no nível "espírito"** (ADR-0021): frase curta e ativa, uma ideia por frase, o mesmo termo para o mesmo conceito, listas verticais, zero floreio/metáfora/hedge. **Não** é a letra completa do ASD-STE100 — sem o dicionário de ~900 palavras aprovadas e sem os artigos/repetições obrigatórios (medidos em +11% de token; STE-espírito mede −15~26%, por isso o alvo é o espírito). **Exceção:** string literal que vira texto visível ao usuário (copy de UI, `err.message`/`message` de erro renderizado na tela), dados de demo/seed (`prisma/seed*.ts`) e fixture de teste que precisa do acento pra testar (ex. `kebabCase.ts` testando remoção de acento) seguem português — é conteúdo de produto/dado, não identificador, mesmo dentro de um `.ts`. Cobre também artefato de processo: **nome de branch, título e corpo de PR, labels** são identificador de processo, sempre inglês (sem a exceção de copy). O subconjunto de PR vira a regra dura 34 (mecânica); o resto — inclusive comentário em português no código — é checado por revisão (nenhum grep pega português sem acento sem falso positivo alto, e o acento sozinho colide com as exceções de conteúdo). Débito legado conhecido: comentários em pt em `prisma/slug.ts`, `src/test/prisma/index.ts`, `src/context/trpc/sessionRefreshLink.ts` e a migration `20250731144607_*` — migração boy-scout ao tocar o arquivo.
-- **Conversão de `/docs/` pra inglês/STE-espírito é forward-only** (ADR-0021). Doc novo nasce em inglês STE-espírito. O normativo vivo (`afm`/`ach`/`prd`/`ust`/`gotchas`/`roadmap`/`rubrics`) converte **doc-a-doc, em PR próprio** (regra 17 — sem colapso). Registro histórico **não** é reescrito: ADRs e `features/` entregues ficam como estão; o ledger append-only (`docs/sessions/`, `docs/.afm-log/`) é proibido de reescrever pela regra 18. Enquanto a conversão não alcança um doc, ele segue pt-BR — o acervo é bilíngue **por doc**, nunca por linha.
+- **Everything in English; `/docs/` in STE-spirit.** Identifiers (models, fields, functions, variables), comments, commit messages, **and `/docs/`** — plus the methodology `.md` files outside them (CLAUDE.md/AGENTS.md/README.md) — are written in **English**. `/docs/` follows **Simplified Technical English at the "spirit" level** (ADR-0021): short active sentences, one idea per sentence, the same term for the same concept, vertical lists, no flair/metaphor/hedge. This is **not** the full letter of ASD-STE100 — no ~900-word approved dictionary and no mandatory articles/repetition (measured at +11% tokens; STE-spirit measures −15~26%, so the spirit is the target). **Exception:** a string literal that becomes user-visible text (UI copy, an `err.message`/`message` rendered on screen), demo/seed data (`prisma/seed*.ts`), and a test fixture that needs the accent to test (e.g. `kebabCase.ts` testing accent removal) stay Portuguese — it is product content/data, not an identifier, even inside a `.ts`. It also covers process artifacts: **branch name, PR title and body, labels** are process identifiers, always English (without the copy exception). The PR subset becomes hard rule 34 (mechanical); the rest — including Portuguese comments in code — is checked by review (no grep catches accent-free Portuguese without high false positives, and the accent alone collides with the content exceptions). Known legacy debt: Portuguese comments in `prisma/slug.ts`, `src/test/prisma/index.ts`, `src/context/trpc/sessionRefreshLink.ts`, and the migration `20250731144607_*` — boy-scout when you touch the file.
+- **Converting `/docs/` to English/STE-spirit is forward-only** (ADR-0021). A new doc is born in English STE-spirit. The live normative core (`afm`/`ach`/`prd`/`ust`/`gotchas`/`roadmap`/`rubrics`) converts **doc-by-doc, in its own PR** (rule 17 — no collapse). Historical record is **not** rewritten: ADRs and delivered `features/` stay as-is; the append-only ledger (`docs/sessions/`, `docs/.afm-log/`) is forbidden to rewrite by rule 18. Until the conversion reaches a doc, it stays pt-BR — the docs are bilingual **per doc**, never per line.
 
-*[A DEFINIR — princípios específicos de intenção de produto vêm da entrevista de adoção retroativa.]*
+*[A DEFINIR — product-intent-specific principles come from the retroactive-adoption interview.]*
 
 ---
 
-## 2. Flow de uma tarefa
+## 2. Task flow
 
 ```
-1. LER        → 2. ENTENDER → 3. PLAN    → 4. RED
+1. READ       → 2. UNDERSTAND → 3. PLAN   → 4. RED
                                               ↓
 8. REPEAT   ← 7. COMMIT   ← 6. REFACTOR ← 5. GREEN
                                               ↓
-                                         8.5 RECONCILIAR
+                                         8.5 RECONCILE
 ```
 
-### 1. LER
+### 1. READ
 
-- `/docs/prd.md` pra contexto de produto (qual RF a tarefa serve).
-- `/docs/ust.md` pra story correspondente (US-NNN) — critérios de aceitação são o oráculo.
-- `/docs/ach.md` pra estrutura (onde vai o código, qual componente).
-- `/docs/gotchas.md` se a área tocada tem gatilho registrado.
-- Código existente nos arquivos que vão mudar + vizinhos.
+- `/docs/prd.md` for product context (which RF the task serves).
+- `/docs/ust.md` for the matching story (US-NNN) — acceptance criteria are the oracle.
+- `/docs/ach.md` for structure (where the code goes, which component).
+- `/docs/gotchas.md` if the touched area has a registered trigger.
+- Existing code in the files that change + neighbors.
 
-### 2. ENTENDER
+### 2. UNDERSTAND
 
-- Reformular em 2 frases: *"o que vai mudar"* e *"por quê"*.
-- Se não consegue em 2 frases → rubber duck ou pergunta.
-- Listar 3-5 arquivos que vão ser tocados.
+- Restate in 2 sentences: *"what changes"* and *"why"*.
+- If you cannot in 2 sentences → rubber duck or ask.
+- List 3-5 files that will be touched.
 
 ### 3. PLAN
 
-- Mudança pequena (< ~50 linhas em 1-2 arquivos): plano mental + comentário no commit basta.
-- Mudança média/grande: plan file explícito antes de tocar código.
-- Mudança arquitetural: **parar e perguntar** (regra dura 11).
+- Small change (< ~50 lines in 1-2 files): a mental plan + a commit note is enough.
+- Medium/large change: an explicit plan file before you touch code.
+- Architectural change: **stop and ask** (hard rule 11).
 
 ### 4. RED
 
-- Escreve o teste (unit / integration / e2e) que falha pela razão certa.
-- Ou a assinatura de tipo que não compila.
-- Confirma que falha por motivo esperado antes do código.
+- Write the test (unit / integration / e2e) that fails for the right reason.
+- Or the type signature that does not compile.
+- Confirm it fails for the expected reason before the code.
 
 ### 5. GREEN
 
-- Implementação mínima que passa.
-- Não tenta otimizar, não antecipa. Só passa.
-- Roda `tsc --noEmit` + `vitest` afetados.
+- The smallest implementation that passes.
+- Do not optimize, do not anticipate. Just pass.
+- Run `tsc --noEmit` + affected `vitest`.
 
-### 5.1 GREEN falhou → reflect-retry capeado
+### 5.1 GREEN failed → capped reflect-retry
 
-Se o GREEN não fica verde, antes de haltar/perguntar, roda um loop curto de auto-correção ancorado na saída real do teste/`tsc` (nunca "reli e parece ok"). Cap 2 retries (3 tentativas no total); mesma falha 2× → para e escala. Cap esgotado → registra em `docs/.afm-log-failures/` antes de reportar.
+If GREEN does not go green, before you halt or ask, run a short self-correction loop anchored in the real test/`tsc` output (never "I reread it and it looks ok"). Cap 2 retries (3 attempts total); the same failure 2× → stop and escalate. Cap spent → record in `docs/.afm-log-failures/` before you report.
 
 ### 6. REFACTOR
 
-- Remove duplicação, melhora nomes, extrai constantes/tipos se ganhar clareza.
-- Roda `tsc --noEmit` + testes afetados + `yarn lint`.
+- Remove duplication, improve names, extract constants/types if clarity improves.
+- Run `tsc --noEmit` + affected tests + `yarn lint`.
 
 ### 7. COMMIT
 
-- Mensagem explica **porquê** (o diff já mostra o quê).
-- Referencia story: `US-NNN: ...` ou requisito: `RF-NN: ...`.
-- Um commit = uma mudança coerente.
-- Segue Conventional Commits (`.commitlintrc` já gateia isso via hook `commit-msg`).
+- The message explains **why** (the diff already shows what).
+- Reference the story: `US-NNN: ...` or the requirement: `RF-NN: ...`.
+- One commit = one coherent change.
+- Follow Conventional Commits (`.commitlintrc` already gates this via the `commit-msg` hook).
 
 ### 8. REPEAT
 
-- Volta pro passo 4 pro próximo slice.
+- Go back to step 4 for the next slice.
 
-### 8.5 RECONCILIAR
+### 8.5 RECONCILE
 
-Antes de fechar a tarefa, pergunta:
+Before you close the task, ask:
 
-- **Aprendi algo que outro dev sem essa sessão precisa saber pra não quebrar?** Se sim → atualiza `/docs/`:
-  - Decisão arquitetural inédita → `/docs/adr/NNNN-titulo.md` + linha em `ach.md`.
-  - Surpresa contraintuitiva → `/docs/gotchas.md`.
-  - Regra reutilizável que o user corrigiu → regra dura nova em `afm.md` (com gatilho mecânico).
-  - Componente novo → atualiza `ach.md` § 3.
-  - Mudança de escopo de produto → `prd.md` § 4.
-
----
-
-## 2.1 Quando feature precisa de pasta própria
-
-O loop em § 2 cobre mudança pequena. Pra feature que bate **qualquer um** dos critérios abaixo, abre `docs/features/NNN-slug/`:
-
-- > 1 dia de trabalho OU > 200 linhas OU > 3 arquivos.
-- Toca camada nova ou cria componente novo (gatilho da regra dura 11).
-- Tem boundary externo novo (API, webhook, CLI, contrato pub/sub).
-- Tem > 2 unknowns que precisariam ser `[NEEDS CLARIFICATION:]`.
-
-Auxiliares disponíveis sob demanda: `/afm:clarify`, `/afm:analyze`, `/afm:research`. Senão (mudança pequena): direto no § 2.
+- **Did I learn something another dev without this session must know to not break things?** If yes → update `/docs/`:
+  - New architectural decision → `/docs/adr/NNNN-title.md` + a line in `ach.md`.
+  - Counterintuitive surprise → `/docs/gotchas.md`.
+  - Reusable rule the user corrected → a new hard rule in `afm.md` (with a mechanical trigger).
+  - New component → update `ach.md` § 3.
+  - Product-scope change → `prd.md` § 4.
 
 ---
 
-## 3. Regras duras
+## 2.1 When a feature needs its own folder
 
-Toda regra abaixo tem **gatilho executável** que o agente roda no teclado — pass/fail binário. Regra sem gatilho vive em § 1.3 como princípio.
+The § 2 loop covers a small change. For a feature that hits **any** of the criteria below, open `docs/features/NNN-slug/`:
 
-1. **Nenhum código novo sem teste.** Inclui teste de tipo.
-   *Verificação:* `vitest` cobre o caminho novo; diff mostra `.test.ts` correspondente.
-2. **Zero `any` / `unknown` em helpers próprios.**
-   *Verificação:* `grep -nE "\bany\b|\bunknown\b" src/` em arquivos não-fronteira.
-4. **Não commita com type-check quebrado.**
-   *Verificação:* `npx tsc --noEmit`.
-5. **Uma responsabilidade por arquivo.** Nome vago ("manager", "utils", "helpers" sem prefixo de domínio) = parte.
-   *Verificação:* `find src -type f \( -iname "*manager*" -o -iname "*utils*" -o -iname "*helpers*" \)` retorna 0 sem prefixo de domínio. Hoje retorna `src/lib/utils.ts` e `src/server/infra/container/helpers.ts` — ver § 3.1 forward-only.
-6. **Arquivo ≤ 300 linhas.** Exceções com header explicando.
-   *Verificação:* `find src -type f \( -name "*.ts" -o -name "*.tsx" \) -not -name "*.test.*" -print0 | xargs -0 wc -l | awk '$2 != "total" && $1 > 300'`. **2 arquivos de produção excedem hoje** (scan de 2026-08-22): `src/server/models/post.ts` (416) e `src/server/features/post/schema.ts` (314) — nenhum dos dois é desta feature; tratados como tech-debt forward-only (§ 3.1), não bloqueio. *(O comando também lista `src/server/models/__test__/prismaModels.ts` (429) — arquivo de teste que o filtro `*.test.*` não pega por usar naming `__test__/`; fora do escopo da regra, que é código produtivo.)*
-7. **Domain-like exporta exatamente UMA função `domain_<action>`.** Domain é regra de negócio; query builder, schema/Zod e transport glue não vão aqui.
-   *Verificação:* `for f in $(find src/server/features -path '*/domain/*.ts'); do n=$(rg -o '^export \{[^}]*\}' "$f" | tr ',' '\n' | wc -l); test "$n" -eq 1 || echo "$f: $n exports"; done` retorna vazio. **Compliant hoje** em 30 arquivos de domain.
-10. **Sem backwards-compat shim.** Caller não existe → deleta. `// removed for X` polui.
-    *Verificação:* `grep -rn "removed\|deprecated\|legacy" src/`. **Compliant hoje** (0 ocorrências).
-11. **Mudança arquitetural pára e pergunta.** Nova camada / componente de 1ª classe / contrato entre módulos / refactor de pastas exige validação do dono da arquitetura.
-    *Verificação (mid-flight):* `git status --porcelain` mostra `A` de diretório novo de 1ª classe sob `src/`, OU o diff move pastas / introduz import cross-módulo inédito → PARA e pergunta.
-12. *(princípio — vive em § 1.3. Sem componente Task-like no projeto hoje — nenhum job/queue/scheduler detectado no scan A.1. Se um for introduzido, promove pra regra dura com gatilho de idempotência.)*
-13. **Tokens e segredos não vazam.** Nunca logar token em claro. Redact em erros. Nunca commitar `.env`. **Cobre `docs/sessions/`** — versionar narrativa é caminho novo de vazamento: o agente cita o comando que rodou, e o comando tinha a chave.
-    *Verificação:* `git diff --staged | grep -nE "(token|secret|api[_-]?key|password|bearer)\s*[:=]\s*['\"][^'\"]+"` retorna 0; `git diff --staged --name-only | grep -E "(^|/)\.env"` vazio; e sobre sessões, `git diff --staged -- docs/sessions/ | grep -nE "(sk-|ghp_|AIza|xox[baprs]-|eyJ[A-Za-z0-9_-]+\.eyJ)"` retorna 0 (prefixos de credencial conhecida — OpenAI/GitHub/Google/Slack/JWT).
-15. **Classificação de erros — Domain ≠ Transport.** Domain/Model não importa `TRPCError` (`@trpc/server`). Procedure mapeia erro de domínio → `TRPCError` no boundary, via `AppError`/`ErrorRegistry` (`ADR-0017`).
-    *Verificação:* `rg -l "TRPCError" src/server/features/*/domain/*.ts`. **Compliant hoje** — migração coordenada fechada em `022-error-registry` (2026-07-27). Ver `ach.md` § 3.2.
-16. **Validação no boundary — schema só em input/output de procedure.** Zod valida em (a) `.input()`/`.output()` de procedure (`src/server/features/<feature>/schema.ts`), (b) payload externo. Domain/Model recebe shape já validado.
-    *Verificação:* `rg -n "z\.|zod" src/server/models src/server/features/*/domain/*.ts` retorna 0. **Compliant hoje.**
-17. **Edit em `/docs/` não colapsa o doc.** Rewrite que apaga mais da metade das linhas num só edit pára e exige revisão explícita.
-    *Verificação:* `git diff --numstat -- docs/ | grep -vE '(^|/)\.afm-log|(^|/)_focus\.md$|(^|/)sessions/' | awk '$2 > 20 && $2/($1+$2+1) > 0.5 {print}'` retorna vazio.
-18. **Substrato de captura é append-only.** `docs/.afm-log/` só recebe append.
-    *Verificação:* `git log -p -- docs/.afm-log/events/ 2>/dev/null | grep -c '^-- \['` retorna `0`.
-19. **Falha ancorada recorrente vira remediação.** Toda `sig=` que aparece ≥2× em `docs/.afm-log-failures/` deve ter artefato de remediação que a cite.
-20. **`docs/_focus.md` é slot-state pequeno e sobrescrivível.**
-    *Verificação:* `{ [ -f docs/_focus.md ] && wc -l < docs/_focus.md || echo 0; } | awk '$1 > 40 {print "INCHOU"}'` retorna vazio.
+- > 1 day of work OR > 200 lines OR > 3 files.
+- Touches a new layer or creates a new component (hard rule 11 trigger).
+- Has a new external boundary (API, webhook, CLI, pub/sub contract).
+- Has > 2 unknowns that would need `[NEEDS CLARIFICATION:]`.
 
-### Regras específicas do projeto (a partir de 30)
-
-30. **Domain/Procedure NÃO importa `PrismaClient`/`@prisma/client`/driver Prisma direto.** Acesso a dados passa por `ctx.repositories` injetado; `src/server/models/*`, `src/server/infra/drivers/prisma.ts` e o seam de teste `src/test/prisma/` são a exceção intencional da camada de dados.
-    *Verificação:* `rg -n "from.*@prisma/client|new PrismaClient|@/server/infra/drivers/prisma" src/server/features/*/domain/*.ts src/server/features/*/procedures/*.ts` retorna 0. **Compliant hoje.**
-31. **Route handler (`src/app/api/**/route.ts`) é fino.** Delega pro tRPC handler; nenhuma regra de negócio inline.
-    *Verificação:* `find src/app/api -name route.ts | xargs wc -l` — todos < 80 linhas. **Compliant hoje** (único route: `src/app/api/trpc/[trpc]/route.ts`).
-32. **Nenhum commit direto em `main`/`develop`.** Todo trabalho de código acontece num branch de feature criado a partir de `develop` (nome em inglês, ex. `feature/016-search-content`), commits seguindo `.commitlintrc` (Conventional Commits, em inglês). PR contra `develop` usando `.github/pull_request_template.md`; só o dono aprova/faz merge no GitHub. `main` só recebe merge de `develop` em release/deploy, nunca commit ou merge de feature branch direto. Branch protection no GitHub (`main`/`develop`, PR obrigatório) é camada extra — o enforcement primário é este check antes de commitar.
-    *Verificação:* `git rev-parse --abbrev-ref HEAD` não é `main` nem `develop`. Se for, cria/troca pra branch de feature antes de qualquer `git commit`.
-
-33. **Erro no boundary é classificado: recuperável (`AppError`) vs. bug.** Falha esperada de negócio é um `AppError` (lançado no domain, traduzido no boundary — regra 15); throw inesperado é bug. O boundary **distingue os dois** — traduz `AppError` → `TRPCError` e **relança o resto** — e nunca dressa um bug como erro de domínio recuperável. O logging central (`onError` do fetch adapter + `src/server/caller.ts`, via `logBoundaryError`) roteia por `level`: bug → `error` com stack; recuperável → seu próprio `level`. Metadata (`retryable`/`level`, `ErrorLevel = fatal|error|warn|info`) vive nos catálogos `src/shared/error/catalog/*.ts` e é resolvida pelo `AppError` com defaults `retryable=false`/`level=warn`. Ver ADR-0018 (estende ADR-0017; `Result<T,E>` foi avaliado e rejeitado).
-    *Verificação:* `rg -l "new TRPCError" src/server/features/*/procedures/*.ts` retorna vazio — a tradução não mora mais na procedure, e sim no único choke point `src/server/http/appErrorToTRPCError.ts`, que devolve `null` pra throw não-`AppError` (bug segue bug, nunca é embrulhado como erro de domínio). **Compliant hoje** — centralizada em `024-error-boundary-centralization` (2026-08-22, ADR-0019).
-    *Nota de 2026-08-22:* o gatilho anterior (`comm -23` entre quem constrói `TRPCError` e quem ramifica em `instanceof AppError`) media a disciplina **dentro** de cada procedure. Com a tradução centralizada, o primeiro conjunto passou a ser vazio e o `comm` passaria **vacuously** — verificando nada. O gatilho novo mira onde a convenção agora vive.
-
-34. **Título e corpo de PR em inglês.** Mecaniza no artefato do GitHub o princípio §1.3 "Código em inglês" (nome de branch, título/corpo de PR, labels — identificador de processo, sempre inglês). Vale pra PR novo (forward — PRs abertos antes desta regra ficam como estão). Cobre título e corpo (artefato durável que vira histórico); **não** cobre a conversa/review do PR, que segue a língua do interlocutor, igual ao chat. O `.github/pull_request_template.md` é em inglês — template que pergunta em português colhe resposta em português.
-    *Verificação:* `gh pr view <N> --json title,body -q '.title + "\n" + .body' | grep -nP '[À-ÿ]'` retorna vazio. Manual hoje (checar antes de abrir/ao revisar); vira step de CI quando o pipeline (`.github/workflows/ci.yml`, PR #208) entrar em develop. **Limite:** o grep pega acento, não português sem acento — mas em prosa longa de PR o acento é praticamente inevitável, o que torna o proxy forte; português sem acento que passe segue sendo violação, pega na revisão.
-
-35. **`src/shared/**` não importa `@trpc/*`.** `shared/` é vocabulário comum a server e client; transporte é opinião de um consumidor específico. O catálogo de erros declara só o que é agnóstico (`message`/`retryable`/`level`); a projeção pro código tRPC vive em `src/server/http/appErrorTransport.ts` como `Record<ErrorCode, TRPC_ERROR_CODE_KEY>` — total, checada em compile-time. Consumidor novo (job, CLI, webhook) ganha a **própria** tabela, não uma coluna no catálogo de domínio. Ver ADR-0019.
-    *Verificação:* `rg -n "from \"@trpc" src/shared/` retorna 0. **Compliant hoje** — inversão feita em `024-error-boundary-centralization` (2026-08-22). *(O gatilho mira o `import`: grep por `@trpc` cru também casaria menção em comentário.)*
+On-demand helpers: `/afm:clarify`, `/afm:analyze`, `/afm:research`. Otherwise (small change): straight to § 2.
 
 ---
 
-## 3.1 Regras forward-only
+## 3. Hard rules
 
-Adoção retroativa via `/afm:refactor` em **2026-06-30**. As regras abaixo se aplicam a **código novo a partir desta data** e a **arquivos modificados** (boy-scout rule). Código legado que viola é tech-debt rastreado, não bloqueio de PR.
+Every rule below has an **executable trigger** the agent runs at the keyboard — binary pass/fail. A rule without a trigger lives in § 1.3 as a principle.
 
-| Regra | Razão pro forward-only | Violação encontrada | Tech-debt rastreado em |
+1. **No new code without a test.** Includes a type test.
+   *Verification:* `vitest` covers the new path; the diff shows a matching `.test.ts`.
+2. **Zero `any` / `unknown` in your own helpers.**
+   *Verification:* `grep -nE "\bany\b|\bunknown\b" src/` in non-boundary files.
+4. **Do not commit with a broken type-check.**
+   *Verification:* `npx tsc --noEmit`.
+5. **One responsibility per file.** A vague name ("manager", "utils", "helpers" without a domain prefix) = split.
+   *Verification:* `find src -type f \( -iname "*manager*" -o -iname "*utils*" -o -iname "*helpers*" \)` returns 0 without a domain prefix. Today it returns `src/lib/utils.ts` and `src/server/infra/container/helpers.ts` — see § 3.1 forward-only.
+6. **File ≤ 300 lines.** Exceptions with a header that explains.
+   *Verification:* `find src -type f \( -name "*.ts" -o -name "*.tsx" \) -not -name "*.test.*" -print0 | xargs -0 wc -l | awk '$2 != "total" && $1 > 300'`. **2 production files exceed today** (scan 2026-08-22): `src/server/models/post.ts` (416) and `src/server/features/post/schema.ts` (314) — neither is from this feature; treated as forward-only tech debt (§ 3.1), not a block. *(The command also lists `src/server/models/__test__/prismaModels.ts` (429) — a test file the `*.test.*` filter misses because of the `__test__/` naming; outside the rule's scope, which is production code.)*
+7. **A domain-like file exports exactly ONE `domain_<action>` function.** Domain is business rule; query builder, schema/Zod, and transport glue do not go here.
+   *Verification:* `for f in $(find src/server/features -path '*/domain/*.ts'); do n=$(rg -o '^export \{[^}]*\}' "$f" | tr ',' '\n' | wc -l); test "$n" -eq 1 || echo "$f: $n exports"; done` returns empty. **Compliant today** across 30 domain files.
+10. **No backwards-compat shim.** The caller does not exist → delete. `// removed for X` pollutes.
+    *Verification:* `grep -rn "removed\|deprecated\|legacy" src/`. **Compliant today** (0 occurrences).
+11. **An architectural change stops and asks.** A new layer / first-class component / cross-module contract / folder refactor needs the architecture owner's sign-off.
+    *Verification (mid-flight):* `git status --porcelain` shows an `A` for a new first-class directory under `src/`, OR the diff moves folders / introduces a new cross-module import → stop and ask.
+12. *(principle — lives in § 1.3. No Task-like component in the project today — no job/queue/scheduler found in scan A.1. If one is introduced, promote to a hard rule with an idempotency trigger.)*
+13. **Tokens and secrets do not leak.** Never log a token in the clear. Redact in errors. Never commit `.env`. **Covers `docs/sessions/`** — versioning narrative is a new leak path: the agent cites the command it ran, and the command had the key.
+    *Verification:* `git diff --staged | grep -nE "(token|secret|api[_-]?key|password|bearer)\s*[:=]\s*['\"][^'\"]+"` returns 0; `git diff --staged --name-only | grep -E "(^|/)\.env"` empty; and about sessions, `git diff --staged -- docs/sessions/ | grep -nE "(sk-|ghp_|AIza|xox[baprs]-|eyJ[A-Za-z0-9_-]+\.eyJ)"` returns 0 (known credential prefixes — OpenAI/GitHub/Google/Slack/JWT).
+15. **Error classification — Domain ≠ Transport.** Domain/Model does not import `TRPCError` (`@trpc/server`). The Procedure maps a domain error → `TRPCError` at the boundary, via `AppError`/`ErrorRegistry` (`ADR-0017`).
+    *Verification:* `rg -l "TRPCError" src/server/features/*/domain/*.ts`. **Compliant today** — coordinated migration closed in `022-error-registry` (2026-07-27). See `ach.md` § 3.2.
+16. **Validation at the boundary — schema only at a procedure's input/output.** Zod validates at (a) a procedure's `.input()`/`.output()` (`src/server/features/<feature>/schema.ts`), (b) an external payload. Domain/Model receives an already-validated shape.
+    *Verification:* `rg -n "z\.|zod" src/server/models src/server/features/*/domain/*.ts` returns 0. **Compliant today.**
+17. **A `/docs/` edit does not collapse the doc.** A rewrite that deletes more than half the lines in one edit stops and needs explicit review.
+    *Verification:* `git diff --numstat -- docs/ | grep -vE '(^|/)\.afm-log|(^|/)_focus\.md$|(^|/)sessions/' | awk '$2 > 20 && $2/($1+$2+1) > 0.5 {print}'` returns empty.
+18. **The capture substrate is append-only.** `docs/.afm-log/` only takes appends.
+    *Verification:* `git log -p -- docs/.afm-log/events/ 2>/dev/null | grep -c '^-- \['` returns `0`.
+19. **A recurring anchored failure becomes remediation.** Every `sig=` that appears ≥2× in `docs/.afm-log-failures/` must have a remediation artifact that cites it.
+20. **`docs/_focus.md` is small, overwritable slot-state.**
+    *Verification:* `{ [ -f docs/_focus.md ] && wc -l < docs/_focus.md || echo 0; } | awk '$1 > 40 {print "INCHOU"}'` returns empty.
+
+### Project-specific rules (from 30)
+
+30. **Domain/Procedure does NOT import `PrismaClient`/`@prisma/client`/the Prisma driver directly.** Data access goes through the injected `ctx.repositories`; `src/server/models/*`, `src/server/infra/drivers/prisma.ts`, and the test seam `src/test/prisma/` are the intentional data-layer exception.
+    *Verification:* `rg -n "from.*@prisma/client|new PrismaClient|@/server/infra/drivers/prisma" src/server/features/*/domain/*.ts src/server/features/*/procedures/*.ts` returns 0. **Compliant today.**
+31. **A route handler (`src/app/api/**/route.ts`) is thin.** It delegates to the tRPC handler; no inline business rule.
+    *Verification:* `find src/app/api -name route.ts | xargs wc -l` — all < 80 lines. **Compliant today** (only route: `src/app/api/trpc/[trpc]/route.ts`).
+32. **No direct commit to `main`/`develop`.** All code work happens on a feature branch created from `develop` (English name, e.g. `feature/016-search-content`), commits following `.commitlintrc` (Conventional Commits, English). PR against `develop` using `.github/pull_request_template.md`; only the owner approves/merges on GitHub. `main` only takes a merge from `develop` at release/deploy, never a commit or a feature-branch merge directly. GitHub branch protection (`main`/`develop`, PR required) is an extra layer — the primary enforcement is this check before you commit.
+    *Verification:* `git rev-parse --abbrev-ref HEAD` is not `main` nor `develop`. If it is, create/switch to a feature branch before any `git commit`.
+
+33. **A boundary error is classified: recoverable (`AppError`) vs. bug.** An expected business failure is an `AppError` (thrown in the domain, translated at the boundary — rule 15); an unexpected throw is a bug. The boundary **distinguishes the two** — it translates `AppError` → `TRPCError` and **rethrows the rest** — and never dresses a bug as a recoverable domain error. Central logging (`onError` of the fetch adapter + `src/server/caller.ts`, via `logBoundaryError`) routes by `level`: a bug → `error` with a stack; a recoverable → its own `level`. Metadata (`retryable`/`level`, `ErrorLevel = fatal|error|warn|info`) lives in the catalogs `src/shared/error/catalog/*.ts` and is resolved by `AppError` with defaults `retryable=false`/`level=warn`. See ADR-0018 (extends ADR-0017; `Result<T,E>` was evaluated and rejected).
+    *Verification:* `rg -l "new TRPCError" src/server/features/*/procedures/*.ts` returns empty — the translation no longer lives in the procedure, but in the single choke point `src/server/http/appErrorToTRPCError.ts`, which returns `null` for a non-`AppError` throw (a bug stays a bug, never wrapped as a domain error). **Compliant today** — centralized in `024-error-boundary-centralization` (2026-08-22, ADR-0019).
+    *Note 2026-08-22:* the previous trigger (`comm -23` between who builds a `TRPCError` and who branches on `instanceof AppError`) measured the discipline **inside** each procedure. With the translation centralized, the first set became empty and the `comm` would pass **vacuously** — verifying nothing. The new trigger targets where the convention now lives.
+
+34. **PR title and body in English.** It mechanizes in the GitHub artifact the § 1.3 principle "code in English" (branch name, PR title/body, labels — process identifiers, always English). Applies to a new PR (forward — PRs opened before this rule stay as they are). Covers title and body (the durable artifact that becomes history); does **not** cover the PR conversation/review, which follows the interlocutor's language, like chat. `.github/pull_request_template.md` is in English — a template that asks in Portuguese harvests Portuguese answers.
+    *Verification:* `gh pr view <N> --json title,body -q '.title + "\n" + .body' | grep -nP '[À-ÿ]'` returns empty. Manual today (check before opening/at review); becomes a CI step when the pipeline (`.github/workflows/ci.yml`, PR #208) lands in develop. **Limit:** the grep catches accent, not accent-free Portuguese — but in long PR prose the accent is nearly inevitable, which makes the proxy strong; accent-free Portuguese that slips through is still a violation, caught at review.
+
+35. **`src/shared/**` does not import `@trpc/*`.** `shared/` is vocabulary common to server and client; transport is one specific consumer's opinion. The error catalog declares only what is agnostic (`message`/`retryable`/`level`); the projection to the tRPC code lives in `src/server/http/appErrorTransport.ts` as `Record<ErrorCode, TRPC_ERROR_CODE_KEY>` — total, checked at compile time. A new consumer (job, CLI, webhook) gets its **own** table, not a column in the domain catalog. See ADR-0019.
+    *Verification:* `rg -n "from \"@trpc" src/shared/` returns 0. **Compliant today** — inversion done in `024-error-boundary-centralization` (2026-08-22). *(The trigger targets the `import`: a raw `@trpc` grep would also match a mention in a comment.)*
+
+---
+
+## 3.1 Forward-only rules
+
+Retroactive adoption via `/afm:refactor` on **2026-06-30**. The rules below apply to **new code from this date** and to **modified files** (boy-scout rule). Legacy code that violates them is tracked tech debt, not a PR block.
+
+| Rule | Reason for forward-only | Violation found | Tech debt tracked in |
 | --- | --- | --- | --- |
-| 1 — TDD/cobertura | Cobertura atual baixa: 23 arquivos de teste / 205 arquivos `src/` (~11.2%). Sweep retroativo seria semanas de trabalho. | 23/205 (~11.2%) | `[A DEFINIR — abrir issue]` |
-| 2 — zero `any`/`unknown` | Volume pequeno, mas ainda existente em helpers/componentes legados; não bloqueia PRs em andamento até o boy-scout alcançar. | 5 ocorrências | `[A DEFINIR]` |
-| 5 — naming vago | 2 arquivos sem prefixo de domínio (`src/lib/utils.ts`, `src/server/infra/container/helpers.ts`). Renomear/particionar exige revisão de todos os imports. | `src/lib/utils.ts`, `src/server/infra/container/helpers.ts` | `[A DEFINIR]` |
-| 6 — arquivo ≤300 linhas | Resolvido pela migração `entities/` → `models/` (ADR-0007); manter como regra forward-only para código novo. | 0 arquivos produtivos >300 linhas | — |
+| 1 — TDD/coverage | Current coverage is low: 23 test files / 205 `src/` files (~11.2%). A retroactive sweep would be weeks of work. | 23/205 (~11.2%) | `[A DEFINIR — open issue]` |
+| 2 — zero `any`/`unknown` | Small volume, but still present in legacy helpers/components; does not block in-flight PRs until the boy-scout reaches it. | 5 occurrences | `[A DEFINIR]` |
+| 5 — vague naming | 2 files without a domain prefix (`src/lib/utils.ts`, `src/server/infra/container/helpers.ts`). Renaming/splitting needs a review of every import. | `src/lib/utils.ts`, `src/server/infra/container/helpers.ts` | `[A DEFINIR]` |
+| 6 — file ≤300 lines | Resolved by the `entities/` → `models/` migration (ADR-0007); kept as a forward-only rule for new code. | 0 production files >300 lines | — |
 
-**Critério de boy-scout:** ao editar arquivo legado que viola regra forward-only, traz pra conformidade no mesmo PR se o escopo justifica. Senão, abre issue separada e linka.
+**Boy-scout criterion:** when you edit a legacy file that violates a forward-only rule, bring it to compliance in the same PR if the scope justifies. Otherwise, open a separate issue and link it.
 
-**Regra 15 removida desta tabela em 2026-07-27** — migração coordenada fechada em `022-error-registry`/`ADR-0017` (era exceção nesta tabela justamente por exigir migração coordenada, não boy-scout arquivo-a-arquivo; a migração aconteceu e a regra 15 voltou a ser universal em § 3).
+**Rule 15 removed from this table on 2026-07-27** — coordinated migration closed in `022-error-registry`/`ADR-0017` (it was an exception in this table exactly because it needed a coordinated migration, not file-by-file boy-scout; the migration happened and rule 15 is universal again in § 3).
 
 ---
 
-## 4. Guidelines por tipo de mudança
+## 4. Guidelines by change type
 
 ### 4.1 Bug fix
 
-1. Reproduzir o bug num teste. **Teste falha pela razão certa antes do fix.**
-2. Implementar o fix mínimo que passa.
-3. Rodar suíte inteira — bug fix frequentemente expõe outro.
-4. Commit: `fix: US-NNN / RF-NN — <o porquê>`.
+1. Reproduce the bug in a test. **The test fails for the right reason before the fix.**
+2. Implement the smallest fix that passes.
+3. Run the whole suite — a bug fix often exposes another.
+4. Commit: `fix: US-NNN / RF-NN — <the why>`.
 
-### 4.2 Feature nova
+### 4.2 New feature
 
-1. Identificar US correspondente. Se não existe, escrever primeiro (`/docs/ust.md`).
-2. Critério de aceitação em Gherkin vira o primeiro teste.
-3. Tracer bullet: ligar UI → router → procedure → domain → entity → DB com o mínimo, ver fluxo fim-a-fim.
-4. Engrossar camadas via TDD.
-5. Commit por slice.
+1. Identify the matching US. If none exists, write it first (`/docs/ust.md`).
+2. The Gherkin acceptance criterion becomes the first test.
+3. Tracer bullet: connect UI → router → procedure → domain → entity → DB with the minimum, see the flow end-to-end.
+4. Thicken layers via TDD.
+5. Commit per slice.
 
 ### 4.3 Refactor
 
-1. Suíte verde antes de começar.
-2. Não muda comportamento observável. Se mudar, é feature/fix, não refactor.
-3. Mudanças pequenas e frequentes.
-4. Se descobrir falta de teste numa área que vai mexer, escreve antes.
-5. Commit: `refactor: <o porquê>`.
+1. Green suite before you start.
+2. No change to observable behavior. If it changes, it is a feature/fix, not a refactor.
+3. Small, frequent changes.
+4. If you find a missing test in an area you will touch, write it first.
+5. Commit: `refactor: <the why>`.
 
-### 4.4 Dependência nova
+### 4.4 New dependency
 
-1. Justificar em 2 linhas no commit / PR (o quê + por quê + alternativa considerada).
-2. Checar licença (MIT/Apache/BSD ok; GPL/AGPL avisar).
-3. Checar tamanho (bundle size pra deps client-side).
+1. Justify in 2 lines in the commit / PR (what + why + alternative considered).
+2. Check the license (MIT/Apache/BSD ok; GPL/AGPL warn).
+3. Check the size (bundle size for client-side deps).
 
 ---
 
-## 5. Sinais de que você está off-track
+## 5. Off-track signals
 
-- **Comentando código pra fazer teste passar.** Falsa confiança.
-- **Mock que simula mais que o necessário.** Está testando o mock.
-- **Adicionando `biome-ignore`, `@ts-ignore`, `@ts-expect-error` sem ticket.** Broken window.
-- **Criando função `utils.ts` sem segundo caller.** Inline.
-- **Duplicando lógica de negócio entre transports.** Move pra Domain/Model puro.
-- **Escrevendo mais de uma implementação em paralelo.** Escolhe uma.
-- **Cobrindo com try/catch todos os awaits.** Erros tipados > catch genérico.
-- **Refatorando "enquanto estou aqui" sem teste prévio.** Outra tarefa.
-- **Tarefa arrastando há horas sem um commit.** Slice maior que o ideal.
-- **Teste que só serve pra subir % de cobertura.** Apaga. Cobertura é métrica, não meta.
-- **Arquivo > 300 linhas.** "Mas é coeso!" — divide.
-- **Nome com "and"/"manager"/"helper"/"utils" genérico.** Renomeia ou parte em dois.
-- **`any` / `as any` aparecendo "por causa do TS".** Investiga inferência.
-- **Código copiado 3×.** Abstrai.
-- **Abstração com 1 caller.** Inline.
-- **Domain-like com 2+ exports.** Parte.
-- **Comentário narrando *o quê*.** Apaga; nome + tipo já dizem.
-- **Comentário compensando código difícil.** Refatora primeiro.
-- **Domain lançando `TRPCError` direto.** Violação da regra 15 (forward-only hoje) — não espalha mais; lança erro de domínio e deixa a Procedure mapear.
+- **Commenting out code to make a test pass.** False confidence.
+- **A mock that simulates more than needed.** You are testing the mock.
+- **Adding `biome-ignore`, `@ts-ignore`, `@ts-expect-error` without a ticket.** Broken window.
+- **Creating a `utils.ts` function without a second caller.** Inline.
+- **Duplicating business logic across transports.** Move it to pure Domain/Model.
+- **Writing more than one implementation in parallel.** Choose one.
+- **Wrapping every await in try/catch.** Typed errors > a generic catch.
+- **Refactoring "while I'm here" without a prior test.** Another task.
+- **A task dragging for hours without a commit.** The slice is bigger than ideal.
+- **A test that only raises coverage %.** Delete it. Coverage is a metric, not a goal.
+- **File > 300 lines.** "But it's cohesive!" — split.
+- **A name with a generic "and"/"manager"/"helper"/"utils".** Rename or split in two.
+- **`any` / `as any` appearing "because of TS".** Investigate the inference.
+- **Code copied 3×.** Abstract.
+- **An abstraction with 1 caller.** Inline.
+- **A domain-like with 2+ exports.** Split.
+- **A comment narrating *what*.** Delete; name + type already say it.
+- **A comment compensating for hard code.** Refactor first.
+- **Domain throwing `TRPCError` directly.** Rule 15 violation (forward-only today) — do not spread it; throw a domain error and let the Procedure map.
 
 ---
 
 ## 6. Definition of Done
 
-Descoberto no scan A.7 (hooks locais — sem CI no repo hoje) e confirmado na entrevista de adoção retroativa (2026-06-30): `.husky/pre-commit` roda `lint-staged`, configurado no `package.json` para executar `biome check --write` nos arquivos staged suportados; `.husky/pre-push` roda `yarn lint` + `yarn test` (vitest); `.husky/commit-msg` roda `commitlint`. DoD de merge inclui **test runner + type check**, mesmo sem CI formal hoje — o agente roda os dois manualmente antes de considerar a tarefa pronta.
+Discovered in scan A.7 (local hooks — no CI in the repo then) and confirmed in the retroactive-adoption interview (2026-06-30): `.husky/pre-commit` runs `lint-staged`, configured in `package.json` to run `biome check --write` on supported staged files; `.husky/pre-push` runs `yarn lint` + `yarn test` (vitest); `.husky/commit-msg` runs `commitlint`. The merge DoD includes **test runner + type check**, even without formal CI then — the agent runs both by hand before it considers the task done.
 
-**Atualizado em 2026-07-04**: a suíte de testes deixou de depender de Postgres/Redis via Docker (`docker-compose-test.yml`, removido) — os testes de procedure agora rodam contra repositórios e gateways fake in-memory injetados via `TestContext` (`src/test/repositories/`, `src/test/gateways/`), o que também tornou o pre-push mais rápido (segundos, não um container build).
+**Updated 2026-07-04:** the test suite no longer depends on Postgres/Redis via Docker (`docker-compose-test.yml`, removed) — procedure tests now run against in-memory fake repositories and gateways injected via `TestContext` (`src/test/repositories/`, `src/test/gateways/`), which also made pre-push faster (seconds, not a container build).
 
-**Atualizado em 2026-07-06 (ADR-0011)**: os repositórios fake escritos à mão (`src/test/repositories/`) foram substituídos por **`prisma-mock`** — client fake gerado do `schema.prisma`, plugado no seam do driver via `vi.mock` em `src/test/setup.ts` (`setupFiles` do vitest). Os models de produção rodam intactos nos testes; só os gateways continuam com fake manual (`src/test/gateways/`). Isolamento por teste: `resetPrismaMock()` de `src/test/prisma/` (o `$clear()` da lib é bugado — ver comentário no seam). Racional e alternativas em `docs/research/001-teste-prisma-sem-banco-real.md`.
+**Updated 2026-07-06 (ADR-0011):** the hand-written fake repositories (`src/test/repositories/`) were replaced by **`prisma-mock`** — a fake client generated from `schema.prisma`, plugged into the driver seam via `vi.mock` in `src/test/setup.ts` (vitest `setupFiles`). Production models run intact in tests; only the gateways keep a manual fake (`src/test/gateways/`). Per-test isolation: `resetPrismaMock()` from `src/test/prisma/` (the lib's `$clear()` is buggy — see the comment in the seam). Rationale and alternatives in `docs/research/001-teste-prisma-sem-banco-real.md`.
 
-**Atualizado em 2026-08-20**: CI formal chegou (`.github/workflows/ci.yml`), gatilho `pull_request`/`push` em `develop`/`main`. Quatro jobs paralelos: `typecheck` (`npx tsc --noEmit`), `lint` (`npx biome check .` — sem `--write`, diferente do hook local, porque CI precisa falhar em vez de corrigir silenciosamente), `test` (`npm test`, `DISABLE_REDIS=true` pra não poluir log com retry de conexão — testes não dependem de Postgres/Redis real, ver nota 2026-07-04), `build` (`npm run build` contra um serviço `postgres:16` real, porque `prisma migrate deploy` — parte do script `build` desde #206 — exige um banco alcançável). O DoD abaixo deixa de ser "o agente roda manualmente" e passa a ser **verificado automaticamente em todo PR**; a checagem manual continua valendo como sinal antecipado antes do push.
+**Updated 2026-08-20:** formal CI arrived (`.github/workflows/ci.yml`), triggered on `pull_request`/`push` to `develop`/`main`. Four parallel jobs: `typecheck` (`npx tsc --noEmit`), `lint` (`npx biome check .` — no `--write`, unlike the local hook, because CI must fail instead of fixing silently), `test` (`npm test`, `DISABLE_REDIS=true` to not pollute the log with connection retries — tests do not depend on real Postgres/Redis, see the 2026-07-04 note), `build` (`npm run build` against a real `postgres:16` service, because `prisma migrate deploy` — part of the `build` script since #206 — needs a reachable database). The DoD below stops being "the agent runs it by hand" and becomes **verified automatically on every PR**; the manual check stays as an early signal before the push.
 
-- [ ] Testes novos cobrem o comportamento adicionado/modificado, e rodam verde.
-- [ ] Suíte inteira roda verde (`yarn test`) — gateado por CI (job `test`).
-- [ ] Type-check passa (`npx tsc --noEmit`) — gateado por CI (job `typecheck`).
-- [ ] Lint passa sem warnings novos (`yarn lint`) — gateado por `.husky/pre-commit` localmente e por CI (job `lint`) no PR.
-- [ ] Build de produção passa (`npm run build`) — gateado por CI (job `build`).
-- [ ] Nenhum `any`/`unknown`/`@ts-ignore` novo sem justificativa.
-- [ ] Nenhum arquivo tocado passou de 300 linhas (ou exceção documentada).
-- [ ] Commit referencia US/RF e explica o *porquê*, segue Conventional Commits.
-- [ ] Se contrato com outra camada mudou: ACH atualizado. Se escopo mudou: PRD atualizado.
-- [ ] Se aprendi algo que outro dev precisa saber: doc atualizado (ADR/gotcha/regra/feature).
+- [ ] New tests cover the added/modified behavior, and run green.
+- [ ] The whole suite runs green (`yarn test`) — gated by CI (`test` job).
+- [ ] Type-check passes (`npx tsc --noEmit`) — gated by CI (`typecheck` job).
+- [ ] Lint passes with no new warnings (`yarn lint`) — gated by `.husky/pre-commit` locally and by CI (`lint` job) on the PR.
+- [ ] Production build passes (`npm run build`) — gated by CI (`build` job).
+- [ ] No new `any`/`unknown`/`@ts-ignore` without a justification.
+- [ ] No touched file passed 300 lines (or a documented exception).
+- [ ] The commit references US/RF and explains the *why*, follows Conventional Commits.
+- [ ] If a contract with another layer changed: ACH updated. If scope changed: PRD updated.
+- [ ] If I learned something another dev must know: doc updated (ADR/gotcha/rule/feature).
 
-### 6.1 Pre-push validation (já gateado por hook — `.husky/pre-push`)
+### 6.1 Pre-push validation (already gated by hook — `.husky/pre-push`)
 
-1. `yarn test` (vitest, sem dependência de Docker/Postgres — ver nota de 2026-07-04 acima).
+1. `yarn test` (vitest, no Docker/Postgres dependency — see the 2026-07-04 note above).
 
-Confirmado na entrevista: mantém só o test runner no pre-push (não adicionar type-check/build nesse hook — ficam no DoD de merge, § 6). Type-check/lint/build continuam fora do pre-push por serem mais lentos; a partir de 2026-08-20 rodam em paralelo no CI a cada PR, então o hook local segue leve de propósito — CI é a rede de segurança, não o hook.
+Confirmed in the interview: keep only the test runner in pre-push (do not add type-check/build to this hook — they stay in the merge DoD, § 6). Type-check/lint/build stay out of pre-push because they are slower; from 2026-08-20 they run in parallel in CI on every PR, so the local hook stays light on purpose — CI is the safety net, not the hook.
 
 ---
 
-*Mudanças neste doc seguem regra 11 (parar e perguntar) se afetarem processo.*
+*Changes to this doc follow rule 11 (stop and ask) if they affect process.*


### PR DESCRIPTION
## What

First conversion under **ADR-0021**: `afm.md` moves to **English at the STE-spirit level**. This is the pilot — the canonical doc dogfoods the rule it just established.

## Byte-exact preservation (verified)

Only prose is translated. All executable content is preserved byte-for-byte:
- **192 code spans** diffed between original and translation — the only 5 deltas are prose-in-backticks (`[A DEFINIR — abrir issue]`→`open issue`, commit-message placeholders, `` `regra` ``→`` `rule` ``). Every verification command, path, identifier, and rule number is unchanged.
- **`[A DEFINIR]` markers** preserved (4 → 4) so the AFM tooling still finds them.
- All 22 rule numbers present (incl. the italic rule 12).
- Rule 17 (collapse guard) does not trip: a 1:1 translation replaces line-for-line (deletion ratio 0.499), so it is not a mechanical collapse — but this PR is still treated as an explicit rule-17 review event by intent.

## Honest measurement

**Token-neutral: 4153 → 4202 words (-0.7% chars).** The −26% that the § 1 prose excerpt showed does **not** hold for the full doc, because `afm.md` is ~half incompressible executable content (commands, paths, identifiers), and the translation stays faithful to preserve normative nuance in § 3.

The value here is **English consistency + dogfooding**, not token savings. The measurable token wins come from the **prose-heavy docs** (`prd`/`roadmap`/`ust`/`gotchas`), which convert next, doc-by-doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)