### PR TITLE
docs(gotchas): translate gotchas.md to English (STE-spirit)

### DIFF
--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -1,114 +1,114 @@
-# Gotchas — surpresas que travam outro dev
+# Gotchas — surprises that block another dev
 
-> Cada item é uma surpresa contraintuitiva descoberta na prática. Nasce vazio, cresce sob demanda.
+> Each item is a counterintuitive surprise found in practice. It starts empty and grows on demand.
 >
-> **Regra de entrada:** só vira gotcha o que travou alguém pelo menos 2× ou tem alta probabilidade de travar (gotcha de SDK/runtime/lib externa). Não inventa gotcha — descobre.
+> **Entry rule:** only what blocked someone at least 2× or has a high chance of blocking (an SDK/runtime/external-lib gotcha) becomes a gotcha. Do not invent a gotcha — discover it.
 >
-> **Formato:** cada gotcha tem **gatilho** ("se você está editando X, leia antes") + **comportamento contraintuitivo** + **solução** + link pro ADR ou doc canônico se houver.
+> **Format:** each gotcha has a **trigger** ("if you are editing X, read first") + **counterintuitive behavior** + **solution** + a link to the ADR or canonical doc if any.
 >
-> **Ordem:** por área (não cronológica). Use Ctrl-F com nome de arquivo ou symbol.
+> **Order:** by area (not chronological). Use Ctrl-F with a file name or symbol.
 
 ---
 
-## Next.js — `cookies()` / `headers()` só em Server Component / route handler
+## Next.js — `cookies()` / `headers()` only in a Server Component / route handler
 
-**Gatilho:** se você está usando `cookies()` ou `headers()` de `next/headers` numa lib pura ou em Client Component.
+**Trigger:** if you are using `cookies()` or `headers()` from `next/headers` in a pure lib or a Client Component.
 
-**Comportamento:** ambos só funcionam no contexto de request — Server Component, route handler, server action. Em qualquer outro lugar joga error em runtime.
+**Behavior:** both work only in the request context — Server Component, route handler, server action. Anywhere else they throw at runtime.
 
-**Solução:** ler cookies no Server Component / route handler, passar pro componente client como prop. Nunca importar `next/headers` em código que pode rodar no browser.
+**Solution:** read cookies in the Server Component / route handler, pass them to the client component as a prop. Never import `next/headers` in code that can run in the browser.
 
-**Ref:** confirmado pelo time na adoção retroativa (`/afm:refactor`, 2026-06-30) como já mordido.
-
----
-
-## Next.js — `revalidatePath` / `revalidateTag` não invalida React Query
-
-**Gatilho:** se você está em route handler ou server action e quer refresh do cache do client.
-
-**Comportamento:** `revalidatePath` invalida o cache do Next (RSC + fetch), mas o React Query no cliente tem cache próprio. Mutation via server action precisa também invalidar a query no cliente — não chega automático.
-
-**Solução:** retorna sinal pro client que dispara `queryClient.invalidateQueries(...)`. Ou usa cliente do stack que já integra (ex: `@trpc/tanstack-react-query` invalida automático em `onSuccess`).
-
-**Ref:** confirmado pelo time na adoção retroativa (`/afm:refactor`, 2026-06-30) como já mordido. Ver `src/server/features/post/procedures/revalidate.ts` + `src/server/features/post/domain/revalidate.ts` (revalidação de ISR, estrutura por-feature do ADR-0006).
+**Ref:** confirmed by the team in the retroactive adoption (`/afm:refactor`, 2026-06-30) as already bitten.
 
 ---
 
-## Node ESM nativo (`prisma/*.ts` via `node`) — não dá pra reimportar `src/lib/*`
+## Next.js — `revalidatePath` / `revalidateTag` does not invalidate React Query
 
-**Gatilho:** se você está escrevendo um script em `prisma/` (seed, script de teste manual, etc.) que roda via `node --env-file=.env prisma/algo.ts` — não via Next.js/webpack.
+**Trigger:** if you are in a route handler or server action and want to refresh the client cache.
 
-**Comportamento:** `tsconfig.json` usa `moduleResolution: "bundler"`, que permite import relativo sem extensão (`from "../adapter"`) em todo `src/`. Node's execução nativa de TS não aceita isso — exige extensão em todo import relativo. Um script em `prisma/` que importa algo de `src/lib/` quebra assim que esse módulo (ou qualquer coisa que ele importa, em cadeia) tiver um import relativo sem extensão — o que é a convenção padrão do projeto inteiro em `src/`. Mordido 2× (`prisma/seed.ts`, `2026-07-11`; `prisma/seed-pagination-test.ts`, `2026-07-12`) — as duas vezes a "solução" virou duplicar a lógica no script, o que por sua vez duplicou a duplicação.
+**Behavior:** `revalidatePath` invalidates the Next cache (RSC + fetch), but React Query on the client has its own cache. A mutation via a server action must also invalidate the query on the client — it does not arrive automatically.
 
-**Solução:** lógica pura reaproveitada por scripts de `prisma/` vive em `prisma/*.ts` (não em `src/`), sem import relativo próprio (arquivo-folha) — assim outro script de `prisma/` pode importar com extensão explícita (`from "./slug.ts"`) sem cair na cadeia quebrada. Precisa de `"allowImportingTsExtensions": true` no `tsconfig.json` (seguro com `noEmit: true`, que já era o caso). Ver `prisma/slug.ts` (fonte única de `generateSlug`, usada por `seed.ts` e `seed-pagination-test.ts`).
+**Solution:** return a signal to the client that triggers `queryClient.invalidateQueries(...)`. Or use a stack client that already integrates it (e.g. `@trpc/tanstack-react-query` invalidates automatically in `onSuccess`).
 
-**Ref:** `docs/features/003-post-pagination/` (achado durante a criação de `seed-pagination-test.ts`, 2026-07-12).
-
----
-
-## Next.js — Cache Components (`cacheComponents: true`) proíbe rota sem `<Suspense>`, mesmo que você não queira PPR
-
-**Gatilho:** se você está tentando fazer uma rota bloquear a resposta inteira até os dados chegarem (ex: pra `notFound()` setar status HTTP 404 de verdade antes do shell ser enviado) removendo o `<Suspense>` que envolve a leitura dinâmica.
-
-**Comportamento:** com `cacheComponents: true` (`next.config.ts`), toda leitura assíncrona não-`"use cache"` (inclusive `await params`, `cookies()`, query de DB) precisa estar dentro de um `<Suspense>` — senão o build falha com `Error: Route "...": Uncached data was accessed outside of <Suspense>` (`next build --debug-prerender` aponta o componente exato). Não existe mais `export const dynamic = "force-dynamic"` como escape hatch por rota — essa route segment config foi removida junto da adoção de Cache Components (Next 16). Ou seja: **não dá pra ter uma rota totalmente bloqueante/dinâmica sob Cache Components** — o shell sempre é enviado antes do conteúdo dinâmico resolver, então o status HTTP do shell (200) não pode mais mudar depois. Mordida em `docs/features/009-post-404-status/` (2026-07-12): tentativa de tirar o `Suspense` de `/post/[slug]` pra corrigir o 404 quebrou o `next build` inteiro.
-
-**Solução:** aceitar que, sob Cache Components, `notFound()`/`redirect()` dentro de um boundary `Suspense` muda o conteúdo mas não o status HTTP do shell já enviado. Pra status HTTP real (bots/SEO), a checagem precisa acontecer **antes** do pipeline de render de página — ex. `middleware`/`proxy` (Edge) fazendo o lookup e retornando 404 direto, fora do Cache Components. Isso é infra nova (rota de dados no Edge), não um fix pontual — parar e validar com o dono antes de implementar.
-
-**Ref:** `docs/features/009-post-404-status/`, `docs/ust.md` § Pendências Técnicas. Doc oficial: https://nextjs.org/docs/messages/blocking-route.
+**Ref:** confirmed by the team in the retroactive adoption (`/afm:refactor`, 2026-06-30) as already bitten. See `src/server/features/post/procedures/revalidate.ts` + `src/server/features/post/domain/revalidate.ts` (ISR revalidation, per-feature structure from ADR-0006).
 
 ---
 
-## Next.js — página `"use cache"` nunca sabe quem está pedindo (sem cookies)
+## Native Node ESM (`prisma/*.ts` via `node`) — you cannot re-import `src/lib/*`
 
-**Gatilho:** se você precisa personalizar o conteúdo de uma rota que hoje é `"use cache"`/`cacheLife(...)` com base em quem está logado (ex: dono vê algo que visitante não vê).
+**Trigger:** if you are writing a script in `prisma/` (seed, manual test script, etc.) that runs via `node --env-file=.env prisma/algo.ts` — not via Next.js/webpack.
 
-**Comportamento:** `src/server/caller.ts` tem dois callers: `createCaller()` (usado dentro de componentes `"use cache"`, monta o contexto com `headers: new Headers()` **sempre vazio, sem cookies**) e `createDynamicCaller()` (lê cookies de verdade, mas **redireciona pra `/auth/login` se não houver sessão** — só serve pra página 100% autenticada). Nenhum dos dois serve sozinho pra "página pública que às vezes precisa saber quem é o dono": `createCaller()` nunca vê `ctx.user` (mordida em `docs/features/011-post-status-preview/plan.md` § 9 — tentar passar `ctx.user?.id` pro domain dentro de um componente `"use cache"` simplesmente nunca resolve, porque o caller usado ali nunca teve cookies em primeiro lugar). E não dá pra só chamar `cookies()` dentro do componente `"use cache"` — Cache Components proíbe leitura dinâmica nesse escopo (mesma família de regra do gotcha anterior).
+**Behavior:** `tsconfig.json` uses `moduleResolution: "bundler"`, which allows an extensionless relative import (`from "../adapter"`) across all of `src/`. Node's native TS execution does not accept it — it requires an extension on every relative import. A script in `prisma/` that imports something from `src/lib/` breaks as soon as that module (or anything it imports, in a chain) has an extensionless relative import — which is the whole project's default convention in `src/`. Bitten 2× (`prisma/seed.ts`, `2026-07-11`; `prisma/seed-pagination-test.ts`, `2026-07-12`) — both times the "solution" became duplicating the logic in the script, which in turn duplicated the duplication.
 
-**Solução:** criar um terceiro caller — `createOptionalDynamicCaller()` (`src/server/caller.ts`) — que lê cookies como `createDynamicCaller` mas **não redireciona** se não houver sessão. Estruturar a página em dois componentes: o cacheado (`"use cache"`, caminho público/comum, via `createCaller()`) tenta primeiro; só quando ele não encontra nada, um componente **novo, não-cacheado, dentro do próprio `<Suspense>`**, tenta de novo com `createOptionalDynamicCaller()`. Isso preserva o cache pro caminho comum e paga o custo dinâmico só no caso raro que precisa de identidade. Não dá pra remover `"use cache"` da página inteira sem perder o cache pro tráfego comum — só faça isso se o caso "personalizado" for a maioria do tráfego, não a exceção.
+**Solution:** pure logic reused by `prisma/` scripts lives in `prisma/*.ts` (not in `src/`), with no relative import of its own (a leaf file) — so another `prisma/` script can import it with an explicit extension (`from "./slug.ts"`) without falling into the broken chain. It needs `"allowImportingTsExtensions": true` in `tsconfig.json` (safe with `noEmit: true`, which was already the case). See `prisma/slug.ts` (single source of `generateSlug`, used by `seed.ts` and `seed-pagination-test.ts`).
+
+**Ref:** `docs/features/003-post-pagination/` (found while creating `seed-pagination-test.ts`, 2026-07-12).
+
+---
+
+## Next.js — Cache Components (`cacheComponents: true`) forbids a route without `<Suspense>`, even if you do not want PPR
+
+**Trigger:** if you are trying to make a route block the whole response until the data arrives (e.g. for `notFound()` to set a real HTTP 404 status before the shell is sent) by removing the `<Suspense>` that wraps the dynamic read.
+
+**Behavior:** with `cacheComponents: true` (`next.config.ts`), every non-`"use cache"` async read (including `await params`, `cookies()`, a DB query) must be inside a `<Suspense>` — otherwise the build fails with `Error: Route "...": Uncached data was accessed outside of <Suspense>` (`next build --debug-prerender` points to the exact component). There is no more `export const dynamic = "force-dynamic"` as a per-route escape hatch — that route segment config was removed with the Cache Components adoption (Next 16). So: **you cannot have a fully blocking/dynamic route under Cache Components** — the shell is always sent before the dynamic content resolves, so the shell's HTTP status (200) can no longer change afterward. Bitten in `docs/features/009-post-404-status/` (2026-07-12): trying to remove the `Suspense` from `/post/[slug]` to fix the 404 broke the whole `next build`.
+
+**Solution:** accept that, under Cache Components, `notFound()`/`redirect()` inside a `Suspense` boundary changes the content but not the HTTP status of the already-sent shell. For a real HTTP status (bots/SEO), the check must happen **before** the page render pipeline — e.g. `middleware`/`proxy` (Edge) doing the lookup and returning 404 directly, outside Cache Components. This is new infra (a data route on the Edge), not a point fix — stop and validate with the owner before you implement it.
+
+**Ref:** `docs/features/009-post-404-status/`, `docs/ust.md` § Pendências Técnicas. Official doc: https://nextjs.org/docs/messages/blocking-route.
+
+---
+
+## Next.js — a `"use cache"` page never knows who is asking (no cookies)
+
+**Trigger:** if you need to personalize the content of a route that is today `"use cache"`/`cacheLife(...)` based on who is logged in (e.g. the owner sees something a visitor does not).
+
+**Behavior:** `src/server/caller.ts` has two callers: `createCaller()` (used inside `"use cache"` components, builds the context with `headers: new Headers()` **always empty, no cookies**) and `createDynamicCaller()` (reads real cookies, but **redirects to `/auth/login` if there is no session** — only for a 100% authenticated page). Neither works alone for "a public page that sometimes needs to know the owner": `createCaller()` never sees `ctx.user` (bitten in `docs/features/011-post-status-preview/plan.md` § 9 — passing `ctx.user?.id` to the domain inside a `"use cache"` component simply never resolves, because the caller used there never had cookies in the first place). And you cannot just call `cookies()` inside the `"use cache"` component — Cache Components forbids a dynamic read in that scope (the same rule family as the previous gotcha).
+
+**Solution:** create a third caller — `createOptionalDynamicCaller()` (`src/server/caller.ts`) — that reads cookies like `createDynamicCaller` but **does not redirect** if there is no session. Structure the page in two components: the cached one (`"use cache"`, the public/common path, via `createCaller()`) tries first; only when it finds nothing, a **new, non-cached component, inside the same `<Suspense>`**, tries again with `createOptionalDynamicCaller()`. This keeps the cache for the common path and pays the dynamic cost only in the rare case that needs identity. You cannot remove `"use cache"` from the whole page without losing the cache for common traffic — only do that if the "personalized" case is the majority of traffic, not the exception.
 
 **Ref:** `docs/features/011-post-status-preview/plan.md` § 9, `src/server/caller.ts`.
 
 ---
 
 <!--
-SEED candidato adicional de módulo detectado no scan (Next.js App Router), ainda não confirmado como mordido — ativar só se acontecer.
+Additional module SEED candidate found in the scan (Next.js App Router), not yet confirmed as bitten — activate only if it happens.
 
-## Next.js — root layout sob segmento dinâmico deixa `_not-found` órfão
+## Next.js — a root layout under a dynamic segment leaves `_not-found` orphaned
 
-**Gatilho:** se você deletar `app/layout.tsx` e mover `<html>`/`<body>` pra um segmento dinâmico (ex: `app/[lang]/layout.tsx`).
+**Trigger:** if you delete `app/layout.tsx` and move `<html>`/`<body>` to a dynamic segment (e.g. `app/[lang]/layout.tsx`).
 
-**Comportamento:** o Next gera uma rota interna `/_not-found` que vive fora do segmento dinâmico, sem root layout pra compor o documento.
+**Behavior:** Next generates an internal route `/_not-found` that lives outside the dynamic segment, with no root layout to compose the document.
 
-**Solução:** `app/global-not-found.tsx` + `experimental.globalNotFound: true`. Não se aplica hoje ao Bearboo (sem rotas `[lang]`), mas fica registrado caso i18n entre em escopo.
+**Solution:** `app/global-not-found.tsx` + `experimental.globalNotFound: true`. Does not apply to Bearboo today (no `[lang]` routes), but is registered in case i18n enters scope.
 -->
 
 ---
 
-*Adicionar gotcha novo: copia o formato acima. Coloca em ordem alfabética por área. Se não tem área pra colocar, cria seção H2 nova.*
+*To add a new gotcha: copy the format above. Place it in alphabetical order by area. If there is no area for it, create a new H2 section.*
 
-## Pre-push hook — roda testes escopados, não suite completa
+## Pre-push hook — runs scoped tests, not the full suite
 
-**Gatilho:** se você está fazendo push e quer entender por que o pre-push não rodou seu teste favorito.
+**Trigger:** if you are pushing and want to understand why pre-push did not run your favorite test.
 
-**Comportamento:** `.husky/pre-push` (desde 2026-07-16) roda `lint-staged --diff "origin/main...HEAD"` em vez de `yarn test` (suite completa). `lint-staged` usa a configuração `.lintstagedrc.json` que chama `vitest related <files>` — ou seja, **só roda testes ligados aos arquivos alterados**. Benefício: pre-push fica rápido (segundos em vez de minutos). Risco: não detecta quebras em arquivos não diretamente relacionados — especialmente relevante em projeto com **mocks compartilhados em estado serial** (`src/test/setup.ts` seam, ADR-0011). Exemplo: teste de `src/server/features/user/procedures/login.ts` é alterado; o pre-push **não roda** testes de `src/server/features/auth/procedures/verifyToken.ts` se não há importação direta.
+**Behavior:** `.husky/pre-push` (since 2026-07-16) runs `lint-staged --diff "origin/main...HEAD"` instead of `yarn test` (the full suite). `lint-staged` uses the `.lintstagedrc.json` config that calls `vitest related <files>` — that is, **it only runs tests linked to the changed files**. Benefit: pre-push stays fast (seconds instead of minutes). Risk: it does not catch breaks in files that are not directly related — especially relevant in a project with **shared mocks in serial state** (`src/test/setup.ts` seam, ADR-0011). Example: a test for `src/server/features/user/procedures/login.ts` is changed; pre-push **does not run** the tests for `src/server/features/auth/procedures/verifyToken.ts` if there is no direct import.
 
-**Solução:** **Pre-push é gate rápido local, e hoje é o único gate automatizado que existe** — `docs/roadmap.md` Fase 10 (CI/CD) ainda não começou (sem `.github/workflows/`), então não há um gate de suite completa rodando em merge pra pegar quebras cross-módulo depois. Mitigação até a Fase 10 existir:
-- Roda localmente `yarn test` (full suite) antes de push quando a mudança toca múltiplos módulos ou mexe em algo usado pelos mocks compartilhados (`src/test/setup.ts`, ADR-0011).
-- Quando a Fase 10 (CI/CD) for implementada, o ideal é a suite completa rodar lá como o gate real — até então, a suite completa só roda se alguém rodar `yarn test` manualmente.
+**Solution:** **Pre-push is a fast local gate, and today it is the only automated gate that exists** — `docs/roadmap.md` Phase 10 (CI/CD) has not started (no `.github/workflows/`), so there is no full-suite gate running at merge to catch cross-module breaks later. Mitigation until Phase 10 exists:
+- Run `yarn test` locally (full suite) before a push when the change touches several modules or touches something used by the shared mocks (`src/test/setup.ts`, ADR-0011).
+- When Phase 10 (CI/CD) is built, the full suite should ideally run there as the real gate — until then, the full suite only runs if someone runs `yarn test` by hand.
 
-**Ref:** `docs/research/003-pre-push-scoped-tests.md` (decision: Opção 2 — lint-staged + vitest related; a research já registrava esse trade-off, esta nota corrige o gotcha que tinha assumido CI/CD como backstop existente).
+**Ref:** `docs/research/003-pre-push-scoped-tests.md` (decision: Option 2 — lint-staged + vitest related; the research already recorded this trade-off, this note corrects the gotcha that had assumed CI/CD as an existing backstop).
 
 ---
 
-## Zod v3 → v4 — validators de formato de string viraram funções top-level (deprecated, não erro)
+## Zod v3 → v4 — string-format validators became top-level functions (deprecated, not an error)
 
-**Gatilho:** se você está escrevendo/revisando um `z.object()` em `schema.ts` de qualquer feature e usa `z.string().url()`, `.email()`, `.uuid()`, `.cuid()`/`.cuid2()`, `.ulid()`, `.datetime()`, `.date()`, `.time()`, `.duration()`, `.ip()`/`.cidr()`, ou `z.nativeEnum()`/`.merge()` em qualquer schema Zod.
+**Trigger:** if you are writing/reviewing a `z.object()` in any feature's `schema.ts` and use `z.string().url()`, `.email()`, `.uuid()`, `.cuid()`/`.cuid2()`, `.ulid()`, `.datetime()`, `.date()`, `.time()`, `.duration()`, `.ip()`/`.cidr()`, or `z.nativeEnum()`/`.merge()` in any Zod schema.
 
-**Comportamento:** o projeto está em `zod@^4.0.10` (`package.json`), mas esses métodos ainda **compilam e funcionam** — são API v3 mantida por compat, sem erro de tipo nem warning de lint, então passam despercebidos em review. Zod v4 moveu os validadores de formato de string pra funções top-level; a forma antiga fica **deprecated silenciosamente**. Pego em `018-seo-overrides-slug-redirect` (`post/schema.ts`): `coverImageUrl`/`canonicalUrl` usavam `z.string().url()`.
+**Behavior:** the project is on `zod@^4.0.10` (`package.json`), but these methods still **compile and work** — they are v3 API kept for compat, with no type error or lint warning, so they slip past review. Zod v4 moved the string-format validators to top-level functions; the old form is **silently deprecated**. Caught in `018-seo-overrides-slug-redirect` (`post/schema.ts`): `coverImageUrl`/`canonicalUrl` used `z.string().url()`.
 
-**Solução — troca 1:1, sem mudança de comportamento:**
+**Solution — a 1:1 swap, no behavior change:**
 
-| v3 (deprecated, ainda funciona) | v4 (correto) |
+| v3 (deprecated, still works) | v4 (correct) |
 | --- | --- |
 | `z.string().url()` | `z.url()` |
 | `z.string().email()` | `z.email()` |
@@ -119,25 +119,25 @@ SEED candidato adicional de módulo detectado no scan (Next.js App Router), aind
 | `z.string().date()` | `z.iso.date()` |
 | `z.string().time()` | `z.iso.time()` |
 | `z.string().duration()` | `z.iso.duration()` |
-| `z.string().ip()` | `z.ipv4()` / `z.ipv6()` (v4 separou os dois) |
+| `z.string().ip()` | `z.ipv4()` / `z.ipv6()` (v4 split the two) |
 | `z.string().cidr()` | `z.cidrv4()` / `z.cidrv6()` |
-| `z.nativeEnum(MyEnum)` | `z.enum(MyEnum)` (v4 aceita TS native enum direto) |
+| `z.nativeEnum(MyEnum)` | `z.enum(MyEnum)` (v4 accepts a native TS enum directly) |
 | `schemaA.merge(schemaB)` | `schemaA.extend(schemaB.shape)` |
 | `error.format()` / `.flatten()` | `z.treeifyError(error)` / `z.prettifyError(error)` |
-| `{ message: "..." }` em refinements/checks | `{ error: "..." }` (v4 unificou `message`/`invalid_type_error`/`required_error` num único `error`) |
+| `{ message: "..." }` in refinements/checks | `{ error: "..." }` (v4 unified `message`/`invalid_type_error`/`required_error` into a single `error`) |
 
-**Não achou no scan de 2026-07-18** (só documentado como referência preventiva, YAGNI de fix — regra de entrada de gotcha satisfeita por ser "comportamento documentado de SDK externo conhecido por surpreender", não por já ter mordido 2×): `nativeEnum`, `.merge()`, `.format()`/`.flatten()`, `email`/`uuid`/`cuid`/`datetime`/`ip`. Só `z.string().url()` foi achado e corrigido (`post/schema.ts`).
+**Not found in the 2026-07-18 scan** (documented only as a preventive reference, YAGNI on the fix — the gotcha entry rule is satisfied by "documented behavior of an external SDK known to surprise", not by having bitten 2×): `nativeEnum`, `.merge()`, `.format()`/`.flatten()`, `email`/`uuid`/`cuid`/`datetime`/`ip`. Only `z.string().url()` was found and fixed (`post/schema.ts`).
 
-**Ref:** confirmado pelo dono (2026-07-18) revisando `018-seo-overrides-slug-redirect`; motivo de virar gotcha em vez de fix silencioso é exatamente não ter dado erro de tipo — sem essa entrada, o padrão antigo volta a vazar em schema novo sem ninguém notar.
+**Ref:** confirmed by the owner (2026-07-18) reviewing `018-seo-overrides-slug-redirect`; the reason it became a gotcha instead of a silent fix is exactly that it gave no type error — without this entry, the old pattern leaks into a new schema again with nobody noticing.
 
 ---
 
-## tRPC — `t.procedure` direto pula o middleware de tradução de erro
+## tRPC — a bare `t.procedure` skips the error-translation middleware
 
-**Gatilho:** se você está criando uma procedure com `t.procedure` direto (em vez de `baseProcedure`/`publicProcedure`/`protectedProcedure`/`verifiedProcedure`/`roleProcedure`).
+**Trigger:** if you are creating a procedure with a bare `t.procedure` (instead of `baseProcedure`/`publicProcedure`/`protectedProcedure`/`verifiedProcedure`/`roleProcedure`).
 
-**Comportamento:** a tradução `DomainError` → `TRPCError` vive num middleware (`withDomainErrors`) montado no `baseProcedure` (ADR-0019). Uma procedure construída fora dessa cadeia não passa pelo middleware — um `DomainError` que escape do resolver vira `INTERNAL_SERVER_ERROR` (500) com o `httpCode` correto perdido, **sem erro visível** em type-check nem em runtime local. Mordeu no `refreshSession` em `024-error-boundary-centralization` (um `TOO_MANY_REQUESTS` virou 500; pego pela suíte, não pelo compilador).
+**Behavior:** the `DomainError` → `TRPCError` translation lives in a middleware (`withDomainErrors`) mounted on `baseProcedure` (ADR-0019). A procedure built outside that chain does not pass through the middleware — a `DomainError` that escapes the resolver becomes `INTERNAL_SERVER_ERROR` (500) with the correct `httpCode` lost, **with no visible error** in type-check or local runtime. It bit `refreshSession` in `024-error-boundary-centralization` (a `TOO_MANY_REQUESTS` became a 500; caught by the suite, not the compiler).
 
-**Solução:** derive de `baseProcedure`, não de `t.procedure` — mesmo quando precisa pular os guards de sessão (foi o motivo de o `baseProcedure` existir separado do `publicProcedure`: ele carrega só a tradução, sem o guard de sessão expirada). `t.procedure` cru só pra caso que comprovadamente não lança `DomainError` nenhum.
+**Solution:** derive from `baseProcedure`, not from `t.procedure` — even when you need to skip the session guards (that was the reason `baseProcedure` exists separately from `publicProcedure`: it carries only the translation, without the expired-session guard). A bare `t.procedure` is only for a case that provably throws no `DomainError`.
 
-**Ref:** ADR-0019 (§ Consequência, gotcha b). Choke point da tradução: `src/server/http/domainErrorToTRPCError.ts`.
+**Ref:** ADR-0019 (§ Consequência, gotcha b). Translation choke point: `src/server/http/domainErrorToTRPCError.ts`.


### PR DESCRIPTION
## What

Third conversion under **ADR-0021**: `gotchas.md` → English, STE-spirit.

## Byte-exact (verified)

- **Zero code-span changes** — all file paths, config keys, and the full Zod v3→v4 table are untouched.
- Residual non-ASCII is only `×` (in "2×"/"3×") and cross-doc anchors to not-yet-converted docs (`§ Pendências Técnicas`, `§ Consequência`).

## Measurement

**Token-neutral (+0.1% chars, 1895 → 1943 words).** `gotchas.md` is identifier/path-dense, so prose translation yields no net savings. Value here is English consistency.

## Known follow-up (not in this PR)

The last gotcha still references `withDomainErrors`/`DomainError`/`domainErrorToTRPCError`, renamed to `withAppErrors`/`AppError`/`appErrorToTRPCError` in ADR-0020. Preserved verbatim to keep this a **pure translation** (clean code-span diff); the rename fan-out across docs is a separate reconcile follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)