### PR TITLE
docs(prd): translate prd.md to English (STE-spirit)

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,127 +1,127 @@
 # PRD — Bearboo
 
-> Product Requirements Document. Documento vivo — editar in-place.
-> Mudanças de escopo passam pelo dono do produto antes do merge.
+> Product Requirements Document. Living doc — edit in place.
+> Scope changes go through the product owner before merge.
 
-## 1. Resumo
+## 1. Summary
 
-Bearboo é um blog técnico pessoal construído com foco em performance, organização de código e boas práticas modernas de desenvolvimento full-stack. Serve como repositório de estudos e demonstração prática de arquitetura (DDD-lite, camadas tipadas ponta-a-ponta) — não é um produto com base de usuários externa hoje.
+Bearboo is a personal technical blog built for performance, code organization, and modern full-stack practices. It is a study repository and a practical architecture demo (DDD-lite, typed end-to-end layers) — not a product with an external user base today.
 
-Proposta de valor em uma frase: *"[A DEFINIR — validar com o dono do produto]"*
+One-line value proposition: *"[A DEFINIR — validate with the product owner]"*
 
-*(Origem: primeiros parágrafos do `README.md`.)*
+*(Source: the first paragraphs of `README.md`.)*
 
-## 2. Problema & Oportunidade
+## 2. Problem & Opportunity
 
-- **Dor observada:** não resolve dor de terceiros — é veículo de estudo e portfólio técnico do dono do produto (praticar arquitetura full-stack, type-safety ponta-a-ponta, boas práticas modernas em produção real).
-- **Por que agora:** [A DEFINIR].
-- **Tamanho do ganho:** demonstração prática e verificável de arquitetura (DDD-lite, tRPC, camadas testáveis) pra quem avalia o trabalho do dono do produto.
+- **Observed pain:** it does not solve a third party's pain — it is the owner's study and technical-portfolio vehicle (practice full-stack architecture, end-to-end type safety, modern practices in real production).
+- **Why now:** [A DEFINIR].
+- **Size of the gain:** a practical, verifiable architecture demo (DDD-lite, tRPC, testable layers) for anyone who assesses the owner's work.
 
-## 3. Usuário-alvo & Jobs-to-be-done
+## 3. Target user & Jobs-to-be-done
 
-**Persona primária:** dupla — (a) o próprio dev (Bruno), escrevendo posts técnicos e evoluindo a arquitetura pra praticar; (b) recrutadores/leitores do portfólio, avaliando o código e o produto publicado.
+**Primary persona:** a pair — (a) the dev himself (Bruno), who writes technical posts and evolves the architecture to practice; (b) recruiters/portfolio readers, who assess the published code and product.
 
-**Empresas típicas:**
-- [A DEFINIR — projeto pessoal, não se aplica hoje].
+**Typical companies:**
+- [A DEFINIR — personal project, does not apply today].
 
 **Jobs-to-be-done:**
-- Quando o Bruno quer praticar uma técnica/arquitetura nova, quero ter um projeto real pra aplicá-la para consolidar aprendizado e ter portfólio verificável.
-- Quando um recrutador/dev avalia o Bruno, quero ver código de produção organizado e testado para formar uma opinião sobre a qualidade do trabalho.
+- When Bruno wants to practice a new technique/architecture, I want a real project to apply it, to consolidate learning and keep a verifiable portfolio.
+- When a recruiter/dev assesses Bruno, I want to see organized, tested production code, to form an opinion on work quality.
 
-**Cenários típicos:**
-- "Bruno quer aprender X (ex: DDD, tRPC, ISR) e aplica no Bearboo pra fixar na prática."
-- "Recrutador clona o repo, lê `/docs/` e o código, e avalia a arquitetura em minutos."
+**Typical scenarios:**
+- "Bruno wants to learn X (e.g. DDD, tRPC, ISR) and applies it on Bearboo to make it stick."
+- "A recruiter clones the repo, reads `/docs/` and the code, and assesses the architecture in minutes."
 
-## 4. Requisitos Funcionais (RF)
+## 4. Functional Requirements (RF)
 
-| ID | Requisito | Prioridade |
+| ID | Requirement | Priority |
 | --- | --- | --- |
-| RF-01 | Autenticação de usuário — registro, login, logout e sessão com refresh automático (Postgres como source of truth; Redis cache removido e pendente de reconstrução futura). **Hardening de produção concluído** (`docs/features/001-auth-hardening/`): expiração real de sessão (idle + vida máxima), rotação de refresh token com detecção de reuse, cookies HttpOnly/SameSite=Lax (nunca mais em `document.cookie`/`localStorage`), rate limiting por endpoint, mensagens genéricas em login/reset contra enumeração de email. Hardening de infra (TLS, credenciais do `docker-compose.yml`) adiado — ver `docs/roadmap.md` | P0 |
-| RF-02 | Verificação de email — token de verificação enviado por email, reenvio de token | P0 |
-| RF-03 | Recuperação de senha — token de reset enviado por email, troca de senha | P0 |
-| RF-04 | CRUD de posts — criar, ler, atualizar, deletar, revalidar (ISR) | P0 |
-| RF-05 | CRUD de comentários em posts — criar, listar, atualizar, deletar | P0 |
-| RF-06 | Perfil de usuário — editar nome/bio, visualizar posts e comentários publicados pelo usuário | P1 |
-| RF-07 | Admin/CMS (autor) — autor controla status de publicação (draft/published/archived), vê preview do próprio post não publicado na URL real, gerencia todos os próprios posts com filtro por status/categoria/tag (`docs/roadmap.md` Fase 2); painel site-wide pra Admin/Editor via RF-08 (`013-role-based-permissions`) | P1 |
-| RF-08 | Papéis e permissões (Admin/Editor/Author) — `docs/roadmap.md` Fase 3: Admin/Editor editam/deletam post de qualquer usuário e gerenciam categorias, Author só o próprio; Admin promove/rebaixa papel de outro usuário; painel de posts (RF-07) fica site-wide pra Admin/Editor. Restrição de publish/archive a Admin/Editor e workflow de revisão ficam pra Fase 4 (`013-role-based-permissions/spec.md` § 4) | P1 |
-| RF-09 | Workflow editorial (revisão de posts) — `docs/roadmap.md` Fase 4: novos status `IN_REVIEW`/`SCHEDULED`; Author envia post pra revisão, Admin/Editor aprova/rejeita (com motivo obrigatório)/publica direto/agenda/arquiva; `PostReviewComment` guarda o histórico de aprovação/rejeição; agendamento resolvido via checagem lazy de visibilidade (sem scheduler novo). Histórico de diffs de edição (`PostRevision`) fica pra rodada futura (`014-post-review-workflow/spec.md` § 4) | P1 |
-| RF-10 | SEO e publicação profissional — `docs/roadmap.md` Fase 5: sitemap.xml dinâmico, robots.txt, RSS feed, canonical URL, Twitter Card, schema.org (`Article` JSON-LD), tudo computado dos campos já existentes do post (sem migration, `015-seo-metadata`). Slug amigável + redirect (301 via `previousSlug`) e campos editáveis de override de SEO (`seoTitle`/`seoDescription`/`canonicalUrl`), fechados em `018-seo-overrides-slug-redirect/spec.md` | P1 |
-| RF-11 | Busca de conteúdo — `docs/roadmap.md` Fase 6: busca por título/conteúdo (`contains`/`insensitive`, sem migration — full-text nativo do Postgres fica pra quando existir teste de integração real, ver `ADR-0011`), com sugestões enquanto digita reusando o mesmo endpoint. Filtro por tag/categoria e posts relacionados já existiam antes desta feature (`readRecent`, `007-posts-relacionados`); ordenação por mais acessado (`sortBy: "mostViewed"`, tiebreak por `id` pra paginação estável) fechada em `019-search-sort-by-views/spec.md`, desbloqueada pelo `Post.viewCount` de RF-12 | P2 |
-| RF-12 | Analytics interno — `docs/roadmap.md` Fase 7: visualização de post registrada automaticamente na leitura pública, dashboard Admin/Editor com total de views por post e ranking de mais acessados. Tecnologia de contagem (buffer Redis com flush batched pro Postgres, evitando message broker dedicado) investigada em `docs/research/002-redis-view-counting.md` e materializada em `ADR-0013`. Breakdown por período (7/30 dias), origem de tráfego e user agent — adiado em `017-post-view-analytics/spec.md § 4` até decidir retenção/privacidade de dados brutos — fechado em `020-view-analytics-breakdown/spec.md` (retenção de 30 dias com deleção lazy, sem IP persistido) | P2 |
-| RF-13 | Upload e gerenciamento de mídia — `docs/roadmap.md` Fase 8: usuário autenticado envia arquivo de imagem (upload real, não só URL), vê a própria biblioteca de mídia, apaga o que enviou, preenche texto alternativo; Admin/Editor enxergam/removem mídia de qualquer usuário (mesmo padrão de bypass de `post:deleteAny`, RF-08). Upload valida tamanho/formato no boundary. Imagem de capa do post (`010-post-cover-image`) passa a poder vir de um upload, sem exigir URL externa. Compressão/otimização automática de imagem fica fora desta rodada (`021-media-upload/spec.md § 4`) | P2 |
-| RF-14 | Tratamento de erro padronizado — `docs/roadmap.md` Fase 9: classificação Domain/Procedure/Infra em `src/shared/error/*`, hoje só parcialmente aplicada (violação da regra dura 15 em ~18-24 `domain/*.ts`, ver `docs/afm.md` § 3.1). `ErrorRegistry` (código namespaced por domínio, `httpCode`/`message` resolvidos automaticamente em `DomainError`, sem switch/if-chain por procedure) formalizado em `ADR-0017` (substitui `ADR-0016`), investigado em `docs/research/004-error-handler-patterns.md` | P2 |
+| RF-01 | User authentication — register, login, logout, and session with automatic refresh (Postgres as source of truth; Redis cache removed, pending a future rebuild). **Production hardening done** (`docs/features/001-auth-hardening/`): real session expiry (idle + max lifetime), refresh-token rotation with reuse detection, HttpOnly/SameSite=Lax cookies (never again in `document.cookie`/`localStorage`), per-endpoint rate limiting, generic login/reset messages against email enumeration. Infra hardening (TLS, `docker-compose.yml` credentials) deferred — see `docs/roadmap.md` | P0 |
+| RF-02 | Email verification — a verification token sent by email, token resend | P0 |
+| RF-03 | Password recovery — a reset token sent by email, password change | P0 |
+| RF-04 | Post CRUD — create, read, update, delete, revalidate (ISR) | P0 |
+| RF-05 | Post comment CRUD — create, list, update, delete | P0 |
+| RF-06 | User profile — edit name/bio, view the user's published posts and comments | P1 |
+| RF-07 | Admin/CMS (author) — the author controls publication status (draft/published/archived), previews an unpublished own post at the real URL, manages all own posts with a status/category/tag filter (`docs/roadmap.md` Phase 2); a site-wide panel for Admin/Editor comes via RF-08 (`013-role-based-permissions`) | P1 |
+| RF-08 | Roles and permissions (Admin/Editor/Author) — `docs/roadmap.md` Phase 3: Admin/Editor edit/delete any user's post and manage categories, Author only their own; Admin promotes/demotes another user's role; the post panel (RF-07) becomes site-wide for Admin/Editor. The publish/archive restriction to Admin/Editor and the review workflow move to Phase 4 (`013-role-based-permissions/spec.md` § 4) | P1 |
+| RF-09 | Editorial workflow (post review) — `docs/roadmap.md` Phase 4: new statuses `IN_REVIEW`/`SCHEDULED`; the Author submits a post for review, Admin/Editor approve/reject (with a mandatory reason)/publish directly/schedule/archive; `PostReviewComment` keeps the approval/rejection history; scheduling resolved via a lazy visibility check (no new scheduler). Edit-diff history (`PostRevision`) moves to a future round (`014-post-review-workflow/spec.md` § 4) | P1 |
+| RF-10 | SEO and professional publishing — `docs/roadmap.md` Phase 5: dynamic sitemap.xml, robots.txt, RSS feed, canonical URL, Twitter Card, schema.org (`Article` JSON-LD), all computed from the post's existing fields (no migration, `015-seo-metadata`). Friendly slug + redirect (301 via `previousSlug`) and editable SEO override fields (`seoTitle`/`seoDescription`/`canonicalUrl`), closed in `018-seo-overrides-slug-redirect/spec.md` | P1 |
+| RF-11 | Content search — `docs/roadmap.md` Phase 6: search by title/content (`contains`/`insensitive`, no migration — native Postgres full-text waits for a real integration test, see `ADR-0011`), with type-ahead suggestions that reuse the same endpoint. Tag/category filter and related posts existed before this feature (`readRecent`, `007-posts-relacionados`); sort by most-viewed (`sortBy: "mostViewed"`, `id` tiebreak for stable pagination) closed in `019-search-sort-by-views/spec.md`, unblocked by `Post.viewCount` from RF-12 | P2 |
+| RF-12 | Internal analytics — `docs/roadmap.md` Phase 7: a post view recorded automatically on public read, an Admin/Editor dashboard with total views per post and a most-viewed ranking. The counting tech (a Redis buffer with a batched flush to Postgres, avoiding a dedicated message broker) investigated in `docs/research/002-redis-view-counting.md` and built in `ADR-0013`. Breakdown by period (7/30 days), traffic source, and user agent — deferred in `017-post-view-analytics/spec.md § 4` until raw-data retention/privacy was decided — closed in `020-view-analytics-breakdown/spec.md` (30-day retention with lazy deletion, no IP persisted) | P2 |
+| RF-13 | Media upload and management — `docs/roadmap.md` Phase 8: an authenticated user uploads an image file (real upload, not just a URL), sees their own media library, deletes what they uploaded, fills alt text; Admin/Editor see/remove any user's media (same bypass pattern as `post:deleteAny`, RF-08). Upload validates size/format at the boundary. A post cover image (`010-post-cover-image`) can now come from an upload, without an external URL. Automatic image compression/optimization stays out of this round (`021-media-upload/spec.md § 4`) | P2 |
+| RF-14 | Standardized error handling — `docs/roadmap.md` Phase 9: Domain/Procedure/Infra classification in `src/shared/error/*`, today only partly applied (rule 15 violation in ~18-24 `domain/*.ts`, see `docs/afm.md` § 3.1). `ErrorRegistry` (domain-namespaced code, `httpCode`/`message` resolved automatically in `DomainError`, no per-procedure switch/if-chain) formalized in `ADR-0017` (replaces `ADR-0016`), investigated in `docs/research/004-error-handler-patterns.md` | P2 |
 
-*(RFs inferidos de `git log` — commits `feat:` de registro/login/sessão, verificação de token, reset de senha, CRUD de post/comentário, e edição de perfil. Ver histórico completo via `git log --oneline --grep=feat`.)*
+*(RFs inferred from `git log` — `feat:` commits for register/login/session, token verification, password reset, post/comment CRUD, and profile editing. See the full history via `git log --oneline --grep=feat`.)*
 
-**Nota de discrepância:** o `README.md` menciona "busca semântica de posts usando vetores de similaridade" nas funcionalidades atuais, mas nenhuma implementação (embeddings/pgvector/similarity) foi encontrada no código (`grep -rniE "embedding|vector|similarity|pgvector"` retorna vazio) — tratar como item de roadmap (`README.md` § Futuro), não RF implementado. [A DEFINIR — confirmar status real com o dono do produto.]
+**Discrepancy note:** `README.md` mentions "semantic post search using similarity vectors" among current features, but no implementation (embeddings/pgvector/similarity) was found in the code (`grep -rniE "embedding|vector|similarity|pgvector"` returns empty) — treat it as a roadmap item (`README.md` § Futuro), not an implemented RF. [A DEFINIR — confirm the real status with the product owner.]
 
-## 5. Requisitos Não-Funcionais (RNF)
+## 5. Non-Functional Requirements (RNF)
 
-| ID | Tipo | Critério |
+| ID | Type | Criterion |
 | --- | --- | --- |
-| RNF-01 | Disponibilidade | [A DEFINIR] |
-| RNF-02 | Latência | [A DEFINIR] |
-| RNF-03 | Segurança | Senhas hasheadas (bcrypt), tokens de sessão/verificação/reset com expiração e uso único (`used: Boolean`) |
+| RNF-01 | Availability | [A DEFINIR] |
+| RNF-02 | Latency | [A DEFINIR] |
+| RNF-03 | Security | Hashed passwords (bcrypt), session/verification/reset tokens with expiry and single use (`used: Boolean`) |
 
-*[A DEFINIR — thresholds numéricos.]*
+*[A DEFINIR — numeric thresholds.]*
 
-## 6. Metas por Etapa
+## 6. Stage Goals
 
-> **Plano de fases detalhado vive em [`docs/roadmap.md`](./roadmap.md)** — 12 fases (0 a 11), da organização inicial até observabilidade. Não duplicado aqui (fonte única); esta seção só posiciona o estado atual dentro desse plano.
+> **The detailed phase plan lives in [`docs/roadmap.md`](./roadmap.md)** — 12 phases (0 to 11), from initial organization to observability. Not duplicated here (single source); this section only positions the current state within that plan.
 
-### 6.1 MVP — estado atual
+### 6.1 MVP — current state
 
-**Objetivo:** blog público + auth + CRUD de posts/comentários funcionando fim-a-fim (Fase 0 do roadmap concluída; Fase 1 "Blog público bem feito" parcialmente concluída).
+**Goal:** a public blog + auth + post/comment CRUD working end-to-end (roadmap Phase 0 done; Phase 1 "public blog" partly done).
 
-**Escopo já implementado:** RF-01 a RF-07.
+**Scope already implemented:** RF-01 to RF-07.
 
-**Fase 1 do roadmap concluída** (com 1 pendência residual aceita — status HTTP de `/post/[slug]`, ver `docs/features/009-post-404-status/`). **Fase 2 concluída** (com 1 pendência adiada pra Fase 8 — upload de arquivo de capa). Ver `docs/roadmap.md` § Progresso geral pro detalhamento por feature.
+**Roadmap Phase 1 done** (with 1 accepted residual — the HTTP status of `/post/[slug]`, see `docs/features/009-post-404-status/`). **Phase 2 done** (with 1 item deferred to Phase 8 — cover-file upload). See `docs/roadmap.md` for the per-feature breakdown.
 
-**Nota de discrepância com o roadmap:** a "stack sugerida" da Fase 0 do roadmap lista Auth.js/Better Auth, Playwright e GitHub Actions. Playwright/GitHub Actions não foram adotados (testes são `vitest`, sem CI — `.github/workflows/` ausente, ver `ach.md` § CI/hooks). **Auth.js/Better Auth foi decisão explícita de não adotar — ver ADR-0005**: a auth própria (sessão opaca em `Session`, Postgres como source of truth) é mantida, com hardening incremental em vez de substituição por lib.
+**Discrepancy note vs. the roadmap:** the roadmap Phase 0 "suggested stack" lists Auth.js/Better Auth, Playwright, and GitHub Actions. Playwright/GitHub Actions were not adopted (tests are `vitest`, no CI — `.github/workflows/` absent, see `ach.md`). **Auth.js/Better Auth was an explicit decision not to adopt — see ADR-0005:** the custom auth (an opaque session in `Session`, Postgres as source of truth) is kept, with incremental hardening instead of a library swap.
 
-**Critério de aceite:** [A DEFINIR].
+**Acceptance criterion:** [A DEFINIR].
 
-**Métrica de sucesso:** [A DEFINIR].
+**Success metric:** [A DEFINIR].
 
-### 6.2 GTM — Fases 2-5 do roadmap
+### 6.2 GTM — roadmap Phases 2-5
 
-Admin/CMS (Fase 2), autenticação com papéis Admin/Editor/Author (Fase 3), workflow editorial DRAFT→IN_REVIEW→SCHEDULED/PUBLISHED (Fase 4), SEO completo (Fase 5). Ver `docs/roadmap.md` para funcionalidades, modelos e critérios de conclusão de cada fase.
+Admin/CMS (Phase 2), authentication with Admin/Editor/Author roles (Phase 3), editorial workflow DRAFT→IN_REVIEW→SCHEDULED/PUBLISHED (Phase 4), full SEO (Phase 5). See `docs/roadmap.md` for each phase's features, models, and completion criteria.
 
-### 6.3 First N — Fases 6-11 do roadmap
+### 6.3 First N — roadmap Phases 6-11
 
-Busca (6), analytics interno (7), upload de mídia (8), qualidade de produção/testes (9), CI/CD e deploy (10), observabilidade (11).
+Search (6), internal analytics (7), media upload (8), production quality/tests (9), CI/CD and deploy (10), observability (11).
 
-## 7. Métricas & North Stars [A DEFINIR]
+## 7. Metrics & North Stars [A DEFINIR]
 
 [A DEFINIR.]
 
-## 8. Riscos & Mitigações [A DEFINIR]
+## 8. Risks & Mitigations [A DEFINIR]
 
-| Risco | Impacto | Probabilidade | Mitigação |
+| Risk | Impact | Probability | Mitigation |
 | --- | --- | --- | --- |
 | [A DEFINIR] | | | |
 
-## 9. Não-escopo (v1)
+## 9. Non-scope (v1)
 
-- **Busca semântica de posts.** Mencionada no README como funcionalidade/futuro, sem implementação atual — fora de escopo até virar RF confirmado.
-- **Tudo das Fases 3-11 do `docs/roadmap.md`** (papéis e permissões, workflow editorial, SEO completo, busca, analytics, upload de mídia, CI/CD, observabilidade) — planejado, não construído (Fase 2, admin/CMS, virou RF-07 e já está concluída). Não é "fora de escopo" permanente, é *ainda não* — cada fase entra como RF novo quando a implementação começar (ver § 4).
+- **Semantic post search.** Mentioned in the README as a feature/future, with no current implementation — out of scope until it becomes a confirmed RF.
+- **Everything in `docs/roadmap.md` Phases 3-11** (roles and permissions, editorial workflow, full SEO, search, analytics, media upload, CI/CD, observability) — planned, not built (Phase 2, admin/CMS, became RF-07 and is done). This is not permanent "out of scope", it is *not yet* — each phase enters as a new RF when its implementation starts (see § 4).
 
-## 10. Glossário
+## 10. Glossary
 
-- **User** — conta de usuário; autentica, publica posts, comenta. Atributos: `id, email, password, name, bio?, verified` (ver `prisma/schema.prisma`).
-- **Session** — sessão de autenticação de um User, com `accessToken`/`refreshToken`. Atributos: `id, userId, accessToken, refreshToken` (ver `prisma/schema.prisma`).
-- **Post** — conteúdo publicado por um User. Atributos: `id, userId, title, content` (ver `prisma/schema.prisma`).
-- **Comment** — comentário de um User em um Post. Atributos: `id, postId, userId, content` (ver `prisma/schema.prisma`).
-- **VerificationToken** — token de verificação de email de um User, com expiração e uso único. Atributos: `id, token, expiresAt, userId, used` (ver `prisma/schema.prisma`).
-- **ResetToken** — token de reset de senha de um User, com expiração e uso único. Atributos: `id, token, expiresAt, userId, used` (ver `prisma/schema.prisma`).
+- **User** — a user account; authenticates, publishes posts, comments. Attributes: `id, email, password, name, bio?, verified` (see `prisma/schema.prisma`).
+- **Session** — a User's auth session, with `accessToken`/`refreshToken`. Attributes: `id, userId, accessToken, refreshToken` (see `prisma/schema.prisma`).
+- **Post** — content published by a User. Attributes: `id, userId, title, content` (see `prisma/schema.prisma`).
+- **Comment** — a User's comment on a Post. Attributes: `id, postId, userId, content` (see `prisma/schema.prisma`).
+- **VerificationToken** — a User's email verification token, with expiry and single use. Attributes: `id, token, expiresAt, userId, used` (see `prisma/schema.prisma`).
+- **ResetToken** — a User's password reset token, with expiry and single use. Attributes: `id, token, expiresAt, userId, used` (see `prisma/schema.prisma`).
 
-## 11. Naming — produto vs identificadores técnicos
+## 11. Naming — product vs technical identifiers
 
-- **Produto user-facing:** "Bearboo" — usar em UI, emails, títulos, copy externa.
-- **Identificadores técnicos NÃO mudam:**
-  - `src/config/site.ts` ainda tem placeholder `"Next.js + HeroUI"` — [A DEFINIR: atualizar pro nome real do produto].
-  - Demais identificadores técnicos (paths, env vars) não inventariados nesta adoção retroativa — crescem sob demanda.
+- **User-facing product:** "Bearboo" — use in UI, emails, titles, external copy.
+- **Technical identifiers do NOT change:**
+  - `src/config/site.ts` still has the placeholder `"Next.js + HeroUI"` — [A DEFINIR: update to the real product name].
+  - Other technical identifiers (paths, env vars) not inventoried in this retroactive adoption — they grow on demand.
 
 ---
 
-*Estado atual e histórico vivo em `/docs/ust.md` (backlog) e `/docs/ach.md` (arquitetura). Decisões de processo em `/docs/afm.md`.*
+*Current state and living history in `/docs/ust.md` (backlog) and `/docs/ach.md` (architecture). Process decisions in `/docs/afm.md`.*


### PR DESCRIPTION
## What

Second conversion under **ADR-0021**: `prd.md` → English, STE-spirit.

## Byte-exact (verified)

- **Zero code-span changes** between original and translation — every path, identifier, ADR ref, and the `grep` command are untouched.
- **`[A DEFINIR]` markers** preserved (14 → 14); all RF-01..RF-14 and RNF-01..03 IDs intact.

## Measurement

**−4.3% chars (1725 → 1640 words).** Real savings, but far below the −26% the pure-prose excerpt suggested. The RF table is reference-dense (feature paths, ADR refs, status identifiers) that does not compress — even a "prose" doc carries a lot of incompressible reference content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)