### PR TITLE
docs: translate the remaining /docs/ to English (STE-spirit)

### DIFF
--- a/docs/ach.md
+++ b/docs/ach.md
@@ -1,17 +1,17 @@
 # ACH — Architecture Guide
 
-> Guia vivo de arquitetura do Bearboo.
-> **Autor:** dono da arquitetura. Mudanças passam por validação antes do merge.
+> Living architecture guide for Bearboo.
+> **Author:** the architecture owner. Changes go through validation before merge.
 >
-> Este documento responde: "onde ponho essa lógica?", "como estruturo esse módulo novo?", "até que nível de teste levo essa mudança?".
+> This doc answers: "where do I put this logic?", "how do I structure this new module?", "how far do I take testing for this change?".
 >
-> **Docs relacionados:** [`/docs/afm.md`](./afm.md) (processo + regras duras), [`/docs/gotchas.md`](./gotchas.md) (surpresas contraintuitivas), [`/docs/adr/`](./adr/) (decisões versionadas).
+> **Related docs:** [`/docs/afm.md`](./afm.md) (process + hard rules), [`/docs/gotchas.md`](./gotchas.md) (counterintuitive surprises), [`/docs/adr/`](./adr/) (versioned decisions).
 
-> **Estado do refactor em 2026-07-04.** ADR-0006 a ADR-0010 já aterrissaram no código: server por feature (`domain/` + `procedures/`), entidades Prisma centralizadas em `src/server/models/`, separação `src/lib/` vs `src/server/infra/`, remoção da implementação Redis antiga e schemas Zod de input/output no boundary. O Redis permanece decisão tecnológica para reconstrução futura (ADR-0003/0009), mas hoje não há adapter/cache Redis em `src/server/`.
+> **Refactor state on 2026-07-04.** ADR-0006 to ADR-0010 have landed in the code: server by feature (`domain/` + `procedures/`), Prisma entities centralized in `src/server/models/`, `src/lib/` vs `src/server/infra/` split, removal of the old Redis implementation, and Zod input/output schemas at the boundary. Redis stays a technology decision for a future rebuild (ADR-0003/0009), but today there is no Redis adapter/cache in `src/server/`.
 
 ---
 
-## 1. Arquitetura Macro
+## 1. Macro Architecture
 
 ```
 Browser
@@ -23,321 +23,318 @@ Next.js App Router (src/app/**)  ──── SSR/ISR/PPR ────►  React
 tRPC route handler (src/app/api/trpc/[trpc]/route.ts)   tRPC client (src/context/trpc/*)
   │
   ▼
-tRPC Router (src/server/features/<feature>/index.ts)  — Procedure-like, agregador da feature
+tRPC Router (src/server/features/<feature>/index.ts)  — Procedure-like, the feature aggregator
   │
   ▼
-Procedure (src/server/features/<feature>/procedures/<action>.ts)  — orquestra
+Procedure (src/server/features/<feature>/procedures/<action>.ts)  — orchestrates
   │
   ▼
 Domain (src/server/features/<feature>/domain/<action>.ts)  — Domain-like
   │
   ▼
-Model (src/server/models/<entity>.ts)  — encapsula acesso Prisma por entidade
+Model (src/server/models/<entity>.ts)  — encapsulates Prisma access per entity
   │
   ▼
 Prisma driver (src/server/infra/drivers/prisma.ts) ──► Postgres
 
-Integrations transversais (adapters tipados, injetados via DI container):
-  - Helpers puros: uidGenerator, passwordHashing (src/lib/*)
+Cross-cutting integrations (typed adapters, injected via a DI container):
+  - Pure helpers: uidGenerator, passwordHashing (src/lib/*)
   - Gateway: mailer (src/server/integrations/gateway/mailer/*)
   - Env: src/lib/env
   - Composition root: src/server/infra/container/{gateways,helpers,repositories}.ts
-  - Drivers (clients singleton): src/server/infra/drivers/prisma.ts
+  - Drivers (singleton clients): src/server/infra/drivers/prisma.ts
 ```
 
-**Entidades canônicas** (de `prisma/schema.prisma`):
-- **User** — conta autenticável; dono de posts, comentários e sessões.
-- **Session** — sessão de autenticação (`accessToken`/`refreshToken`) de um User.
-- **Post** — conteúdo publicado por um User.
-- **Comment** — comentário de um User em um Post.
-- **VerificationToken** — token de verificação de email de um User.
-- **ResetToken** — token de reset de senha de um User.
+**Canonical entities** (from `prisma/schema.prisma`):
+- **User** — an authenticatable account; owner of posts, comments, and sessions.
+- **Session** — a User's auth session (`accessToken`/`refreshToken`).
+- **Post** — content published by a User.
+- **Comment** — a User's comment on a Post.
+- **VerificationToken** — a User's email verification token.
+- **ResetToken** — a User's password reset token.
 
-**Mini-ER (relações declaradas no schema):**
+**Mini-ER (relations declared in the schema):**
 ```
 User 1───N Session
 User 1───N Post
 User 1───N Comment
 Post 1───N Comment
-User 1───N VerificationToken   (userId sem @relation declarada no schema)
-User 1───N ResetToken          (userId sem @relation declarada no schema)
+User 1───N VerificationToken   (userId with no @relation declared in the schema)
+User 1───N ResetToken          (userId with no @relation declared in the schema)
 ```
 
 **Dataflow:**
-- **Postgres (Prisma)** — source of truth de todas as entidades (User, Session, Post, Comment, VerificationToken, ResetToken).
-- **Redis** — a implementação antiga de cache foi removida pela ADR-0009. Redis segue como tecnologia aceita para uma reconstrução futura, mas o código atual não consulta Redis nem mantém porta de cache ativa.
+- **Postgres (Prisma)** — source of truth for every entity (User, Session, Post, Comment, VerificationToken, ResetToken).
+- **Redis** — the old cache implementation was removed by ADR-0009. Redis stays an accepted technology for a future rebuild, but the current code neither queries Redis nor keeps an active cache port.
 
 ---
 
-## 2. Arquitetura de Pastas
+## 2. Folder Architecture
 
 ```
 src/
-├── app/                        # Next.js App Router — rotas, layouts, route groups
-│   ├── (half)/                 # Route group: páginas de post/user (layout largo) — nome herdado, não redocumentar semântica sem confirmar com o time
-│   ├── (smal)/                 # Route group: páginas de auth (layout estreito) — idem
-│   └── api/trpc/[trpc]/        # Handler HTTP único do tRPC
-├── components/                 # Componentes React reutilizáveis + components/ui (shadcn-style)
+├── app/                        # Next.js App Router — routes, layouts, route groups
+│   ├── (half)/                 # Route group: post/user pages (wide layout) — inherited name, do not redocument the semantics without confirming with the team
+│   ├── (smal)/                 # Route group: auth pages (narrow layout) — idem
+│   └── api/trpc/[trpc]/        # The single tRPC HTTP handler
+├── components/                 # Reusable React components + components/ui (shadcn-style)
 ├── config/                     # site.ts, fonts.ts, featureFlags.ts
-├── context/                    # Providers React (auth, trpc client)
-├── lib/                        # libs puras sem ORM/framework: env, error, featureFlags, utils, validation, helpers
-│   ├── env/                    # leitura tipada de env vars via dotenv
-│   ├── passwordHashing/        # adapter + implementação bcrypt
-│   └── uidGenerator/           # adapter + implementação uuid
-├── server/                     # Camada backend
-│   ├── routers/app.routes.ts   # Agregador raiz — importa o router de cada feature (não é feature)
+├── context/                    # React providers (auth, trpc client)
+├── lib/                        # pure libs with no ORM/framework: env, error, featureFlags, utils, validation, helpers
+│   ├── env/                    # typed env var reading via dotenv
+│   ├── passwordHashing/        # adapter + bcrypt implementation
+│   └── uidGenerator/           # adapter + uuid implementation
+├── server/                     # Backend layer
+│   ├── routers/app.routes.ts   # Root aggregator — imports each feature's router (not a feature)
 │   ├── features/<feature>/     # index.ts (router) + schema.ts + domain/ + procedures/
-│   │   ├── index.ts            # tRPC router da feature — agrega procedures/<action>.ts
-│   │   ├── schema.ts           # Zod schemas de input/output da feature (1 arquivo por feature)
-│   │   ├── procedures/<action>.ts        # orquestra: valida via schema, chama domain/, retorna
-│   │   ├── procedures/<action>.test.ts   # teste vizinho, sem __tests__/
-│   │   └── domain/<action>.ts             # regra de negócio — UMA função por arquivo (regra dura 7)
-│   ├── models/                 # base.ts + model por entidade Prisma
+│   │   ├── index.ts            # the feature's tRPC router — aggregates procedures/<action>.ts
+│   │   ├── schema.ts           # the feature's Zod input/output schemas (1 file per feature)
+│   │   ├── procedures/<action>.ts        # orchestrates: validates via schema, calls domain/, returns
+│   │   ├── procedures/<action>.test.ts   # neighbor test, no __tests__/
+│   │   └── domain/<action>.ts             # business rule — ONE function per file (hard rule 7)
+│   ├── models/                 # base.ts + a model per Prisma entity
 │   ├── infra/
-│   │   ├── container/           # Composition root — liga implementações concretas
-│   │   └── drivers/             # Clients singleton (prisma.ts)
+│   │   ├── container/           # Composition root — wires concrete implementations
+│   │   └── drivers/             # Singleton clients (prisma.ts)
 │   ├── integrations/
 │   │   └── gateway/<name>/      # adapter.ts + implementations/  (mailer)
 │   └── createContext.ts, createRouter.ts, caller.ts
-├── shared/error/               # maquinaria na raiz (registry, domainError, index, boundaryLog, validation)
-│   └── catalog/<domínio>.ts    # os 8 catálogos por domínio (auth/comment/media/post/resetToken/session/user/verifyToken)
+├── shared/error/               # machinery at the root (registry, domainError, index, boundaryLog, validation)
+│   └── catalog/<domain>.ts     # the 8 per-domain catalogs (auth/comment/media/post/resetToken/session/user/verifyToken)
 ├── test/
-│   ├── context/                 # TestContext — helper de setup pra testes de procedure
-│   ├── gateways/                # gateways fake in-memory
-│   ├── prisma/                  # client prisma-mock (fake schema-driven do PrismaClient) + reset
-│   └── setup.ts                 # setupFiles do vitest — mocka o driver Prisma e reseta o estado por teste
+│   ├── context/                 # TestContext — setup helper for procedure tests
+│   ├── gateways/                # in-memory fake gateways
+│   ├── prisma/                  # prisma-mock client (schema-driven fake of PrismaClient) + reset
+│   └── setup.ts                 # vitest setupFiles — mocks the Prisma driver and resets state per test
 └── utils/                       # authStorage, error, validation (client-side helpers)
 ```
 
-### Regras de import
+### Import rules
 
 ```
-routers/app.routes.ts     → pode importar: features/<feature> (o index.ts de cada feature)
-                             NUNCA importa: models/*, infra/*, integrations/* direto
+routers/app.routes.ts     → may import: features/<feature> (each feature's index.ts)
+                             NEVER imports: models/*, infra/*, integrations/* directly
 
-features/<feature>/index.ts        → pode importar: procedures/*, schema.ts
-                                      NUNCA importa: models/*, infra/*, integrations/* direto (delega pra procedure)
+features/<feature>/index.ts        → may import: procedures/*, schema.ts
+                                      NEVER imports: models/*, infra/*, integrations/* directly (delegates to the procedure)
 
-features/<feature>/procedures/*.ts → pode importar: domain/* (mesma feature ou outra), schema.ts, createContext/createRouter types
-                                      NUNCA importa: Prisma/driver direto (recebe via ctx.repositories)
+features/<feature>/procedures/*.ts → may import: domain/* (same feature or another), schema.ts, createContext/createRouter types
+                                      NEVER imports: Prisma/driver directly (receives it via ctx.repositories)
 
-features/<feature>/domain/*.ts     → pode importar: createDomain, tipos inferidos do schema, outro domain/* (mesma feature)
-                                      NUNCA importa: zod runtime, Prisma/driver ou implementation concreta
+features/<feature>/domain/*.ts     → may import: createDomain, types inferred from the schema, another domain/* (same feature)
+                                      NEVER imports: zod runtime, Prisma/driver, or a concrete implementation
 
-models/*.ts               → pode importar: models/base, infra/drivers/prisma
-                             NUNCA importa: features/*, server/schema, tipos de erro de transport
-
-integrations/**/adapter.ts → interface pura (porta tipada), zero import de implementação concreta
-integrations/**/implementations/* → implementa a porta; pode receber config/env via constructor; não lê container
+integrations/**/adapter.ts → a pure interface (typed port), zero import of a concrete implementation
+integrations/**/implementations/* → implements the port; may receive config/env via the constructor; does not read the container
 ```
 
-**Import cross-feature confirmado no código:** `features/user/procedures/login.ts` importa `features/auth/domain/createAuthSession`; `features/user/procedures/register.ts` importa `features/auth/domain/createToken` e `features/mail/domain/sendMail`; `features/auth/procedures/*.ts` importa `features/mail/domain/*`. Domain-a-domain cross-feature é aceito hoje (não há módulo isolado forçando boundary) — revisitar se a regra dura 11 (mudança arquitetural) apontar necessidade de portas explícitas entre features.
+**Cross-feature import confirmed in the code:** `features/user/procedures/login.ts` imports `features/auth/domain/createAuthSession`; `features/user/procedures/register.ts` imports `features/auth/domain/createToken` and `features/mail/domain/sendMail`; `features/auth/procedures/*.ts` imports `features/mail/domain/*`. Domain-to-domain cross-feature is accepted today (no isolated module forces a boundary) — revisit if hard rule 11 (architectural change) shows a need for explicit ports between features.
 
-**Promoção pra `domain/shared/`:** ainda não há necessidade observada (Rule of Three) — nenhuma lógica duplicada em 3+ módulos identificada no scan. Cresce sob demanda.
+**Promotion to `domain/shared/`:** no observed need yet (Rule of Three) — no logic duplicated across 3+ modules found in the scan. It grows on demand.
 
 ---
 
-## 3. Componentes
+## 3. Components
 
-### 3.1 Componentes de 1ª classe
+### 3.1 First-class components
 
-#### Procedure-like — handler sync request/response
+#### Procedure-like — sync request/response handler
 
-- **Implementação no stack:** router tRPC em `src/server/features/<feature>/index.ts`, agregando as procedures da própria feature.
-- **Convenção de nome:** router `<Feature>Router`; procedure = verbo (`create`, `read`, `update`, `delete`, `readRecent`, `revalidate`, `login`, `register`).
-- **Exemplo canônico:** `src/server/features/post/index.ts`.
-- **Nota:** `login`/`register` são expostos por `features/user/index.ts` (`trpc.user.login`/`trpc.user.register`) — fisicamente vivem em `user/` mesmo sendo conceitualmente "auth", decisão tomada durante a ADR-0006 pra eliminar o roteamento cruzado que existia antes (`auth.routes.ts` chamando controllers de `user/`).
+- **Implementation in the stack:** a tRPC router in `src/server/features/<feature>/index.ts`, aggregating the feature's own procedures.
+- **Naming convention:** router `<Feature>Router`; procedure = a verb (`create`, `read`, `update`, `delete`, `readRecent`, `revalidate`, `login`, `register`).
+- **Canonical example:** `src/server/features/post/index.ts`.
+- **Note:** `login`/`register` are exposed by `features/user/index.ts` (`trpc.user.login`/`trpc.user.register`) — they physically live in `user/` even though they are conceptually "auth", a decision taken during ADR-0006 to remove the cross-routing that existed before (`auth.routes.ts` calling `user/` controllers).
 
-#### Procedure — orquestrador thin
+#### Procedure — thin orchestrator
 
-- **Conceito:** camada entre o router tRPC e o Domain — aplica `.input()`/`.output()`, recebe `input` + `ctx`, chama a função de domain com `DomainInput<T>` e retorna o resultado.
-- **Implementação:** `src/server/features/<feature>/procedures/<action>.ts`, export `procedure_<action>`.
-- **Quando NÃO usar:** lógica de negócio real → delega pro `domain/`.
-- **Exemplo canônico:** `src/server/features/post/procedures/create.ts`.
+- **Concept:** the layer between the tRPC router and the Domain — applies `.input()`/`.output()`, receives `input` + `ctx`, calls the domain function with `DomainInput<T>`, and returns the result.
+- **Implementation:** `src/server/features/<feature>/procedures/<action>.ts`, export `procedure_<action>`.
+- **When NOT to use:** real business logic → delegate to `domain/`.
+- **Canonical example:** `src/server/features/post/procedures/create.ts`.
 
-#### Domain-like — função pura de regra de negócio
+#### Domain-like — a pure business-rule function
 
-- **Conceito universal:** função que aplica regra de negócio, recebendo repositórios/helpers já resolvidos (injeção explícita, não IO direto).
-- **Implementação no stack:** `src/server/features/<feature>/domain/<action>.ts`, export único `domain_<action>`.
-- **UMA função exportada por arquivo — compliant em todo `src/server/features/` desde a ADR-0006 (2026-07-01).** Auditoria original (retroativa, `/afm:refactor`) tinha reportado "compliant" por engano num grep que contava linhas de `export {...}` em vez de símbolos — a violação real (`auth/resetToken`, `auth/session`, `auth/verifyToken`, `user/profile`, `mail` bundlando 2-3 funções por arquivo) foi corrigida durante a implementação desta ADR, quebrando cada arquivo multi-export em um arquivo por função.
-- **Quando NÃO usar:** validação de schema (fica no `schema.ts` da feature, boundary), transport glue (fica na procedure).
-- **Exemplo canônico:** `src/server/features/post/domain/create.ts`.
+- **Universal concept:** a function that applies a business rule, receiving already-resolved repositories/helpers (explicit injection, not direct IO).
+- **Implementation in the stack:** `src/server/features/<feature>/domain/<action>.ts`, single export `domain_<action>`.
+- **ONE exported function per file — compliant across all of `src/server/features/` since ADR-0006 (2026-07-01).** The original audit (retroactive, `/afm:refactor`) had reported "compliant" by mistake, on a grep that counted `export {...}` lines instead of symbols — the real violation (`auth/resetToken`, `auth/session`, `auth/verifyToken`, `user/profile`, `mail` bundling 2-3 functions per file) was fixed during this ADR's implementation, splitting each multi-export file into one file per function.
+- **When NOT to use:** schema validation (stays in the feature's `schema.ts`, the boundary), transport glue (stays in the procedure).
+- **Canonical example:** `src/server/features/post/domain/create.ts`.
 
-#### Model — encapsula acesso Prisma por entidade (camada local, não do vocabulário universal)
+#### Model — encapsulates Prisma access per entity (a local layer, not universal vocabulary)
 
-- **Conceito:** classe que estende `BaseModel<Entity>` (`src/server/models/base.ts`), fornecendo CRUD genérico (`create/read/update/delete`) + métodos extras específicos da entidade (ex: `PostModel.readRecents`, `PostModel.readUserPosts`, `PostModel.readBySlug`, `UserModel.readByEmail`).
-- **Implementação:** `src/server/models/<entity>.ts`, instância singleton exportada (`const <Entity>Model = new <Entity>ModelClass()`).
-- **Quando usar:** toda entidade do `prisma/schema.prisma` que precisa de acesso a dado + lógica de leitura/escrita específica.
-- **Nota:** Domain acessa dados via `ctx.repositories.<entity>`; runtime e testes usam os **mesmos models** — nos testes o driver Prisma é substituído por um client `prisma-mock` gerado do `schema.prisma` (ADR-0011, seam em `src/test/setup.ts` + `src/test/prisma/`).
+- **Concept:** a class that extends `BaseModel<Entity>` (`src/server/models/base.ts`), giving generic CRUD (`create/read/update/delete`) + entity-specific extra methods (e.g. `PostModel.readRecents`, `PostModel.readUserPosts`, `PostModel.readBySlug`, `UserModel.readByEmail`).
+- **Implementation:** `src/server/models/<entity>.ts`, an exported singleton instance (`const <Entity>Model = new <Entity>ModelClass()`).
+- **When to use:** every `prisma/schema.prisma` entity that needs data access + specific read/write logic.
+- **Note:** the Domain accesses data via `ctx.repositories.<entity>`; runtime and tests use the **same models** — in tests the Prisma driver is replaced by a `prisma-mock` client generated from `schema.prisma` (ADR-0011, seam in `src/test/setup.ts` + `src/test/prisma/`).
 
-#### Adapter-like — implementação de porta tipada
+#### Adapter-like — a typed-port implementation
 
-- **Conceito universal:** implementação concreta de uma porta (`adapter.ts`) — mesmo shape de retorno entre implementações (LSP).
-- **Implementação no stack:**
-  - Models de dados: `src/server/models/<entity>.ts`.
-  - Helper puro: `src/lib/<name>/adapter.ts` + `implementations/<concreto>.ts` (ex: `uidGenerator`, `passwordHashing`, `slug` — gerador determinístico de slug a partir de título, usado em `domain_createPost`; `rateLimit` — adicionado em `001-auth-hardening`, `IRateLimitHelperAdapter` + `InMemoryRateLimit`, key opaca prefixada por endpoint no call site, sem dependência de Redis; `permissions` — adicionado em `013-role-based-permissions`, `IPermissionHelperAdapter` + `MatrixPermission`, `can(role, action)` puro contra a matriz fixa da Fase 3, sem I/O; ganhou a ação `post:publish` em `014-post-review-workflow` — Fase 4, gateia `submitForReview`/`publish`/`reject`/`archive`).
-  - Gateway externo: `src/server/integrations/gateway/<name>/adapter.ts` + `implementations/<concreto>.ts` (ex: `mailer`).
-- **OCP em ação:** provider novo (ex: outro mailer) = arquivo novo em `implementations/`, sem `switch (provider)` espalhado.
+- **Universal concept:** a concrete implementation of a port (`adapter.ts`) — the same return shape across implementations (LSP).
+- **Implementation in the stack:**
+  - Data models: `src/server/models/<entity>.ts`.
+  - Pure helper: `src/lib/<name>/adapter.ts` + `implementations/<concrete>.ts` (e.g. `uidGenerator`, `passwordHashing`, `slug` — a deterministic slug generator from a title, used in `domain_createPost`; `rateLimit` — added in `001-auth-hardening`, `IRateLimitHelperAdapter` + `InMemoryRateLimit`, an opaque key prefixed by endpoint at the call site, no Redis dependency; `permissions` — added in `013-role-based-permissions`, `IPermissionHelperAdapter` + `MatrixPermission`, a pure `can(role, action)` against the fixed Phase 3 matrix, no I/O; it gained the `post:publish` action in `014-post-review-workflow` — Phase 4, gates `submitForReview`/`publish`/`reject`/`archive`).
+  - External gateway: `src/server/integrations/gateway/<name>/adapter.ts` + `implementations/<concrete>.ts` (e.g. `mailer`).
+- **OCP in action:** a new provider (e.g. another mailer) = a new file in `implementations/`, with no `switch (provider)` scattered around.
 
-#### Composition root — wiring de implementações concretas (camada local)
+#### Composition root — wiring of concrete implementations (a local layer)
 
-- **Implementação:** `src/server/infra/container/{gateways,helpers,repositories}.ts` — resolve qual `implementations/*` concreta cada adapter usa e injeta config/env quando necessário.
-- **Drivers:** `src/server/infra/drivers/prisma.ts` — client singleton cru, consumido só por infra/model.
+- **Implementation:** `src/server/infra/container/{gateways,helpers,repositories}.ts` — resolves which concrete `implementations/*` each adapter uses and injects config/env when needed.
+- **Drivers:** `src/server/infra/drivers/prisma.ts` — a raw singleton client, consumed only by infra/model.
 
-#### Response cookie jar — peça nova de `001-auth-hardening` (2026-07-12)
+#### Response cookie jar — a new piece from `001-auth-hardening` (2026-07-12)
 
-- **Conceito:** `src/server/http/cookieJar.ts` (`class CookieJar`) — acumula `Set-Cookie` pendentes durante o request; `src/server/http/serializeCookie.ts` — função pura que formata cada cookie (`HttpOnly`, `SameSite=Lax`, `Secure` condicional a `NODE_ENV=production`).
-- **Contrato:** `createContext.ts` instancia um `CookieJar` por request (`ctx.resCookies`); procedures chamam `ctx.resCookies.set(...)`/`.clear(...)`; `src/app/api/trpc/[trpc]/route.ts` captura a `ctx` criada e usa `responseMeta` do `fetchRequestHandler` pra emitir os headers `set-cookie` depois que o batch resolve.
-- **Por que existe:** o adapter tRPC (`@trpc/server/adapters/fetch`) não tem, por padrão, nenhum jeito de uma procedure influenciar headers da resposta — decisão de arquitetura validada em gate (`docs/features/001-auth-hardening/plan.md` § 4.1), não um padrão pré-existente do stack.
+- **Concept:** `src/server/http/cookieJar.ts` (`class CookieJar`) — accumulates pending `Set-Cookie` during the request; `src/server/http/serializeCookie.ts` — a pure function that formats each cookie (`HttpOnly`, `SameSite=Lax`, `Secure` conditional on `NODE_ENV=production`).
+- **Contract:** `createContext.ts` instantiates one `CookieJar` per request (`ctx.resCookies`); procedures call `ctx.resCookies.set(...)`/`.clear(...)`; `src/app/api/trpc/[trpc]/route.ts` captures the created `ctx` and uses `responseMeta` of the `fetchRequestHandler` to emit the `set-cookie` headers after the batch resolves.
+- **Why it exists:** the tRPC adapter (`@trpc/server/adapters/fetch`) has, by default, no way for a procedure to influence response headers — an architecture decision validated at a gate (`docs/features/001-auth-hardening/plan.md` § 4.1), not a pre-existing stack pattern.
 
-#### Guard de papel (`roleProcedure`) — peça nova de `013-role-based-permissions` (2026-07-12)
+#### Role guard (`roleProcedure`) — a new piece from `013-role-based-permissions` (2026-07-12)
 
-- **Conceito:** `src/server/createRouter.ts` — `roleProcedure(allowed: IRole[])`, 4ª camada da cadeia de guard tRPC (`public` → `protected` → `verified` → `role`), parametrizada por allowlist de papel em vez de fixa (cada call site passa os papéis que pode aceitar, ex. `roleProcedure(["ADMIN","EDITOR"])`). Lança `FORBIDDEN`/`AuthErrorCode.INSUFFICIENT_ROLE` se `ctx.user.role` não está na allowlist.
-- **Quando usar:** ação que **nunca** depende de dono de recurso (`category.create`, `user.updateRole`). Ownership condicional (post update/delete: "dono OU tem permissão de bypass") fica em `verifiedProcedure` + checagem no domain via `ctx.helpers.permissions.can(role, action)` — `roleProcedure` não serve pra isso porque a decisão depende do dado (quem é o dono), não só do papel do chamador (`013-role-based-permissions/plan.md` § 4.2).
-- **`IRole`:** union literal hand-rolled (`"ADMIN" | "EDITOR" | "AUTHOR"`) em `src/server/models/user.ts`, mesmo padrão de `IPostStatus`/`PostStatus` — não importa o enum gerado pelo Prisma client em código de app (só `infra/drivers/prisma.ts`/`test/prisma/` importam `@prisma/client` direto).
+- **Concept:** `src/server/createRouter.ts` — `roleProcedure(allowed: IRole[])`, the 4th layer of the tRPC guard chain (`public` → `protected` → `verified` → `role`), parameterized by a role allowlist instead of fixed (each call site passes the roles it accepts, e.g. `roleProcedure(["ADMIN","EDITOR"])`). Throws `FORBIDDEN`/`AuthErrorCode.INSUFFICIENT_ROLE` if `ctx.user.role` is not in the allowlist.
+- **When to use:** an action that **never** depends on the resource owner (`category.create`, `user.updateRole`). Conditional ownership (post update/delete: "owner OR has a bypass permission") stays in `verifiedProcedure` + a domain check via `ctx.helpers.permissions.can(role, action)` — `roleProcedure` does not serve this because the decision depends on the data (who the owner is), not only the caller's role (`013-role-based-permissions/plan.md` § 4.2).
+- **`IRole`:** a hand-rolled literal union (`"ADMIN" | "EDITOR" | "AUTHOR"`) in `src/server/models/user.ts`, the same pattern as `IPostStatus`/`PostStatus` — do not import the Prisma-client-generated enum in app code (only `infra/drivers/prisma.ts`/`test/prisma/` import `@prisma/client` directly).
 
-#### Workflow de status (state machine em domain, sem novo componente) — peça nova de `014-post-review-workflow` (2026-07-14)
+#### Status workflow (a state machine in domain, no new component) — a new piece from `014-post-review-workflow` (2026-07-14)
 
-- **Conceito:** transições de `Post.status` (`submitForReview`/`publish`/`reject`/`archive`) viram 4 domain functions dedicadas em vez de aceitar `status` livre em `post.update` — cada uma valida estado de origem + permissão antes de escrever. `updatePostSchema` **não** aceita mais `status` (regra dura 16 — validação no boundary continua em `schema.ts`, mas a *state machine* em si vive no domain).
-- **`SCHEDULED` sem scheduler:** visibilidade pública de post `SCHEDULED` é resolvida com `scheduledAt <= now` no momento da query (`PostModel.readRecents`/`readRelated`/`readUserPosts`/`readBySlug`), não por um job que flipa o status no banco — evita introduzir o primeiro componente Task-like do projeto (`afm.md` § 3 regra 12) só pra isso (`014-post-review-workflow/plan.md` § 4.1).
-- **`PostReviewComment`:** model novo (`src/server/models/reviewComment.ts`), mesmo padrão de `Comment` — guarda motivo de aprovação (opcional) ou rejeição (obrigatório), lido via `post.readReviewComments` (dono do post ou quem tem `post:publish`).
+- **Concept:** `Post.status` transitions (`submitForReview`/`publish`/`reject`/`archive`) become 4 dedicated domain functions instead of accepting a free `status` in `post.update` — each validates the source state + permission before writing. `updatePostSchema` **no longer** accepts `status` (hard rule 16 — boundary validation stays in `schema.ts`, but the *state machine* itself lives in the domain).
+- **`SCHEDULED` with no scheduler:** the public visibility of a `SCHEDULED` post is resolved with `scheduledAt <= now` at query time (`PostModel.readRecents`/`readRelated`/`readUserPosts`/`readBySlug`), not by a job that flips the status in the database — it avoids introducing the project's first Task-like component (`afm.md` § 3 rule 12) just for this (`014-post-review-workflow/plan.md` § 4.1).
+- **`PostReviewComment`:** a new model (`src/server/models/reviewComment.ts`), the same pattern as `Comment` — stores an approval reason (optional) or a rejection reason (mandatory), read via `post.readReviewComments` (the post owner or whoever has `post:publish`).
 
-#### Superfície HTTP pública não-tRPC (App Router special files) — peça nova de `015-seo-metadata` (2026-07-14)
+#### Public non-tRPC HTTP surface (App Router special files) — a new piece from `015-seo-metadata` (2026-07-14)
 
-- **Conceito:** `sitemap.xml`, `robots.txt` e `feed.xml` não são endpoints tRPC — são convenções de arquivo especial do próprio Next.js (`src/app/sitemap.ts`, `src/app/robots.ts`, `src/app/feed.xml/route.ts`), no mesmo nível de `page.tsx`/`layout.tsx` já existentes. Não é uma camada arquitetural nova: todos os 3 chamam `createCaller()` (mesmo caller usado por `generateMetadata`) pra ler dado via tRPC, e `sitemap.ts`/`feed.xml/route.ts` usam a mesma tríade `"use cache"` + `cacheLife("hours")` + `cacheTag("posts")` já estabelecida em `post/[slug]/page.tsx` (`014-post-review-workflow/plan.md`).
-- **Pegadinha:** `"use cache"` não pode envolver uma função que retorna `NextResponse`/`Response` (classe, não serializável) — a leitura de dado cacheada fica numa função separada que retorna um valor plano (string/array), e o `Response` é construído fora do cache, no handler (`src/app/feed.xml/route.ts`: `readFeedXml()` cacheada retorna `string`; `GET()` não-cacheada monta o `NextResponse`).
-- **`src/server/http/` deixa de ser só cookie jar:** ganhou `buildRssXml.ts` (RSS 2.0 hand-rolled) e `buildArticleJsonLd.ts` (JSON-LD `schema.org/Article`, com escape de `<` pra não quebrar a tag `<script>`) — funções puras de formatação de output, mesmo critério do `serializeCookie.ts` (transport glue, não regra de negócio — por isso não vivem em `domain/`).
-- **`post.readSitemapEntries`:** procedure pública nova, enxuta (só `slug`+`updatedAt`, sem `include` de relations, sem paginação) — não reusa `post.readRecent` pro sitemap pra não pagar o custo do include completo nem generalizar uma procedure já usada em produção (`015-seo-metadata/plan.md` § 4.1).
+- **Concept:** `sitemap.xml`, `robots.txt`, and `feed.xml` are not tRPC endpoints — they are Next.js special-file conventions (`src/app/sitemap.ts`, `src/app/robots.ts`, `src/app/feed.xml/route.ts`), at the same level as the existing `page.tsx`/`layout.tsx`. It is not a new architectural layer: all 3 call `createCaller()` (the same caller used by `generateMetadata`) to read data via tRPC, and `sitemap.ts`/`feed.xml/route.ts` use the same triad `"use cache"` + `cacheLife("hours")` + `cacheTag("posts")` already established in `post/[slug]/page.tsx` (`014-post-review-workflow/plan.md`).
+- **Gotcha:** `"use cache"` cannot wrap a function that returns a `NextResponse`/`Response` (a class, not serializable) — the cached data read stays in a separate function that returns a plain value (string/array), and the `Response` is built outside the cache, in the handler (`src/app/feed.xml/route.ts`: cached `readFeedXml()` returns `string`; non-cached `GET()` builds the `NextResponse`).
+- **`src/server/http/` is no longer just the cookie jar:** it gained `buildRssXml.ts` (hand-rolled RSS 2.0) and `buildArticleJsonLd.ts` (JSON-LD `schema.org/Article`, with `<` escaping so it does not break the `<script>` tag) — pure output-formatting functions, the same criterion as `serializeCookie.ts` (transport glue, not a business rule — that is why they do not live in `domain/`).
+- **`post.readSitemapEntries`:** a new lean public procedure (only `slug`+`updatedAt`, no relation `include`, no pagination) — it does not reuse `post.readRecent` for the sitemap, to not pay the full-include cost nor generalize a procedure already used in production (`015-seo-metadata/plan.md` § 4.1).
 
-#### `viewCounter` — primeiro Gateway-like com I/O real além de `mailer` — peça nova de `017-post-view-analytics` (2026-07-16, `ADR-0013`)
+#### `viewCounter` — the first Gateway-like with real I/O beyond `mailer` — a new piece from `017-post-view-analytics` (2026-07-16, `ADR-0013`)
 
-- **Conceito:** `src/server/integrations/gateway/viewCounter/adapter.ts` (`IViewCounterGatewayAdapter`) — `recordView(postId, visitorId, event)` (dedup por visitante em janela de 24h + contagem + buffer do evento bruto, mesma chamada), `drainPendingCounts()` (flush de contagem pro Postgres) e `drainPendingEvents()` (flush do evento bruto pro `PostView`, extensão de `020-view-analytics-breakdown`, `ADR-0014`). Duas implementações concretas, mesmo padrão dev/prod de `mailer` (`ConsoleMailTransport` vs `NodemailerMailTransport`): `implementations/inMemory.ts` (`InMemoryViewCounterGateway`, fallback quando `env.disableRedis`) e `implementations/redis.ts` (`RedisViewCounterGateway`, via `ioredis` — primeiro uso real da lib em runtime de app; até aqui só constava no `package.json`). Registrado em `IGateways` (`src/server/infra/container/gateways.ts`), **não** em `IHelpers` — motivo completo em `ADR-0013`.
-- **Por que Gateway e não Helper:** todo helper hoje (`hashing`/`uid`/`slug`/`rateLimit`/`permissions`/`referrerClassifier`/`userAgentClassifier`) é puro/local, sem I/O de rede, e por isso `TestContext.helpers` usa a implementação real sem override até em teste. Um Redis real registrado como helper quebraria qualquer teste que tocasse a feature (`ach.md § 4.1`: testes rodam sem Postgres/Redis). `IGateways` já resolve isso — `viewCounter` reusa `FakeViewCounterGateway` (`src/test/gateways/viewCounter.ts`) via `createFakeGateways()`, mesmo molde de `FakeMailerGateway`.
-- **Flush lazy, sem scheduler:** `domain_readDashboard` drena os contadores e eventos pendentes do gateway e aplica no Postgres (`PostModel.applyViewIncrements` + `PostViewModel.create`) toda vez que o dashboard é lido — mesmo truque já usado pra visibilidade de `SCHEDULED` (`014-post-review-workflow`), evita introduzir o primeiro componente Task-like do projeto (`afm.md § 3` regra 12).
-- **Cookie de visitante:** `src/server/createContext.ts` lê o cookie `visitorId` (mesmo `parseCookie` já usado pra `accessToken`/`refreshToken`); `analytics.recordView` gera um novo via `ctx.helpers.uid.generate()` e seta via `ctx.resCookies` (mesmo mecanismo de `001-auth-hardening`) quando ausente.
+- **Concept:** `src/server/integrations/gateway/viewCounter/adapter.ts` (`IViewCounterGatewayAdapter`) — `recordView(postId, visitorId, event)` (dedup per visitor in a 24h window + count + raw-event buffer, one call), `drainPendingCounts()` (flush the count to Postgres) and `drainPendingEvents()` (flush the raw event to `PostView`, an extension from `020-view-analytics-breakdown`, `ADR-0014`). Two concrete implementations, the same dev/prod pattern as `mailer` (`ConsoleMailTransport` vs `NodemailerMailTransport`): `implementations/inMemory.ts` (`InMemoryViewCounterGateway`, a fallback when `env.disableRedis`) and `implementations/redis.ts` (`RedisViewCounterGateway`, via `ioredis` — the first real use of the lib in app runtime; until here it was only in `package.json`). Registered in `IGateways` (`src/server/infra/container/gateways.ts`), **not** in `IHelpers` — full reason in `ADR-0013`.
+- **Why a Gateway and not a Helper:** every helper today (`hashing`/`uid`/`slug`/`rateLimit`/`permissions`/`referrerClassifier`/`userAgentClassifier`) is pure/local, with no network I/O, so `TestContext.helpers` uses the real implementation without an override even in tests. A real Redis registered as a helper would break any test that touched the feature (`ach.md § 4.1`: tests run without Postgres/Redis). `IGateways` already solves this — `viewCounter` reuses `FakeViewCounterGateway` (`src/test/gateways/viewCounter.ts`) via `createFakeGateways()`, the same mold as `FakeMailerGateway`.
+- **Lazy flush, no scheduler:** `domain_readDashboard` drains the gateway's pending counts and events and applies them to Postgres (`PostModel.applyViewIncrements` + `PostViewModel.create`) every time the dashboard is read — the same trick already used for `SCHEDULED` visibility (`014-post-review-workflow`), avoiding the project's first Task-like component (`afm.md § 3` rule 12).
+- **Visitor cookie:** `src/server/createContext.ts` reads the `visitorId` cookie (the same `parseCookie` already used for `accessToken`/`refreshToken`); `analytics.recordView` generates a new one via `ctx.helpers.uid.generate()` and sets it via `ctx.resCookies` (the same mechanism as `001-auth-hardening`) when absent.
 
-#### Breakdown de analytics (`PostView` + `referrerClassifier`/`userAgentClassifier`) — peça nova de `020-view-analytics-breakdown` (2026-07-18, `ADR-0014`)
+#### Analytics breakdown (`PostView` + `referrerClassifier`/`userAgentClassifier`) — a new piece from `020-view-analytics-breakdown` (2026-07-18, `ADR-0014`)
 
-- **`PostView` (model novo):** `src/server/models/postView.ts` (`PostViewModel`, estende `BaseModel`) — evento bruto por-view (`postId`, `referrerBucket`, `userAgent`, `createdAt`), sem IP (decisão de privacidade, `ADR-0014`). Métodos extras: `countSince(days)`, `readReferrerBreakdown(days)` (Prisma `groupBy`), `readUserAgents(days)`, `deleteOlderThan(days)` (retenção de 30 dias, lazy no read).
-- **Dois Helper-like novos, puros:** `src/lib/referrerClassifier/` (classifica o header `Referer` em `DIRECT`/`SEARCH`/`SOCIAL`/`OTHER` — resolvido na escrita) e `src/lib/userAgentClassifier/` (categoriza `User-Agent` em navegador/SO por regex — resolvido na leitura, sobre a string bruta salva). Mesmo padrão de `slug`/`rateLimit`/`permissions`: `adapter.ts` + `implementations/regex.ts`, registrados em `IHelpers` (`src/server/infra/container/helpers.ts`), sem fake em teste (puro, `TestContext` usa a implementação real).
-- **`analytics.readDashboard` (boundary estendido, não nova procedure):** ganhou `viewsLast7Days`/`viewsLast30Days`/`trafficOrigin`/`browsers` no mesmo output schema — decisão consciente de não criar uma 2ª procedure pra não fragmentar a leitura do dashboard em múltiplos round-trips.
+- **`PostView` (new model):** `src/server/models/postView.ts` (`PostViewModel`, extends `BaseModel`) — a raw per-view event (`postId`, `referrerBucket`, `userAgent`, `createdAt`), no IP (a privacy decision, `ADR-0014`). Extra methods: `countSince(days)`, `readReferrerBreakdown(days)` (Prisma `groupBy`), `readUserAgents(days)`, `deleteOlderThan(days)` (30-day retention, lazy on read).
+- **Two new pure Helper-like:** `src/lib/referrerClassifier/` (classifies the `Referer` header into `DIRECT`/`SEARCH`/`SOCIAL`/`OTHER` — resolved on write) and `src/lib/userAgentClassifier/` (categorizes `User-Agent` into browser/OS by regex — resolved on read, over the saved raw string). The same pattern as `slug`/`rateLimit`/`permissions`: `adapter.ts` + `implementations/regex.ts`, registered in `IHelpers` (`src/server/infra/container/helpers.ts`), no fake in tests (pure, `TestContext` uses the real implementation).
+- **`analytics.readDashboard` (extended boundary, not a new procedure):** it gained `viewsLast7Days`/`viewsLast30Days`/`trafficOrigin`/`browsers` in the same output schema — a conscious decision to not create a 2nd procedure, to avoid fragmenting the dashboard read into several round-trips.
 
-#### Slug editável + redirect e domain helper compartilhado — peça nova de `018-seo-overrides-slug-redirect` (2026-07-18)
+#### Editable slug + redirect and a shared domain helper — a new piece from `018-seo-overrides-slug-redirect` (2026-07-18)
 
-- **`domain_resolveAvailableSlug`:** `src/server/features/post/domain/resolveAvailableSlug.ts` — algoritmo de sufixo numérico incremental (`titulo`, `titulo-2`, ...) extraído de `domain_createPost` pra ser reusado por `domain_updatePost` (edição de slug), com parâmetro opcional `excludePostId` pra ignorar colisão com o próprio post sendo editado. Mesmo padrão de domain helper compartilhado dentro de uma feature já usado em `user/domain/getUserOrThrow.ts` (regra dura 7 — 1 export por arquivo de domain, então extração vira arquivo novo, não função extra no mesmo arquivo).
-- **`previousSlug` (1 coluna, não tabela de histórico):** `Post.previousSlug` guarda só o slug imediatamente anterior — decisão consciente de cobrir "corrigi um slug uma vez" e não reescritas repetidas (YAGNI, mesmo raciocínio de evitar componente Task-like só pra `SCHEDULED` em `014-post-review-workflow`). Redirect resolvido por `domain_readRedirectSlug` → `post.readRedirectSlug` (procedure pública enxuta, mesmo padrão de `post.readSitemapEntries`), chamado em `PostContent` (`post/[slug]/page.tsx`) no catch de `POST_NOT_FOUND`, antes do fallback `OwnerPreview`; se resolver, `permanentRedirect()` (`next/navigation`). Redirect roda só no render, não em `generateMetadata` (`018-seo-overrides-slug-redirect/plan.md § 4`).
-- **Overrides de SEO (`seoTitle`/`seoDescription`/`canonicalUrl`):** nullable no `Post`, lidos em `generateMetadata` com fallback pro comportamento computado anterior (`post.seoTitle ?? post.title`, etc.) — zero regressão pra post sem override.
+- **`domain_resolveAvailableSlug`:** `src/server/features/post/domain/resolveAvailableSlug.ts` — the incremental numeric-suffix algorithm (`titulo`, `titulo-2`, ...) extracted from `domain_createPost` to be reused by `domain_updatePost` (slug editing), with an optional `excludePostId` param to ignore a collision with the post being edited itself. The same shared-domain-helper pattern within a feature already used in `user/domain/getUserOrThrow.ts` (hard rule 7 — 1 export per domain file, so an extraction becomes a new file, not an extra function in the same file).
+- **`previousSlug` (1 column, not a history table):** `Post.previousSlug` stores only the immediately previous slug — a conscious decision to cover "I fixed a slug once" and not repeated rewrites (YAGNI, the same reasoning as avoiding a Task-like component just for `SCHEDULED` in `014-post-review-workflow`). The redirect is resolved by `domain_readRedirectSlug` → `post.readRedirectSlug` (a lean public procedure, the same pattern as `post.readSitemapEntries`), called in `PostContent` (`post/[slug]/page.tsx`) in the `POST_NOT_FOUND` catch, before the `OwnerPreview` fallback; if it resolves, `permanentRedirect()` (`next/navigation`). The redirect runs only on render, not in `generateMetadata` (`018-seo-overrides-slug-redirect/plan.md § 4`).
+- **SEO overrides (`seoTitle`/`seoDescription`/`canonicalUrl`):** nullable on `Post`, read in `generateMetadata` with a fallback to the previous computed behavior (`post.seoTitle ?? post.title`, etc.) — zero regression for a post with no override.
 
-#### `mediaStorage` — segundo Gateway-like com I/O real, primeiro que escreve no filesystem — peça nova de `021-media-upload` (2026-07-26, `ADR-0015`)
+#### `mediaStorage` — the second Gateway-like with real I/O, the first that writes to the filesystem — a new piece from `021-media-upload` (2026-07-26, `ADR-0015`)
 
-- **Conceito:** `src/server/integrations/gateway/mediaStorage/adapter.ts` (`IMediaStorageGatewayAdapter`) — `save({ buffer, filename, mimeType }): Promise<{ url, storageKey }>`, `delete(storageKey): Promise<void>`. Mesmo padrão dev/prod de `mailer`/`viewCounter`, mas só uma implementação concreta nesta rodada: `implementations/local.ts` (`LocalMediaStorage`) grava em `env.media.uploadDir` (default `public/uploads`) e devolve `{ url: "/uploads/<storageKey>", storageKey }`. Sem `output: "standalone"` no `next.config.ts`, o `next start` serve `public/` direto do disco a cada request — um arquivo escrito em runtime em `public/uploads/` fica servível em `/uploads/<arquivo>` sem route handler novo. Registrado em `IGateways` (`src/server/infra/container/gateways.ts`); teste usa `FakeMediaStorageGateway` (`src/test/gateways/mediaStorage.ts`, `Map` em memória), mesmo molde de `FakeMailerGateway`/`FakeViewCounterGateway`.
-- **`{ url, storageKey }`, não só `url`:** decisão de `ADR-0015` — um storage futuro (Cloudinary/S3) tem um identificador de exclusão que não é a URL pública (`public_id`, não a URL). Guardar os dois agora no `Media.storageKey`/`Media.url` evita migration só pra isso quando o storage trocar.
-- **Upload sobe pela mesma rota tRPC, não por um route handler novo:** `media.upload` usa `.input()` com um schema Zod que aceita `z.instanceof(FormData)` e faz `.transform()` pra validar/extrair `{ file, altText }` — o content-type handler nativo do `fetchRequestHandler` (tRPC v11) entrega a `FormData` bruta como raw input quando o request é `multipart/form-data`, então o schema **precisa** aceitar `FormData`, não um objeto já desestruturado. Client-side, `httpBatchLink` (o link default do projeto) **não** suporta `FormData`/`File` — ele serializa todo op do batch em JSON. `src/context/trpc/client.ts` usa `splitLink` pra rotear só os inputs `isNonJsonSerializable` (checado via `@trpc/client`) pro `httpLink` (não-batched, que faz `getBody: () => input` cru); todo o resto continua no `httpBatchLink`. Achado e corrigido só depois de testar contra um dev server real — `createCaller` (usado nos testes de procedure) não passa pelo link nem pelo content-type handler, então não pega esse tipo de bug.
-- **Nova ação de permissão:** `media:deleteAny` (`src/lib/permissions/adapter.ts` + `implementations/matrix.ts`) → `["ADMIN", "EDITOR"]`, mesmo padrão de `post:deleteAny`. `domain_readOwnMedia` reusa essa mesma ação (não uma `media:readAny` separada) pra decidir se a leitura é escopada ao usuário ou site-wide — mesmo truque de `domain_readOwnPosts` com `post:editAny`.
-- **`AppError` genérico — primeiro uso da regra 15 forward-only:** `src/shared/error/appError.ts` (`class AppError<C extends string>`), desenho já prescrito em `docs/rubrics/error-classification.md` (Opção B) mas nunca usado até aqui — todo domain existente lança `TRPCError` direto (débito rastreado em `afm.md § 3.1`). `media/domain/{upload,readOwn,delete}.ts` não importam `TRPCError`; a procedure de delete (`media/procedures/delete.ts`) mapeia `AppError` → `TRPCError` no boundary (`NOT_FOUND`/`FORBIDDEN`), único ponto que conhece transport.
+- **Concept:** `src/server/integrations/gateway/mediaStorage/adapter.ts` (`IMediaStorageGatewayAdapter`) — `save({ buffer, filename, mimeType }): Promise<{ url, storageKey }>`, `delete(storageKey): Promise<void>`. The same dev/prod pattern as `mailer`/`viewCounter`, but only one concrete implementation this round: `implementations/local.ts` (`LocalMediaStorage`) writes to `env.media.uploadDir` (default `public/uploads`) and returns `{ url: "/uploads/<storageKey>", storageKey }`. Without `output: "standalone"` in `next.config.ts`, `next start` serves `public/` straight from disk on each request — a file written at runtime in `public/uploads/` is servable at `/uploads/<file>` with no new route handler. Registered in `IGateways` (`src/server/infra/container/gateways.ts`); the test uses `FakeMediaStorageGateway` (`src/test/gateways/mediaStorage.ts`, an in-memory `Map`), the same mold as `FakeMailerGateway`/`FakeViewCounterGateway`.
+- **`{ url, storageKey }`, not just `url`:** a decision from `ADR-0015` — a future storage (Cloudinary/S3) has a deletion identifier that is not the public URL (`public_id`, not the URL). Storing both now in `Media.storageKey`/`Media.url` avoids a migration just for this when the storage changes.
+- **The upload comes through the same tRPC route, not a new route handler:** `media.upload` uses `.input()` with a Zod schema that accepts `z.instanceof(FormData)` and does `.transform()` to validate/extract `{ file, altText }` — the native content-type handler of `fetchRequestHandler` (tRPC v11) hands the raw `FormData` as raw input when the request is `multipart/form-data`, so the schema **must** accept `FormData`, not an already-destructured object. Client-side, `httpBatchLink` (the project's default link) does **not** support `FormData`/`File` — it serializes every batch op into JSON. `src/context/trpc/client.ts` uses `splitLink` to route only the `isNonJsonSerializable` inputs (checked via `@trpc/client`) to `httpLink` (non-batched, which does a raw `getBody: () => input`); everything else stays on `httpBatchLink`. Found and fixed only after testing against a real dev server — `createCaller` (used in procedure tests) does not pass through the link or the content-type handler, so it does not catch this kind of bug.
+- **New permission action:** `media:deleteAny` (`src/lib/permissions/adapter.ts` + `implementations/matrix.ts`) → `["ADMIN", "EDITOR"]`, the same pattern as `post:deleteAny`. `domain_readOwnMedia` reuses this same action (not a separate `media:readAny`) to decide whether the read is scoped to the user or site-wide — the same trick as `domain_readOwnPosts` with `post:editAny`.
+- **Generic `AppError` — the first use of the forward-only rule 15:** `src/shared/error/appError.ts` (`class AppError<C extends string>`), a design already prescribed in `docs/rubrics/error-classification.md` (Option B) but never used until here — every existing domain throws `TRPCError` directly (debt tracked in `afm.md § 3.1`). `media/domain/{upload,readOwn,delete}.ts` do not import `TRPCError`; the delete procedure (`media/procedures/delete.ts`) maps `AppError` → `TRPCError` at the boundary (`NOT_FOUND`/`FORBIDDEN`), the only point that knows transport.
 
-### 3.2 Componentes de suporte (2ª classe)
+### 3.2 Support components (second-class)
 
-#### Schema — validação no boundary
+#### Schema — validation at the boundary
 
-`src/server/features/<feature>/schema.ts` — Zod schemas de input e output de procedure, um arquivo por feature. Procedures aplicam `.input()` e `.output()` no boundary; domain recebe `DomainInput<T>` com tipos inferidos via `z.TypeOf`, sem validar runtime de novo. Confirmado no scan: zero `import zod` dentro de `models/*` ou `features/*/domain/*.ts` (regra dura 16 já respeitada).
+`src/server/features/<feature>/schema.ts` — Zod input and output schemas of a procedure, one file per feature. Procedures apply `.input()` and `.output()` at the boundary; the domain receives `DomainInput<T>` with types inferred via `z.TypeOf`, without validating at runtime again. Confirmed in the scan: zero `import zod` inside `models/*` or `features/*/domain/*.ts` (hard rule 16 already respected).
 
-#### Shared error — ErrorRegistry (`ADR-0017`, migração fechada em `022-error-registry`; centralizado e invertido em `ADR-0019`/`024`)
+#### Shared error — ErrorRegistry (`ADR-0017`, migration closed in `022-error-registry`; centralized and inverted in `ADR-0019`/`024`)
 
-`src/shared/error/registry.ts` — `defineDomainErrors(domain, errors)` namespaces cada catálogo por domínio (`"auth.invalid_credentials"` etc.) e valida contra domínio duplicado em runtime (`Set`). `src/shared/error/index.ts` agrega os 8 catálogos de `src/shared/error/catalog/` (`auth`, `comment`, `media`, `post`, `resetToken`, `session`, `user`, `verifyToken`) num `Errors`/`ErrorCode` central **e expõe `resolveErrorEntry(code)`** — o lookup que o registry não tinha: até a feature 024 os catálogos só eram escritos, nunca lidos, porque o `AppError` copiava os campos pra si e todo mundo lia a cópia. O lookup devolve `message`/`retryable`/`level` já com os defaults aplicados (uma vez, no lookup — não `?? false` em cada consumidor).
+`src/shared/error/registry.ts` — `defineDomainErrors(domain, errors)` namespaces each catalog by domain (`"auth.invalid_credentials"` etc.) and validates against a duplicate domain at runtime (`Set`). `src/shared/error/index.ts` aggregates the 8 catalogs from `src/shared/error/catalog/` (`auth`, `comment`, `media`, `post`, `resetToken`, `session`, `user`, `verifyToken`) into a central `Errors`/`ErrorCode` **and exposes `resolveErrorEntry(code)`** — the lookup the registry lacked: until feature 024 the catalogs were only written, never read, because `AppError` copied the fields to itself and everyone read the copy. The lookup returns `message`/`retryable`/`level` with the defaults already applied (once, at the lookup — not `?? false` in each consumer).
 
-**`AppError` carrega só o `code`** (`ADR-0019`). `httpCode`/`message`/`retryable`/`level` eram cópias de uma função estática do código; consumidores resolvem via `resolveErrorEntry` (política) ou `appErrorTransport` (transporte). `super(code)` faz o código ser a mensagem do `Error` — o texto humano é resolvido no boundary, que é onde i18n vai morar.
+**`AppError` carries only the `code`** (`ADR-0019`). `httpCode`/`message`/`retryable`/`level` were copies of a static function of the code; consumers resolve them via `resolveErrorEntry` (policy) or `appErrorTransport` (transport). `super(code)` makes the code the `Error` message — the human text is resolved at the boundary, which is where i18n will live.
 
-**A tradução é um middleware, não um bloco por procedure.** `src/server/http/appErrorToTRPCError.ts` (função pura) é montada em `createRouter.ts` como primeiro `.use()` de um `baseProcedure`, então envolve guards **e** resolver. Nenhuma procedure constrói `TRPCError` — `rg -l "new TRPCError" src/server/features/*/procedures/*.ts` retorna vazio (eram 26 cópias + 6 nos guards). O middleware inspeciona `result.ok` em vez de `try/catch`: o tRPC captura o throw do resolver e o devolve como `{ ok: false, error }` já embrulhado por `getTRPCErrorFromUnknown`, então não há o que capturar — há um resultado pra remapear. **Gotcha:** procedure construída fora da cadeia (`t.procedure` direto) não recebe a tradução; foi o caso do `refreshSession`, que usa `baseProcedure` pra pular o guard de sessão expirada sem perder a tradução.
+**The translation is a middleware, not a per-procedure block.** `src/server/http/appErrorToTRPCError.ts` (a pure function) is mounted in `createRouter.ts` as the first `.use()` of a `baseProcedure`, so it wraps guards **and** resolver. No procedure builds a `TRPCError` — `rg -l "new TRPCError" src/server/features/*/procedures/*.ts` returns empty (it was 26 copies + 6 in the guards). The middleware inspects `result.ok` instead of `try/catch`: tRPC catches the resolver's throw and returns it as `{ ok: false, error }` already wrapped by `getTRPCErrorFromUnknown`, so there is nothing to catch — there is a result to remap. **Gotcha:** a procedure built outside the chain (a bare `t.procedure`) does not get the translation; that was the `refreshSession` case, which uses `baseProcedure` to skip the expired-session guard without losing the translation.
 
-**Transporte fora do vocabulário de domínio (regra dura 35).** `src/server/http/appErrorTransport.ts` guarda `Record<ErrorCode, TRPC_ERROR_CODE_KEY>` — a projeção dos 29 códigos de domínio sobre 7 códigos tRPC. É total, então código novo sem mapeamento quebra `tsc`, não vira 500. `src/shared/error/**` não importa `@trpc/*`. Consumidor novo (job, CLI, webhook) ganha a própria tabela em vez de uma coluna no catálogo.
+**Transport outside the domain vocabulary (hard rule 35).** `src/server/http/appErrorTransport.ts` holds `Record<ErrorCode, TRPC_ERROR_CODE_KEY>` — the projection of the 29 domain codes onto 7 tRPC codes. It is total, so a new code with no mapping breaks `tsc`, not becomes a 500. `src/shared/error/**` does not import `@trpc/*`. A new consumer (job, CLI, webhook) gets its own table instead of a column in the catalog.
 
-**Regra dura 15 fechada:** `rg -l "TRPCError" src/server/features/*/domain/*.ts` retorna vazio — os 23 arquivos que lançavam `TRPCError` direto (contagem no início de `022-error-registry`) migraram pra `AppError`. Não é mais forward-only (removido de `afm.md` § 3.1).
+**Hard rule 15 closed:** `rg -l "TRPCError" src/server/features/*/domain/*.ts` returns empty — the 23 files that threw `TRPCError` directly (count at the start of `022-error-registry`) migrated to `AppError`. It is no longer forward-only (removed from `afm.md` § 3.1).
 
-**Cutover completo (2026-07-30):** todos os 8 catálogos tiveram o enum antigo (`<Feature>ErrorCode`/`<Feature>ErrorMessages`) removido — `defineDomainErrors` embute o texto humano inline, sem indireção por enum. `auth`/`session`/`post` foram os últimos a fechar porque tinham consumidor legítimo fora da camada de domínio: guards de `createRouter.ts` (`publicProcedure`/`assertRateLimit`/`protectedProcedure`/`verifiedProcedure`/`roleProcedure`), `refreshSession.ts` (token ausente), `src/server/caller.ts`, `src/context/trpc/sessionRefreshLink.ts` e `analytics/procedures/recordView.ts`. Todos migraram pra sintetizar `new AppError("<code>")` no ponto de detecção (não há domain function separada pra lançar/capturar nesses casos — a checagem já vive no boundary) e relançar via `{code: error.httpCode, message: error.message, cause: error}`. Não sobra nenhum `TRPCError` construído com `message` de enum bare em lugar nenhum do código (verificado via `grep -rn "message: .*ErrorCode\." src` → vazio). *(Registro histórico do cutover de 2026-07-30: esse relançamento manual foi removido de todos esses pontos na feature 024 — hoje quem relança é o middleware.)*
+**Cutover complete (2026-07-30):** all 8 catalogs had the old enum (`<Feature>ErrorCode`/`<Feature>ErrorMessages`) removed — `defineDomainErrors` embeds the human text inline, with no enum indirection. `auth`/`session`/`post` were the last to close because they had a legitimate consumer outside the domain layer: `createRouter.ts` guards (`publicProcedure`/`assertRateLimit`/`protectedProcedure`/`verifiedProcedure`/`roleProcedure`), `refreshSession.ts` (missing token), `src/server/caller.ts`, `src/context/trpc/sessionRefreshLink.ts`, and `analytics/procedures/recordView.ts`. All migrated to synthesize `new AppError("<code>")` at the detection point (there is no separate domain function to throw/catch in these cases — the check already lives at the boundary) and rethrow via `{code: error.httpCode, message: error.message, cause: error}`. No `TRPCError` built with a bare enum `message` is left anywhere in the code (verified via `grep -rn "message: .*ErrorCode\." src` → empty). *(Historical record of the 2026-07-30 cutover: this manual rethrow was removed from all these points in feature 024 — today the middleware is what rethrows.)*
 
-**Dois jeitos de ler o código de domínio no boundary:** `createCaller()`/callers in-process (`post/[slug]/page.tsx`, `src/server/caller.ts`) leem `error.cause instanceof AppError && error.cause.code` direto, sem round-trip de rede. Client-side sobre HTTP (`sessionRefreshLink.ts`) não tem acesso a `.cause` do objeto original — o `errorFormatter` de `createRouter.ts` propaga o `code` namespaced via `data.domainCode` (campo próprio, não confundir com `data.code` nativo do tRPC que já é o HTTP code).
+**Two ways to read the domain code at the boundary:** `createCaller()`/in-process callers (`post/[slug]/page.tsx`, `src/server/caller.ts`) read `error.cause instanceof AppError && error.cause.code` directly, with no network round-trip. The client-side over HTTP (`sessionRefreshLink.ts`) has no access to the original object's `.cause` — the `errorFormatter` of `createRouter.ts` propagates the namespaced `code` via `data.domainCode` (its own field, not to be confused with tRPC's native `data.code`, which is already the HTTP code).
 
-`src/lib/error.ts` (`getErrorMessage`) ficou só com o lookup de `ValidationErrorMessages` (códigos de validação client-only, de `utils/validation.ts` — nunca tocam o server) com pass-through pro resto (`?? code`). Não sobra mais nenhum catálogo de domínio (`Auth`/`Post`/`Session`) nessa função — todo `error.message` vindo do server já é texto final, sempre.
+`src/lib/error.ts` (`getErrorMessage`) kept only the lookup of `ValidationErrorMessages` (client-only validation codes, from `utils/validation.ts` — they never touch the server) with a pass-through for the rest (`?? code`). No domain catalog (`Auth`/`Post`/`Session`) is left in this function — every `error.message` coming from the server is already final text, always.
 
-**Metadata + convenção bug/recuperável (feature 023, ADR-0018):** o `ErrorEntry` do catálogo carrega `message` e os opcionais `retryable?: boolean` e `level?: ErrorLevel` (`fatal|error|warn|info`); `resolveErrorEntry` os resolve com defaults `retryable=false`/`level=warn`. *(Até a feature 024 o `ErrorEntry` também carregava `httpCode` e quem resolvia era o `AppError` — ver ADR-0019.)* O boundary distingue **recuperável** (é/tem-causa `AppError`) de **bug** (qualquer outro throw): `src/shared/error/boundaryLog.ts` (`classifyBoundaryError` puro + `logBoundaryError`) é o ponto único; ativado no `onError` do fetch adapter (`app/api/trpc/[trpc]/route.ts`) e no `src/server/caller.ts`. Bug loga `error` com stack; recuperável loga no seu `level`. O `errorFormatter` continua puro (só shaping — `domainCode`/`zodError`); logging vive no `onError`. Formalizado na regra dura 33. `retryable`/`level` são **server-side only** hoje (não expostos ao cliente — YAGNI, sem consumidor). `Result<T,E>` foi avaliado e rejeitado (ADR-0018 § alternativas).
+**Metadata + bug/recoverable convention (feature 023, ADR-0018):** the catalog's `ErrorEntry` carries `message` and the optional `retryable?: boolean` and `level?: ErrorLevel` (`fatal|error|warn|info`); `resolveErrorEntry` resolves them with defaults `retryable=false`/`level=warn`. *(Until feature 024 the `ErrorEntry` also carried `httpCode` and `AppError` was what resolved it — see ADR-0019.)* The boundary distinguishes **recoverable** (is/has-cause `AppError`) from **bug** (any other throw): `src/shared/error/boundaryLog.ts` (pure `classifyBoundaryError` + `logBoundaryError`) is the single point; activated in the fetch adapter's `onError` (`app/api/trpc/[trpc]/route.ts`) and in `src/server/caller.ts`. A bug logs `error` with a stack; a recoverable logs at its `level`. The `errorFormatter` stays pure (only shaping — `domainCode`/`zodError`); logging lives in `onError`. Formalized in hard rule 33. `retryable`/`level` are **server-side only** today (not exposed to the client — YAGNI, no consumer). `Result<T,E>` was evaluated and rejected (ADR-0018 § alternatives).
 
 #### UI primitives
 
-`src/components/ui/` — componentes Radix + `class-variance-authority` (estilo shadcn). Sem fetch direto; dados via tRPC + React Query (`src/context/trpc/`).
+`src/components/ui/` — Radix + `class-variance-authority` components (shadcn style). No direct fetch; data via tRPC + React Query (`src/context/trpc/`).
 
 ---
 
-## 4. Estratégia de Testes
+## 4. Testing Strategy
 
-### 4.1 Níveis observados
+### 4.1 Observed levels
 
-| Nível | O que testa | Onde vive | Estado atual |
+| Level | What it tests | Where it lives | Current state |
 | ----- | ----------- | --------- | ------------- |
-| **Unit/Procedure** | Procedure + Domain + Model via `TestContext` | `src/server/features/**/procedures/*.test.ts` | 23 arquivos de teste (`vitest`) |
-| **Integration** | [A DEFINIR — não identificado no scan] | — | — |
-| **E2E** | [A DEFINIR — não identificado no scan] | — | — |
+| **Unit/Procedure** | Procedure + Domain + Model via `TestContext` | `src/server/features/**/procedures/*.test.ts` | 23 test files (`vitest`) |
+| **Integration** | [A DEFINIR — not found in the scan] | — | — |
+| **E2E** | [A DEFINIR — not found in the scan] | — | — |
 
-Cobertura atual (proxy `tests/src`): 23 arquivos de teste / 205 arquivos `.ts`/`.tsx` em `src/` (~11.2%). Ver `afm.md` § 3.1 forward-only.
+Current coverage (proxy `tests/src`): 23 test files / 205 `.ts`/`.tsx` files in `src/` (~11.2%). See `afm.md` § 3.1 forward-only.
 
-Os testes de procedure rodam sem Postgres/Redis: o vitest mocka o driver Prisma globalmente (`src/test/setup.ts`) com um client **`prisma-mock`** gerado do `schema.prisma` (`src/test/prisma/` — ADR-0011), então os models de produção rodam intactos contra um banco in-memory com unique constraints enforçadas; `createTestContext()` injeta só os gateways fake (`src/test/gateways/`). Isolamento por teste via `resetPrismaMock()` (não usar `$clear()` — ver comentário no seam). O hook de pre-push roda `yarn test` direto.
+Procedure tests run without Postgres/Redis: vitest mocks the Prisma driver globally (`src/test/setup.ts`) with a **`prisma-mock`** client generated from `schema.prisma` (`src/test/prisma/` — ADR-0011), so production models run intact against an in-memory database with unique constraints enforced; `createTestContext()` injects only the fake gateways (`src/test/gateways/`). Per-test isolation via `resetPrismaMock()` (do not use `$clear()` — see the comment in the seam). The pre-push hook runs `yarn test` directly.
 
-### 4.2 TDD duro + types-as-test
+### 4.2 Hard TDD + types-as-test
 
-Runner: `vitest run --reporter verbose` (script `test`). `tsconfig.json` tem `strict: true`.
+Runner: `vitest run --reporter verbose` (the `test` script). `tsconfig.json` has `strict: true`.
 
-### 4.3 Regressão
+### 4.3 Regression
 
-Padrão observado no `git log`: vários commits `test:` acompanham `fix:`/`refactor:` na mesma área (ex: "add error handling tests for non-existent posts and unauthorized updates"). Manter esse padrão.
+Pattern observed in `git log`: several `test:` commits accompany `fix:`/`refactor:` in the same area (e.g. "add error handling tests for non-existent posts and unauthorized updates"). Keep this pattern.
 
-### 4.4 Tipos como teste
+### 4.4 Types as test
 
-`grep -rn ': any' src/` → 2 ocorrências. `grep '@ts-ignore\|@ts-expect-error' src/` → 0. Ver `afm.md` § 3.1.
+`grep -rn ': any' src/` → 2 occurrences. `grep '@ts-ignore\|@ts-expect-error' src/` → 0. See `afm.md` § 3.1.
 
-### 4.5 Cobertura alvo por camada
+### 4.5 Target coverage per layer
 
-[A DEFINIR — sem threshold definido hoje.]
-
----
-
-## 5. Princípios transversais
-
-- **XP + Pragmatic** — DRY, YAGNI, KISS, Broken Windows, Design by Contract, Rubber Duck. Práticas diárias em [`/docs/afm.md`](./afm.md).
-- **Postgres = source of truth de todas as entidades.** Redis cache antigo foi removido; reconstrução futura passa por ADR nova/continuação da ADR-0009.
-- **Tipos no lugar de comentários.** Nome + tipo carregam o *o quê*. Comentário só pra justificar *porquê* surpreendente.
-- **Injeção explícita via `ctx`/`DomainInput`**, nunca acesso direto a driver dentro de Domain/Procedure — mantém a camada testável sem infra real (nos testes o driver vira um client `prisma-mock` in-memory, ADR-0011).
-- **Erro classificado por domínio, nunca genérico** — todo domínio tem seu próprio `<Domínio>ErrorCode` em `src/shared/error/`.
+[A DEFINIR — no threshold defined today.]
 
 ---
 
-## 6. Convenções de código (cheat-sheet)
+## 5. Cross-cutting principles
 
-### Rubricas de decisão
+- **XP + Pragmatic** — DRY, YAGNI, KISS, Broken Windows, Design by Contract, Rubber Duck. Daily practices in [`/docs/afm.md`](./afm.md).
+- **Postgres = source of truth for every entity.** The old Redis cache was removed; a future rebuild goes through a new ADR / a continuation of ADR-0009.
+- **Types in place of comments.** Name + type carry the *what*. A comment is only to justify a surprising *why*.
+- **Explicit injection via `ctx`/`DomainInput`**, never direct driver access inside Domain/Procedure — it keeps the layer testable without real infra (in tests the driver becomes an in-memory `prisma-mock` client, ADR-0011).
+- **Error classified by domain, never generic** — every domain has its own `<Domínio>ErrorCode` in `src/shared/error/`.
 
-Consulte as rubricas em [`docs/rubrics/`](./rubrics/) **antes** de escolher onde algo vai: `when-to-create-lib.md`, `when-to-create-module.md`, `when-to-create-dsl.md`, `enum-vs-union-vs-branded.md`, `error-classification.md`, `failure-classification.md`, `episodic-vs-semantic-boundary.md`, `negative-filters.md`, `solid-triggers.md`, `validation-boundary.md`, `when-to-evolve-methodology.md`, `template-vs-streaming-precedence.md`.
+---
 
-### Nomeação (observada no código)
+## 6. Code conventions (cheat-sheet)
 
-| Camada | Padrão do export | Padrão do arquivo |
+### Decision rubrics
+
+Consult the rubrics in [`docs/rubrics/`](./rubrics/) **before** you choose where something goes: `when-to-create-lib.md`, `when-to-create-module.md`, `when-to-create-dsl.md`, `enum-vs-union-vs-branded.md`, `error-classification.md`, `failure-classification.md`, `episodic-vs-semantic-boundary.md`, `negative-filters.md`, `solid-triggers.md`, `validation-boundary.md`, `when-to-evolve-methodology.md`, `template-vs-streaming-precedence.md`.
+
+### Naming (observed in the code)
+
+| Layer | Export pattern | File pattern |
 | ----- | ---- | ---- |
 | Router (Procedure-like) | `<Feature>Router` | `features/<feature>/index.ts` |
 | Procedure | `procedure_<action>` | `features/<feature>/procedures/<action>.ts` |
 | Domain-like | `domain_<action>` | `features/<feature>/domain/<action>.ts` |
 | Domain input | `DomainInput<T>` | `server/createDomain.ts` |
-| Model | `<Entidade>Model` (instância) | `server/models/<entity>.ts` |
-| Adapter (porta) | `I<Nome>Adapter` (tipo) | `adapter.ts` |
-| Test file | mesmo nome (sem sufixo `.test.ts`) | pasta `__test__/` (singular) vizinha ao código — **corrigido em 2026-07-11**: a versão anterior desta linha ("sem `__tests__/`") divergia do `vitest.config.ts` real (`include: ["src/**/__test__/**/*.ts"]`) e de todo o código existente (`procedures/__test__/<action>.ts`, `src/lib/slug/__test__/kebabCase.ts`) |
+| Model | `<Entity>Model` (instance) | `server/models/<entity>.ts` |
+| Adapter (port) | `I<Name>Adapter` (type) | `adapter.ts` |
+| Test file | same name (no `.test.ts` suffix) | a neighbor `__test__/` folder (singular) next to the code — **fixed on 2026-07-11**: the previous version of this line ("no `__tests__/`") diverged from the real `vitest.config.ts` (`include: ["src/**/__test__/**/*.ts"]`) and from all existing code (`procedures/__test__/<action>.ts`, `src/lib/slug/__test__/kebabCase.ts`) |
 
-### Tamanho e responsabilidade
+### Size and responsibility
 
-- ≤ 300 linhas por arquivo (sem exceção produtiva conhecida no scan de 2026-07-04).
-- Uma responsabilidade por arquivo.
+- ≤ 300 lines per file (no known production exception in the 2026-07-04 scan).
+- One responsibility per file.
 
-### Tipos: explícitos nas fronteiras, inferência no resto
+### Types: explicit at boundaries, inference elsewhere
 
-- **Explícito:** retorno de funções exportadas de domain/procedure, schemas/tipos de boundary, props de componentes exportados.
-- **Nunca `any` / `unknown` em helper próprio** (5 ocorrências conhecidas hoje — ver `afm.md` § 3.1).
+- **Explicit:** the return of exported domain/procedure functions, boundary schemas/types, exported component props.
+- **Never `any` / `unknown` in your own helper** (5 known occurrences today — see `afm.md` § 3.1).
 
 ---
 
-*Mudanças aqui seguem regra dura 11 (mudança arquitetural pára e pergunta).*
+*Changes here follow hard rule 11 (an architectural change stops and asks).*

--- a/docs/protocols/p1.md
+++ b/docs/protocols/p1.md
@@ -1,9 +1,9 @@
-# P1 — Entrega Autônoma
+# P1 — Autonomous Delivery
 
-> **Para:** POC e MVP. Velocidade e ausência de interação valem mais que profundidade.
-> **Concedido na sessão, nunca pelo repo** (`core/protocol.md` § 6).
+> **For:** POC and MVP. Speed and no interaction matter more than depth.
+> **Granted in the session, never by the repo** (`core/protocol.md` § 6).
 
-| Campo | Valor |
+| Field | Value |
 | --- | --- |
 | `plan` | `auto` |
 | `exec` | `auto` |
@@ -16,8 +16,8 @@
 | `delegation` | full |
 | `MAX_PARALLEL_SUBAGENTS` | 4 |
 
-**O que "autônomo" NÃO significa aqui:** regra dura com gatilho executável continua 0/1, e postura de segurança não é negociável (`afm.md § 1.3`). Relaxa **profundidade** — cobertura, exaustividade de edge case, refinamento de nome.
+**What "autonomous" does NOT mean here:** a hard rule with an executable trigger stays 0/1, and the security posture is non-negotiable (`afm.md § 1.3`). It relaxes **depth** — coverage, edge-case exhaustiveness, name refinement.
 
-**Como "não pergunta" é mecânico:** `ROUND_CAP = 0`. Sem rodada disponível, todo irredutível cai em `UNKNOWN_POLICY` e vira suposição **registrada no artefato** — documentada, nunca chutada em silêncio (princípio #4).
+**How "does not ask" is mechanical:** `ROUND_CAP = 0`. With no round available, every irreducible falls into `UNKNOWN_POLICY` and becomes an assumption **recorded in the artifact** — documented, never silently guessed (principle #4).
 
-**Cadência:** `reflect` ao fim de cada entregável; `evolve` a cada 3-4.
+**Cadence:** `reflect` at the end of each deliverable; `evolve` every 3-4.

--- a/docs/protocols/p2.md
+++ b/docs/protocols/p2.md
@@ -1,8 +1,8 @@
-# P2 — Entrega Assistida
+# P2 — Assisted Delivery
 
-> **Para:** pair programming. Humano = dev sênior; o agente escala cedo em vez de seguir errado.
+> **For:** pair programming. The human = a senior dev; the agent escalates early instead of going wrong.
 
-| Campo | Valor |
+| Field | Value |
 | --- | --- |
 | `plan` | `assisted` |
 | `exec` | `assisted` |
@@ -11,12 +11,12 @@
 | `MAX_DISCOVERY_ROUNDS` | 3 |
 | `HALT_PER_PHASE` | **on** |
 | `SUPPRESS_SUBGATES` | **off** |
-| `UNKNOWN_POLICY` | pergunta |
+| `UNKNOWN_POLICY` | ask |
 | `delegation` | none |
 | `MAX_PARALLEL_SUBAGENTS` | **2** |
 
-**P2 é composicional, não introspectivo.** Ele não é "pergunte quando estiver inseguro" — confiança auto-relatada não é gatilho executável (princípio #3; CRITIC: auto-crítica sem ferramenta externa degrada). P2 são exatamente três knobs que já existiam: supressão desligada, `RETRY_CAP=1` (o primeiro vermelho escala), e parada por fase.
+**P2 is compositional, not introspective.** It is not "ask when you are unsure" — self-reported confidence is not an executable trigger (principle #3; CRITIC: self-critique without an external tool degrades). P2 is exactly three knobs that already existed: suppression off, `RETRY_CAP=1` (the first red escalates), and halt per phase.
 
-**Piso.** Abaixo da heurística de feature-folder (`afm.md § 2.1`), a postura degrada para **"reporta antes de commitar"**. Perguntar a cada passo de mudança trivial é ruído — e ruído faz desligar o protocolo, que é pior que não tê-lo.
+**Floor.** Below the feature-folder heuristic (`afm.md § 2.1`), the posture degrades to **"report before commit"**. Asking at every step of a trivial change is noise — and noise turns the protocol off, which is worse than not having it.
 
-**Cadência:** `reflect` ao fim de cada entregável; `evolve` a cada 3-4.
+**Cadence:** `reflect` at the end of each deliverable; `evolve` every 3-4.

--- a/docs/protocols/p3.md
+++ b/docs/protocols/p3.md
@@ -1,10 +1,10 @@
-# P3 — Entrega Planejada Autônoma
+# P3 — Planned Autonomous Delivery
 
-> **Para:** o meio-termo — qualidade de P2 com interação de P1. Planeja junto, executa sozinho.
+> **For:** the middle ground — P2 quality with P1 interaction. Plans together, executes alone.
 
-| Campo | Fase 1 (planejamento) | Fase 2 (execução) |
+| Field | Phase 1 (planning) | Phase 2 (execution) |
 | --- | --- | --- |
-| postura | `assisted` | `auto` |
+| posture | `assisted` | `auto` |
 | `RETRY_CAP` | 2 | 2 |
 | `ROUND_CAP` | 2 | **0** |
 | `HALT_PER_PHASE` | — | off |
@@ -12,10 +12,10 @@
 | `delegation` | read-only | full |
 | `MAX_PARALLEL_SUBAGENTS` | **6** | 4 |
 
-**Gate de transição — o único gate, e o critério é mecânico:** `plan.md` e `tasks.md` sem nenhum `[NEEDS CLARIFICATION:]` aberto. `grep`, 0/1 — não é julgamento sobre "o plano está bom".
+**Transition gate — the only gate, and the criterion is mechanical:** `plan.md` and `tasks.md` with no open `[NEEDS CLARIFICATION:]`. A `grep`, 0/1 — not a judgment on "is the plan good".
 
-**Por que a fase 2 pode ser autônoma:** todo imprevisto já foi decidido na fase 1 e todo ponto crítico já foi resolvido. A execução é prevista e conhecida. `ROUND_CAP = 0` na fase 2 materializa isso: se aparecer algo **fora do planejado**, não há orçamento de pergunta — o caso cai na tabela de parada do `deliver` (regra 11, bright line, falha além do `RETRY_CAP`), que é escalada por sinal externo, não por confiança.
+**Why phase 2 can be autonomous:** every unforeseen thing was already decided in phase 1 and every critical point already resolved. Execution is foreseen and known. `ROUND_CAP = 0` in phase 2 materializes this: if something **outside the plan** appears, there is no question budget — the case falls into the `deliver` halt table (rule 11, bright line, a failure beyond `RETRY_CAP`), which is escalated by an external signal, not by confidence.
 
-**Cadência (iniciativa grande):** `reflect` a cada 3-4 tasks; ao fechar o entregável, `reflect` generalista → `evolve`.
+**Cadence (a large initiative):** `reflect` every 3-4 tasks; when the deliverable closes, a generalist `reflect` → `evolve`.
 
-**É o precedente do plan mode do Claude Code:** planejamento assistido, e a aprovação oferece *"Yes, and use auto mode"* — um gate transitando pra execução autônoma.
+**It is the precedent for Claude Code's plan mode:** assisted planning, and the approval offers *"Yes, and use auto mode"* — a gate transitioning to autonomous execution.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,70 +1,70 @@
-# Roadmap — Blog/CMS nível pleno
+# Roadmap — Blog/CMS at mid-level
 
-## Progresso geral
+## Overall progress
 
-> Atualizado em 2026-06-30, a partir de auditoria de código (não de memória) na adoção do AFM. Cada fase abaixo tem checklist próprio nas seções correspondentes — isto é só o resumo executivo. Reconciliar esta tabela sempre que uma tarefa mudar de estado (ver `CLAUDE.md` § Doutrina).
+> Updated on 2026-06-30, from a code audit (not from memory) during AFM adoption. Each phase below has its own checklist in the matching section — this is only the executive summary. Reconcile this table whenever a task changes state (see `CLAUDE.md` § Doutrina).
 
-| Fase | Status | Nota |
+| Phase | Status | Note |
 | --- | --- | --- |
-| 0 — Organização inicial | ✅ Concluída | — |
-| 1 — Blog público bem feito | ✅ Concluída (com 1 pendência residual) | todos os itens do checklist implementados: slug, paginação, status/publicação, tags/categorias (`docs/features/002` a `005`), tempo de leitura (`006`), posts relacionados (`007`), imagem de capa (`010`); pendência residual: status HTTP de `/post/[slug]` continua `200` em vez de `404` pra slug inexistente — limitação de framework (Cache Components), aceita como conhecida por ora (`docs/features/009-post-404-status/`) |
-| 2 — Admin/CMS | ✅ Concluída (com 1 pendência adiada) | seletor de status, preview de rascunho na URL real (`docs/features/011-post-status-preview/`), painel "meus posts" com filtros por status/categoria/tag (`docs/features/012-my-posts-panel/`, escopado sem roles — ver nota na fase); pendência adiada: upload de arquivo de imagem de capa vai pra Fase 8 (decisão do dono, 2026-07-12) — capa via URL já existe (`docs/features/010-post-cover-image/`) |
-| 3 — Autenticação e permissões | ✅ Concluída (com 1 pendência adiada pra Fase 4) | `docs/features/013-role-based-permissions/`: papéis ADMIN/EDITOR/AUTHOR, `roleProcedure`, `src/lib/permissions/` (matrix); pré-requisito `001-auth-hardening` (2026-07-12) satisfeito. Pendência (restringir publish/archive a Admin/Editor) fechada pela Fase 4 |
-| 4 — Workflow editorial | ✅ Concluída (com 1 pendência adiada) | `docs/features/014-post-review-workflow/`: `IN_REVIEW`/`SCHEDULED`, enviar/aprovar/rejeitar (motivo obrigatório)/publicar direto/agendar/arquivar, `PostReviewComment`; restrição de publish/archive a Admin/Editor (fecha a pendência da Fase 3); agendamento via checagem lazy no read, sem scheduler novo. Pendência adiada: histórico de diffs de edição (`PostRevision`) — mesmo padrão da Fase 2, que adiou upload de imagem pra Fase 8 |
-| 5 — SEO e publicação profissional | ✅ Concluída | `docs/features/015-seo-metadata/`: sitemap.xml, robots.txt, RSS feed, canonical, Twitter Card, schema.org — todos computados de campos já existentes, sem migration. `docs/features/018-seo-overrides-slug-redirect/`: campos editáveis de override de SEO (`seoTitle`/`seoDescription`/`canonicalUrl`) e slug editável com redirect 301 automático (`previousSlug`, 1 nível de histórico) — as 2 pendências que ficavam essa fase parcial |
-| 6 — Busca e descoberta | ✅ Concluída | `docs/features/016-search-content/`: busca por título/conteúdo via `contains`/`insensitive` (não `tsvector` nativo — ADR-0011), autocomplete no header; filtro por tag/categoria e posts relacionados já existiam de fases anteriores. `docs/features/019-search-sort-by-views/`: ordenação por mais acessado (`sortBy: "mostViewed"`), desbloqueada pelo `Post.viewCount` da Fase 7 — a pendência que deixava essa fase parcial |
-| 7 — Analytics interno | ✅ Concluída | `docs/features/017-post-view-analytics/`: registrar view (dedup por visitante 24h via Redis/cookie, ADR-0013), contar total, posts mais acessados, dashboard Admin/Editor. `docs/features/020-view-analytics-breakdown/`: contagem por período (7/30 dias), origem de tráfego e navegador/SO — pendências que deixavam a fase parcial, fechadas com retenção de 30 dias (deleção lazy) e sem persistir IP |
-| 8 — Upload e gerenciamento de mídia | ✅ Concluída (com 1 pendência adiada) | `docs/features/021-media-upload/`: upload real de imagem (FormData via tRPC, `ADR-0015`), biblioteca de mídia, apagar (dono ou `media:deleteAny`), alt text, validação de formato/tamanho, capa de post a partir de mídia enviada. Pendência adiada: compressão/otimização de imagem (explicitamente opcional no roadmap; some sozinha se o storage final for um CDN de imagem) |
-| 9 — Qualidade de produção | 🟡 Parcial | Zod, migrations, seed, alguns testes/error pages já existem; rate limiting em memória cobre login/registro/reset/refresh (`docs/features/001-auth-hardening/`) — não é rate limiting geral de toda a API; falta logs estruturados, cobertura de teste (~8.6% hoje) |
-| 10 — CI/CD e deploy | ⬜ Não iniciada | sem `.github/workflows/`, sem deploy configurado |
-| 11 — Observabilidade | ⬜ Não iniciada | sem `/api/health`, sem tracing/métricas |
+| 0 — Initial setup | ✅ Done | — |
+| 1 — Solid public blog | ✅ Done (with 1 residual item) | all checklist items implemented: slug, pagination, status/publishing, tags/categories (`docs/features/002` to `005`), reading time (`006`), related posts (`007`), cover image (`010`); residual item: the HTTP status of `/post/[slug]` is still `200` instead of `404` for a nonexistent slug — framework limitation (Cache Components), accepted as known for now (`docs/features/009-post-404-status/`) |
+| 2 — Admin/CMS | ✅ Done (with 1 item deferred) | status selector, draft preview on the real URL (`docs/features/011-post-status-preview/`), "my posts" panel with filters by status/category/tag (`docs/features/012-my-posts-panel/`, scoped without roles — see note in the phase); item deferred: cover-image file upload moves to Phase 8 (owner decision, 2026-07-12) — cover via URL already exists (`docs/features/010-post-cover-image/`) |
+| 3 — Authentication and permissions | ✅ Done (with 1 item deferred to Phase 4) | `docs/features/013-role-based-permissions/`: ADMIN/EDITOR/AUTHOR roles, `roleProcedure`, `src/lib/permissions/` (matrix); prerequisite `001-auth-hardening` (2026-07-12) satisfied. The pending item (restrict publish/archive to Admin/Editor) is closed by Phase 4 |
+| 4 — Editorial workflow | ✅ Done (with 1 item deferred) | `docs/features/014-post-review-workflow/`: `IN_REVIEW`/`SCHEDULED`, submit/approve/reject (reason required)/publish directly/schedule/archive, `PostReviewComment`; publish/archive restricted to Admin/Editor (closes the Phase 3 item); scheduling via a lazy check on read, no new scheduler. Item deferred: edit diff history (`PostRevision`) — same pattern as Phase 2, which deferred image upload to Phase 8 |
+| 5 — SEO and professional publishing | ✅ Done | `docs/features/015-seo-metadata/`: sitemap.xml, robots.txt, RSS feed, canonical, Twitter Card, schema.org — all computed from fields that already existed, no migration. `docs/features/018-seo-overrides-slug-redirect/`: editable SEO override fields (`seoTitle`/`seoDescription`/`canonicalUrl`) and an editable slug with automatic 301 redirect (`previousSlug`, 1 level of history) — the 2 items that had left this phase partial |
+| 6 — Search and discovery | ✅ Done | `docs/features/016-search-content/`: search by title/content via `contains`/`insensitive` (not native `tsvector` — ADR-0011), header autocomplete; filter by tag/category and related posts already existed from earlier phases. `docs/features/019-search-sort-by-views/`: sort by most viewed (`sortBy: "mostViewed"`), unlocked by `Post.viewCount` from Phase 7 — the item that had left this phase partial |
+| 7 — Internal analytics | ✅ Done | `docs/features/017-post-view-analytics/`: record view (dedup per visitor for 24h via Redis/cookie, ADR-0013), count total, most-viewed posts, Admin/Editor dashboard. `docs/features/020-view-analytics-breakdown/`: counts by period (7/30 days), traffic source, and browser/OS — items that had left the phase partial, closed with 30-day retention (lazy deletion) and no IP persisted |
+| 8 — Media upload and management | ✅ Done (with 1 item deferred) | `docs/features/021-media-upload/`: real image upload (FormData via tRPC, `ADR-0015`), media library, delete (owner or `media:deleteAny`), alt text, format/size validation, post cover image from uploaded media. Item deferred: image compression/optimization (explicitly optional in the roadmap; goes away on its own if the final storage is an image CDN) |
+| 9 — Production quality | 🟡 Partial | Zod, migrations, seed, some tests/error pages already exist; in-memory rate limiting covers login/register/reset/refresh (`docs/features/001-auth-hardening/`) — not general rate limiting for the whole API; missing: structured logs, test coverage (~8.6% today) |
+| 10 — CI/CD and deploy | ⬜ Not started | no `.github/workflows/`, no deploy configured |
+| 11 — Observability | ⬜ Not started | no `/api/health`, no tracing/metrics |
 
-**Fora do roadmap numerado, concluído (2026-07-12):** `docs/features/001-auth-hardening/` — hardening de segurança da sessão/auth atual (pré-requisito da Fase 3, não uma fase nova). Camada de aplicação fechada; hardening de infra (TLS/HTTPS via nginx+certificado, remoção de credenciais hardcoded do `docker-compose.yml`, porta do Postgres exposta ao host sem necessidade) foi escopado fora desta rodada — natureza operacional diferente (depende de domínio/certificado, não testável por `vitest`), decisão do dono em 2026-07-12 (`docs/features/001-auth-hardening/spec.md` § 7). Candidato natural: Fase 10 (CI/CD e deploy) quando essa fase começar.
+**Outside the numbered roadmap, done (2026-07-12):** `docs/features/001-auth-hardening/` — security hardening of the current session/auth (prerequisite for Phase 3, not a new phase). The application layer is closed; infra hardening (TLS/HTTPS via nginx+certificate, removing hardcoded credentials from `docker-compose.yml`, the Postgres port exposed to the host without need) was scoped out of this round — different operational nature (depends on a domain/certificate, not testable with `vitest`), owner decision on 2026-07-12 (`docs/features/001-auth-hardening/spec.md` § 7). Natural candidate: Phase 10 (CI/CD and deploy) when that phase starts.
 
-**Nota de sequenciamento (2026-07-11):** o back-end já passou por uma refatoração grande (models com delegate pluggável, camada domain/procedure, etc. — ver `docs/adr/`). Uma refatoração equivalente está planejada para o front-end, mas o desenho ainda não existe. Até lá, o foco é entregar funcionalidades de **back-end** (ex.: paginação); mudanças de front continuam aceitas quando a feature exige (ex.: renderizar os controles de paginação), mas evitando decisão estrutural nova do lado do front (padrão de state management, nova camada de componentes, reorganização de pastas) que a futura refatoração teria que desfazer.
+**Sequencing note (2026-07-11):** the back end already went through a large refactor (models with a pluggable delegate, domain/procedure layer, etc. — see `docs/adr/`). An equivalent refactor is planned for the front end, but the design does not exist yet. Until then, the focus is delivering **back-end** functionality (e.g., pagination); front-end changes are still accepted when a feature requires them (e.g., rendering pagination controls), but new structural decisions on the front-end side (state-management pattern, new component layer, folder reorganization) are avoided, since the future refactor would have to undo them.
 
 ---
 
-## Objetivo final
+## Final goal
 
-Construir uma **plataforma de publicação técnica** com:
+Build a **technical publishing platform** with:
 
-* blog público;
-* painel administrativo;
-* autenticação;
-* permissões;
-* fluxo editorial;
+* public blog;
+* admin panel;
+* authentication;
+* permissions;
+* editorial workflow;
 * SEO;
-* analytics interno;
-* busca;
-* testes;
+* internal analytics;
+* search;
+* tests;
 * Docker;
 * CI/CD;
 * deploy.
 
-A ideia não é fazer “mais um blog”, mas sim uma aplicação que mostre que você sabe construir, organizar, proteger, publicar e manter um sistema real.
+The idea is not to build "just another blog," but an application that shows you can build, organize, secure, publish, and maintain a real system.
 
-## Fase 0 — Organização inicial ✅ Concluída
+## Phase 0 — Initial setup ✅ Done
 
-### Objetivo
+### Objective
 
-Transformar o projeto atual em uma base minimamente organizada para crescer.
+Turn the current project into a minimally organized base to grow from.
 
-### Tarefas
+### Tasks
 
-* [x] revisar o CRUD atual;
-* [x] definir stack final;
-* [x] organizar estrutura de pastas;
-* [x] criar README inicial;
-* [x] configurar `.env.example`;
-* [x] configurar Docker com PostgreSQL;
-* [x] configurar Prisma;
-* [x] configurar lint/format;
-* [x] configurar scripts básicos.
+* [x] review the current CRUD;
+* [x] define the final stack;
+* [x] organize the folder structure;
+* [x] create an initial README;
+* [x] set up `.env.example`;
+* [x] set up Docker with PostgreSQL;
+* [x] set up Prisma;
+* [x] set up lint/format;
+* [x] set up basic scripts.
 
-### Stack sugerida
+### Suggested stack
 
-> **Decisão (2026-06-30, ver `docs/adr/0005-manter-auth-propria.md`):** Auth.js/Better Auth **não foi adotado** — a auth própria já implementada é mantida, com hardening incremental. Playwright/GitHub Actions também não foram adotados até aqui (`vitest` sem CI).
+> **Decision (2026-06-30, see `docs/adr/0005-manter-auth-propria.md`):** Auth.js/Better Auth was **not adopted** — the existing custom auth is kept, with incremental hardening. Playwright/GitHub Actions also have not been adopted so far (`vitest` without CI).
 
 ```txt
 Next.js
@@ -72,14 +72,14 @@ TypeScript
 PostgreSQL
 Prisma
 Zod
-Auth.js ou Better Auth
+Auth.js or Better Auth
 Docker
 Vitest
 Playwright
 GitHub Actions
 ```
 
-### Estrutura inicial sugerida
+### Suggested initial structure
 
 ```txt
 src/
@@ -96,11 +96,11 @@ src/
     analytics/
 ```
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando outra pessoa consegue clonar o projeto, rodar um comando e subir a aplicação localmente.
+This phase is done when another person can clone the project, run one command, and get the application running locally.
 
-Exemplo:
+Example:
 
 ```bash
 docker compose up -d
@@ -108,27 +108,27 @@ pnpm install
 pnpm dev
 ```
 
-## Fase 1 — Blog público bem feito ✅ Concluída (com 1 pendência residual)
+## Phase 1 — Solid public blog ✅ Done (with 1 residual item)
 
-### Objetivo
+### Objective
 
-Ter a parte pública do blog funcionando bem.
+Get the public part of the blog working well.
 
-### Funcionalidades
+### Features
 
-* [x] listar posts publicados (`readRecent`, paginado, filtrado por `status: PUBLISHED` — `docs/features/004-post-status/`);
-* [x] visualizar post por slug — código escrito e verificado (`docs/features/002-post-slug/`, rota pública `/post/[slug]`, `Post.slug` único gerado no `create` via `src/lib/slug/`); `tsc --noEmit` e `vitest` (111/111) verdes; **2026-07-11: migration aplicada num Postgres real e `/post/<slug>` testado ao vivo no browser** — fechado. Achado durante a verificação: seed (`prisma/seed.ts`) estava quebrado por import de `src/lib/slug` incompatível com execução nativa `node`, e slug inexistente caía num `error.tsx` genérico em vez de `notFound()` — ambos corrigidos (commit `a620cde`). Pendência residual: status HTTP da resposta de `notFound()` continua `200`, não `404` (streaming/`Suspense` — ver `docs/ust.md` § Pendências Técnicas);
-* [x] paginação — cursor-based (`Post.id`), tamanho de página default 10, `post.readRecent({ cursor?, limit? })` retorna `{ posts, nextCursor }`; front (`postFeed.client.tsx`) tem botão "Carregar mais" (`docs/features/003-post-pagination/`);
-* [x] status do post — `enum PostStatus { DRAFT PUBLISHED ARCHIVED }`, default `PUBLISHED` (decidido no domain, não no banco); `post.create`/`post.update` aceitam `status` opcional; leituras públicas (`readRecent`, `user.readPosts`, `readBySlug`) só expõem `PUBLISHED` (`docs/features/004-post-status/`). Sem UI de seletor de status ainda — fica pra Fase 2 (Admin/CMS);
-* [x] tags — `Tag`/`PostTag` (N:N), features `tag.create`/`tag.readAll`; `post.create`/`post.update` aceitam `tagIds` opcionais; `post.readRecent` filtra por `tagId`, `post.readBySlug` retorna as tags do post (`docs/features/005-tags-categorias/`);
-* [x] categorias — `Category` (`Post.categoryId?`, N:1), features `category.create`/`category.readAll`; `post.create`/`post.update` aceitam `categoryId` opcional; `post.readRecent` filtra por `categoryId`, `post.readBySlug` retorna a categoria do post (`docs/features/005-tags-categorias/`). Sem UI de seletor ainda — fica pra Fase 2 (Admin/CMS);
-* [x] autor (post/comentário mostram o `user` relacionado);
-* [x] imagem de capa — `Post.coverImageUrl?` (migration `add_post_cover_image`); `post.create`/`post.update` aceitam URL opcional (validada com `z.string().url()`); exibida no card da listagem e no topo da página do post (`<img>` simples, sem `next/image` — repo não usa, evita configurar `images.remotePatterns` pra URL arbitrária de usuário) (`docs/features/010-post-cover-image/`). Sem upload de arquivo — fica pra Fase 2 (Admin/CMS);
-* [x] tempo estimado de leitura — `readingTimeMinutes` calculado on-the-fly a partir do `content` (200 palavras/minuto, mínimo 1 min), via `z.transform()` no schema de output de post; aparece em todo endpoint que retorna post (`create`, `read`, `readBySlug`, `update`, `revalidate`, `readRecent`, `user.readPosts`) sem tocar domain/model (`docs/features/006-tempo-leitura/`). Sem UI mostrando o valor ainda — fica pra depois da refatoração de front;
-* [x] posts relacionados — `post.readRelated` (mesma categoria OU pelo menos uma tag em comum, exclui o próprio post, só `PUBLISHED`, ordena por mais recente); seção "Related posts" na página do post (`docs/features/007-posts-relacionados/`). Sem ranking ponderado — fica pra Fase 6 (busca/descoberta);
-* [x] página pública do autor (`src/app/(half)/user/[id]/`).
+* [x] list published posts (`readRecent`, paginated, filtered by `status: PUBLISHED` — `docs/features/004-post-status/`);
+* [x] view a post by slug — code written and verified (`docs/features/002-post-slug/`, public route `/post/[slug]`, unique `Post.slug` generated on `create` via `src/lib/slug/`); `tsc --noEmit` and `vitest` (111/111) green; **2026-07-11: migration applied to a real Postgres and `/post/<slug>` tested live in the browser** — closed. Found during verification: the seed (`prisma/seed.ts`) was broken by an `src/lib/slug` import incompatible with native `node` execution, and a nonexistent slug fell through to a generic `error.tsx` instead of `notFound()` — both fixed (commit `a620cde`). Residual item: the HTTP status of the `notFound()` response is still `200`, not `404` (streaming/`Suspense` — see `docs/ust.md` § Pendências Técnicas);
+* [x] pagination — cursor-based (`Post.id`), default page size 10, `post.readRecent({ cursor?, limit? })` returns `{ posts, nextCursor }`; the front end (`postFeed.client.tsx`) has a "Load more" button (`docs/features/003-post-pagination/`);
+* [x] post status — `enum PostStatus { DRAFT PUBLISHED ARCHIVED }`, default `PUBLISHED` (decided in the domain, not the database); `post.create`/`post.update` accept an optional `status`; public reads (`readRecent`, `user.readPosts`, `readBySlug`) expose only `PUBLISHED` (`docs/features/004-post-status/`). No status-selector UI yet — moves to Phase 2 (Admin/CMS);
+* [x] tags — `Tag`/`PostTag` (N:N), `tag.create`/`tag.readAll` features; `post.create`/`post.update` accept optional `tagIds`; `post.readRecent` filters by `tagId`, `post.readBySlug` returns the post's tags (`docs/features/005-tags-categorias/`);
+* [x] categories — `Category` (`Post.categoryId?`, N:1), `category.create`/`category.readAll` features; `post.create`/`post.update` accept an optional `categoryId`; `post.readRecent` filters by `categoryId`, `post.readBySlug` returns the post's category (`docs/features/005-tags-categorias/`). No selector UI yet — moves to Phase 2 (Admin/CMS);
+* [x] author (post/comment show the related `user`);
+* [x] cover image — `Post.coverImageUrl?` (migration `add_post_cover_image`); `post.create`/`post.update` accept an optional URL (validated with `z.string().url()`); shown on the listing card and at the top of the post page (a plain `<img>`, not `next/image` — the repo does not use it, avoiding the need to configure `images.remotePatterns` for an arbitrary user URL) (`docs/features/010-post-cover-image/`). No file upload — moves to Phase 2 (Admin/CMS);
+* [x] estimated reading time — `readingTimeMinutes` computed on the fly from `content` (200 words/minute, minimum 1 min), via `z.transform()` in the post output schema; appears on every endpoint that returns a post (`create`, `read`, `readBySlug`, `update`, `revalidate`, `readRecent`, `user.readPosts`) without touching domain/model (`docs/features/006-tempo-leitura/`). No UI showing the value yet — moves to after the front-end refactor;
+* [x] related posts — `post.readRelated` (same category OR at least one shared tag, excludes the post itself, only `PUBLISHED`, ordered by most recent); "Related posts" section on the post page (`docs/features/007-posts-relacionados/`). No weighted ranking — moves to Phase 6 (search/discovery);
+* [x] public author page (`src/app/(half)/user/[id]/`).
 
-### Modelos principais
+### Main models
 
 ```ts
 User
@@ -138,7 +138,7 @@ Tag
 PostTag
 ```
 
-### Exemplo de status inicial do post
+### Example initial post status
 
 ```ts
 enum PostStatus {
@@ -148,38 +148,38 @@ enum PostStatus {
 }
 ```
 
-### Regras importantes
+### Important rules
 
-* somente posts `PUBLISHED` aparecem no blog público — implementado (`docs/features/004-post-status/`): `readRecent`, `user.readPosts` filtram na query, `readBySlug` trata post não-`PUBLISHED` como não encontrado;
-* slug deve ser único;
-* post arquivado não aparece em listagens públicas — implementado junto do item acima;
-* post sem título não pode ser publicado;
-* post sem conteúdo não pode ser publicado.
+* only `PUBLISHED` posts appear on the public blog — implemented (`docs/features/004-post-status/`): `readRecent`, `user.readPosts` filter in the query, `readBySlug` treats a non-`PUBLISHED` post as not found;
+* the slug must be unique;
+* an archived post does not appear in public listings — implemented together with the item above;
+* a post without a title cannot be published;
+* a post without content cannot be published.
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando o usuário consegue acessar o blog público, ver posts, navegar por tags/categorias e abrir posts individuais.
+This phase is done when the user can access the public blog, view posts, browse by tags/categories, and open individual posts.
 
-## Fase 2 — Admin/CMS próprio ✅ Concluída (com 1 pendência adiada)
+## Phase 2 — Own Admin/CMS ✅ Done (with 1 item deferred)
 
-### Objetivo
+### Objective
 
-Criar um painel administrativo para gerenciar posts.
+Build an admin panel to manage posts.
 
-### Funcionalidades
+### Features
 
-* [x] login (existe, mas não há área `/admin` separada — é a auth geral);
-* [x] criar post (`src/app/(half)/post/create/`);
-* [x] editar post (`src/app/(half)/post/edit/[id]/`);
-* [x] deletar post;
-* [x] publicar post / salvar como rascunho / arquivar — seletor de status (`<select>`) nos formulários de criar/editar; `PostStatus` já existia no schema (`docs/features/004-post-status/`) (`docs/features/011-post-status-preview/`);
-* [ ] upload de imagem de capa — adiado pra Fase 8 (decisão do dono, 2026-07-12): capa via URL já existe (`docs/features/010-post-cover-image/`), upload de arquivo real exige decisão de storage que pertence à Fase 8 (Upload e mídia), não faz sentido decidir só pro post;
-* [x] preview antes de publicar — dono consegue abrir a URL real do próprio post (`/post/<slug>`) mesmo em DRAFT/ARCHIVED e vê um banner "só você vê isso"; qualquer outra pessoa continua recebendo 404 (`docs/features/011-post-status-preview/`);
-* [x] listagem de posts no admin — escopado como painel **"meus posts"** (`/post/mine`), não site-wide: sem roles (Fase 3 ainda não iniciada), a única regra de autorização hoje é "dono edita/deleta o próprio post", então o painel só lista os posts do usuário logado; quando Fase 3 trouxer roles, um `ADMIN` pode ganhar acesso a ver posts de outros usuários como extensão desta tela (`docs/features/012-my-posts-panel/`);
-* [x] filtros por status — painel "meus posts" filtra por qualquer status, não só `PUBLISHED` (`docs/features/012-my-posts-panel/`);
-* [x] filtros por categoria/tag — idem, no mesmo painel (`docs/features/012-my-posts-panel/`).
+* [x] login (exists, but there is no separate `/admin` area — it is the general auth);
+* [x] create post (`src/app/(half)/post/create/`);
+* [x] edit post (`src/app/(half)/post/edit/[id]/`);
+* [x] delete post;
+* [x] publish post / save as draft / archive — status selector (`<select>`) in the create/edit forms; `PostStatus` already existed in the schema (`docs/features/004-post-status/`) (`docs/features/011-post-status-preview/`);
+* [ ] cover-image file upload — deferred to Phase 8 (owner decision, 2026-07-12): cover via URL already exists (`docs/features/010-post-cover-image/`), real file upload requires a storage decision that belongs to Phase 8 (Upload and media), it does not make sense to decide that just for posts;
+* [x] preview before publishing — the owner can open the post's real URL (`/post/<slug>`) even in DRAFT/ARCHIVED and sees a "only you can see this" banner; anyone else still gets a 404 (`docs/features/011-post-status-preview/`);
+* [x] post listing in admin — scoped as a **"my posts"** panel (`/post/mine`), not site-wide: without roles (Phase 3 not started yet), the only authorization rule today is "owner edits/deletes their own post," so the panel lists only the logged-in user's posts; when Phase 3 brings roles, an `ADMIN` may gain access to see other users' posts as an extension of this screen (`docs/features/012-my-posts-panel/`);
+* [x] filters by status — the "my posts" panel filters by any status, not only `PUBLISHED` (`docs/features/012-my-posts-panel/`);
+* [x] filters by category/tag — same, in the same panel (`docs/features/012-my-posts-panel/`).
 
-### Telas
+### Screens
 
 ```txt
 /admin/login
@@ -191,29 +191,29 @@ Criar um painel administrativo para gerenciar posts.
 /admin/tags
 ```
 
-### Regras importantes
+### Important rules
 
-* usuário não autenticado não acessa `/admin`;
-* somente usuário autorizado pode criar post;
-* somente admin/editor pode publicar;
-* autor pode editar os próprios rascunhos;
-* post publicado precisa passar por validação.
+* an unauthenticated user cannot access `/admin`;
+* only an authorized user can create a post;
+* only admin/editor can publish;
+* an author can edit their own drafts;
+* a published post must pass validation.
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando você consegue gerenciar todo o conteúdo pelo admin, sem mexer direto no banco.
+This phase is done when you can manage all content through the admin, without touching the database directly.
 
-## Fase 3 — Autenticação e permissões ✅ Concluída (com 1 pendência adiada pra Fase 4)
+## Phase 3 — Authentication and permissions ✅ Done (with 1 item deferred to Phase 4)
 
-> **Pré-requisito (2026-06-30):** antes de empilhar papéis/permissões em cima da sessão atual, ver `docs/features/001-auth-hardening/spec.md` — sessão sem expiração no servidor, cookies sem `HttpOnly`/CSRF, sem rate limiting. Adicionar roles sobre essa base propagaria a mesma superfície de ataque pra cada papel novo. **Satisfeito (2026-07-12)** — `001-auth-hardening` done.
+> **Prerequisite (2026-06-30):** before stacking roles/permissions on top of the current session, see `docs/features/001-auth-hardening/spec.md` — session with no server-side expiration, cookies without `HttpOnly`/CSRF, no rate limiting. Adding roles on top of that base would propagate the same attack surface to every new role. **Satisfied (2026-07-12)** — `001-auth-hardening` done.
 >
-> **Implementação:** `docs/features/013-role-based-permissions/` (RF-08). "Publicar post"/"Arquivar post" na tabela abaixo continuam liberados pro Author sobre o próprio post nesta rodada — restringir a Admin/Editor exigiria o workflow de revisão da Fase 4 (`enviar pra revisão` → `aprovar`), que ainda não existe; aplicar a restrição sem esse workflow travaria qualquer Author sem Admin/Editor com posts presos em `DRAFT`. Decisão do dono, 2026-07-12 (`013-role-based-permissions/spec.md` § 4/§ 7).
+> **Implementation:** `docs/features/013-role-based-permissions/` (RF-08). "Publish post"/"Archive post" in the table below are still allowed for the Author on their own post in this round — restricting them to Admin/Editor would require the review workflow from Phase 4 (`submit for review` → `approve`), which does not exist yet; applying the restriction without that workflow would trap any Author without Admin/Editor with posts stuck in `DRAFT`. Owner decision, 2026-07-12 (`013-role-based-permissions/spec.md` § 4/§ 7).
 
-### Objetivo
+### Objective
 
-Adicionar controle real de acesso.
+Add real access control.
 
-### Papéis sugeridos
+### Suggested roles
 
 ```ts
 enum UserRole {
@@ -223,41 +223,41 @@ enum UserRole {
 }
 ```
 
-### Permissões
+### Permissions
 
-| Ação                 | Admin | Editor | Author |
-| -------------------- | ----: | -----: | -----: |
-| Criar post           |   Sim |    Sim |    Sim |
-| Editar qualquer post |   Sim |    Sim |    Não |
-| Editar próprio post  |   Sim |    Sim |    Sim |
-| Publicar post        |   Sim |    Sim |    Não |
-| Arquivar post        |   Sim |    Sim |    Não |
-| Gerenciar usuários   |   Sim |    Não |    Não |
-| Gerenciar categorias |   Sim |    Sim |    Não |
+| Action                | Admin | Editor | Author |
+| --------------------- | ----: | -----: | -----: |
+| Create post            |   Yes |    Yes |    Yes |
+| Edit any post          |   Yes |    Yes |     No |
+| Edit own post           |   Yes |    Yes |    Yes |
+| Publish post            |   Yes |    Yes |     No |
+| Archive post            |   Yes |    Yes |     No |
+| Manage users            |   Yes |     No |     No |
+| Manage categories       |   Yes |    Yes |     No |
 
-### Tarefas
+### Tasks
 
-* [x] configurar autenticação (existe — sem papéis ainda, ver `docs/adr/0005-manter-auth-propria.md`);
-* [x] proteger rotas admin — `roleProcedure(allowed)` (`src/server/createRouter.ts`) gateia `category.create` e `user.updateRole` a `ADMIN`/`EDITOR`; post edit/delete de terceiros liberado pra `ADMIN`/`EDITOR` via bypass de ownership (013);
-* [x] criar middleware de autorização — `roleProcedure`, camada de guard tRPC (mesmo nível de `verifiedProcedure`), não `src/middleware.tsx`/Edge (checagem de role depende do DB, ver `013-role-based-permissions/spec.md` § 5);
-* [x] criar helper de permissões — `src/lib/permissions/` (`MatrixPermission`, mesmo padrão adapter+implementation de `rateLimit`/`slug`);
-* [x] adicionar testes das regras de permissão — `src/lib/permissions/__test__/matrix.ts` + testes de bypass em `post`/`category`/`user` procedures.
+* [x] set up authentication (exists — no roles yet, see `docs/adr/0005-manter-auth-propria.md`);
+* [x] protect admin routes — `roleProcedure(allowed)` (`src/server/createRouter.ts`) gates `category.create` and `user.updateRole` to `ADMIN`/`EDITOR`; editing/deleting another user's post is allowed for `ADMIN`/`EDITOR` via an ownership bypass (013);
+* [x] create an authorization middleware — `roleProcedure`, a tRPC guard layer (the same level as `verifiedProcedure`), not `src/middleware.tsx`/Edge (the role check depends on the DB, see `013-role-based-permissions/spec.md` § 5);
+* [x] create a permissions helper — `src/lib/permissions/` (`MatrixPermission`, same adapter+implementation pattern as `rateLimit`/`slug`);
+* [x] add tests for the permission rules — `src/lib/permissions/__test__/matrix.ts` plus bypass tests in the `post`/`category`/`user` procedures.
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando o sistema impede ações indevidas tanto no frontend quanto no backend.
+This phase is done when the system prevents improper actions both in the frontend and the backend.
 
-Ponto importante: **não confie só no botão escondido no frontend**. A regra precisa estar protegida no backend também.
+Important point: **do not rely only on a hidden button in the frontend**. The rule must also be enforced in the backend.
 
-## Fase 4 — Workflow editorial ✅ Concluída (com 1 pendência adiada)
+## Phase 4 — Editorial workflow ✅ Done (with 1 item deferred)
 
-> **Implementação:** `docs/features/014-post-review-workflow/` (RF-09). Fecha a pendência deixada pela Fase 3 (`013-role-based-permissions/spec.md` § 4): Author não publica/arquiva mais o próprio post direto, precisa passar pelo workflow de revisão. "Histórico de alterações" (diff de cada edição, `PostRevision`) fica adiado — decisão do dono, 2026-07-14 (`014-post-review-workflow/spec.md` § 4), mesmo padrão da Fase 2 (upload de imagem adiado pra Fase 8).
+> **Implementation:** `docs/features/014-post-review-workflow/` (RF-09). Closes the item left by Phase 3 (`013-role-based-permissions/spec.md` § 4): an Author no longer publishes/archives their own post directly, they must go through the review workflow. "Change history" (a diff of each edit, `PostRevision`) is deferred — owner decision, 2026-07-14 (`014-post-review-workflow/spec.md` § 4), the same pattern as Phase 2 (image upload deferred to Phase 8).
 
-### Objetivo
+### Objective
 
-Deixar o blog mais próximo de uma plataforma real de publicação.
+Bring the blog closer to a real publishing platform.
 
-### Novos status
+### New statuses
 
 ```ts
 enum PostStatus {
@@ -269,66 +269,66 @@ enum PostStatus {
 }
 ```
 
-### Funcionalidades
+### Features
 
-* [x] enviar post para revisão — `post.submitForReview` (dono, só a partir de `DRAFT`);
-* [x] aprovar post — `post.publish` a partir de `IN_REVIEW` (Admin/Editor);
-* [x] rejeitar post — `post.reject`, motivo obrigatório, volta pra `DRAFT` (Admin/Editor);
-* [x] publicar imediatamente — `post.publish` a partir de `DRAFT`, pulando revisão (Admin/Editor);
-* [x] agendar publicação — `post.publish` com `scheduledAt` futuro → `SCHEDULED`; visibilidade pública resolvida via checagem lazy no read (`scheduledAt <= now`), sem scheduler/job novo;
-* [x] arquivar post — `post.archive`, qualquer status exceto já arquivado (Admin/Editor; Author perde o bypass que tinha na Fase 3);
-* [ ] histórico de alterações — adiado (diff de cada edição, `PostRevision`), ver nota acima;
-* [x] comentários internos de revisão — `PostReviewComment`, lido via `post.readReviewComments` (dono do post ou Admin/Editor).
+* [x] submit post for review — `post.submitForReview` (owner, only from `DRAFT`);
+* [x] approve post — `post.publish` from `IN_REVIEW` (Admin/Editor);
+* [x] reject post — `post.reject`, reason required, goes back to `DRAFT` (Admin/Editor);
+* [x] publish immediately — `post.publish` from `DRAFT`, skipping review (Admin/Editor);
+* [x] schedule publication — `post.publish` with a future `scheduledAt` → `SCHEDULED`; public visibility is resolved via a lazy check on read (`scheduledAt <= now`), no new scheduler/job;
+* [x] archive post — `post.archive`, any status except already archived (Admin/Editor; the Author loses the bypass they had in Phase 3);
+* [ ] change history — deferred (diff of each edit, `PostRevision`), see note above;
+* [x] internal review comments — `PostReviewComment`, read via `post.readReviewComments` (post owner or Admin/Editor).
 
-### Modelos novos
+### New models
 
 ```ts
 PostRevision
 PostReviewComment
 ```
 
-### Regras importantes
+### Important rules
 
-* author cria post como `DRAFT`;
-* author pode enviar para `IN_REVIEW`;
-* editor/admin pode aprovar;
-* editor/admin pode publicar;
-* post agendado só aparece publicamente depois da data;
-* alterações importantes geram revisão.
+* an author creates a post as `DRAFT`;
+* an author can submit for `IN_REVIEW`;
+* an editor/admin can approve;
+* an editor/admin can publish;
+* a scheduled post appears publicly only after the date;
+* important changes generate a revision.
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando existe um fluxo real:
+This phase is done when there is a real flow:
 
 ```txt
 DRAFT -> IN_REVIEW -> SCHEDULED/PUBLISHED
 ```
 
-Aqui o projeto começa a ficar com cara de pleno, porque deixa de ser CRUD e passa a ter **regra de negócio**.
+At this point the project starts to look mid-level, because it stops being plain CRUD and starts having **business rules**.
 
-## Fase 5 — SEO e publicação profissional ✅ Concluída
+## Phase 5 — SEO and professional publishing ✅ Done
 
-> **Implementação:** `docs/features/015-seo-metadata/` (RF-10). SEO automático — sitemap/robots/RSS/canonical/Twitter Card/schema.org — tudo computado dos campos já existentes do post (`title`/`content`/`slug`/`coverImageUrl`/`createdAt`/`updatedAt`), sem migration. Decisão do dono, 2026-07-14 (`015-seo-metadata/spec.md` § 4/§ 7): campos editáveis de override (`seoTitle`/`seoDescription`/`canonicalUrl`) e "slug amigável + redirect quando slug mudar" ficavam adiados por falta de demanda — fechadas em `docs/features/018-seo-overrides-slug-redirect/` (2026-07-18, US-015): slug agora é editável (Autor/Editor, mesma regra de `post.update`), com resolução de colisão via sufixo numérico (mesmo algoritmo do create) e redirect 301 automático do slug antigo pro novo (`Post.previousSlug`, 1 nível de histórico — ver `docs/ach.md § 3.1`); `seoTitle`/`seoDescription`/`canonicalUrl` editáveis no form de edição, com fallback pro comportamento computado quando vazios.
+> **Implementation:** `docs/features/015-seo-metadata/` (RF-10). Automatic SEO — sitemap/robots/RSS/canonical/Twitter Card/schema.org — all computed from fields the post already had (`title`/`content`/`slug`/`coverImageUrl`/`createdAt`/`updatedAt`), no migration. Owner decision, 2026-07-14 (`015-seo-metadata/spec.md` § 4/§ 7): editable override fields (`seoTitle`/`seoDescription`/`canonicalUrl`) and "friendly slug + redirect when the slug changes" were deferred for lack of demand — closed in `docs/features/018-seo-overrides-slug-redirect/` (2026-07-18, US-015): the slug is now editable (Author/Editor, same rule as `post.update`), with collision resolution via a numeric suffix (same algorithm as create) and an automatic 301 redirect from the old slug to the new one (`Post.previousSlug`, 1 level of history — see `docs/ach.md § 3.1`); `seoTitle`/`seoDescription`/`canonicalUrl` are editable in the edit form, falling back to the computed behavior when empty.
 
-### Objetivo
+### Objective
 
-Fazer o blog ser indexável e bem apresentado quando compartilhado.
+Make the blog indexable and well presented when shared.
 
-### Funcionalidades
+### Features
 
-* [x] metadata dinâmica por post (`generateMetadata` em `src/app/(half)/post/[slug]/page.tsx`);
-* [x] title e description por post;
-* [x] Open Graph (title/description/type/image — `coverImageUrl` já wireado como `ogImageUrl`, `015`);
-* [x] Twitter Card (`summary_large_image` com capa, `summary` sem capa, `015`);
-* [x] canonical URL (self-referencial via `alternates.canonical` + `metadataBase`, `015`);
-* [x] sitemap.xml dinâmico (`src/app/sitemap.ts`, só posts publicamente visíveis, `015`);
-* [x] robots.txt (`src/app/robots.ts`, bloqueia rotas privadas, aponta pro sitemap, `015`);
+* [x] dynamic metadata per post (`generateMetadata` in `src/app/(half)/post/[slug]/page.tsx`);
+* [x] title and description per post;
+* [x] Open Graph (title/description/type/image — `coverImageUrl` already wired as `ogImageUrl`, `015`);
+* [x] Twitter Card (`summary_large_image` with a cover, `summary` without one, `015`);
+* [x] canonical URL (self-referential via `alternates.canonical` + `metadataBase`, `015`);
+* [x] dynamic sitemap.xml (`src/app/sitemap.ts`, only publicly visible posts, `015`);
+* [x] robots.txt (`src/app/robots.ts`, blocks private routes, points to the sitemap, `015`);
 * [x] RSS feed (`src/app/feed.xml/route.ts`, hand-rolled RSS 2.0, `015`);
-* [x] schema.org para artigo (JSON-LD `Article` embutido em `PostView`, `015`);
-* [x] slug amigável (editável pelo Autor/Editor, `018`);
-* [x] redirect quando slug muda (301 automático via `previousSlug`, `018`).
+* [x] schema.org for the article (JSON-LD `Article` embedded in `PostView`, `015`);
+* [x] friendly slug (editable by Author/Editor, `018`);
+* [x] redirect when the slug changes (automatic 301 via `previousSlug`, `018`).
 
-### Campos novos no post
+### New post fields
 
 ```ts
 seoTitle
@@ -339,45 +339,45 @@ publishedAt
 updatedAt
 ```
 
-> **Nota (`015`, 2026-07-14):** nenhum desses campos foi adicionado ao schema nesta rodada — `ogImageUrl` reusa `coverImageUrl` (`010`) já existente; `seoTitle`/`seoDescription`/`canonicalUrl` como colunas editáveis ficaram adiados (sem pedido de UI pra customizar SEO diferente do conteúdo do post); `publishedAt` não foi necessário — `lastModified`/`pubDate` usam `updatedAt`/`createdAt` já existentes.
+> **Note (`015`, 2026-07-14):** none of these fields were added to the schema in this round — `ogImageUrl` reuses the existing `coverImageUrl` (`010`); `seoTitle`/`seoDescription`/`canonicalUrl` as editable columns were deferred (no request for UI to customize SEO differently from the post content); `publishedAt` was not needed — `lastModified`/`pubDate` use the existing `updatedAt`/`createdAt`.
 >
-> **Nota (`018`, 2026-07-18):** `seoTitle`/`seoDescription`/`canonicalUrl` adicionados ao schema (nullable) + editáveis no form de edição do post; `Post.previousSlug` (nullable, `@unique`) adicionado pra suportar o redirect — não estava listado acima porque a decisão de como implementar o redirect (coluna única vs. tabela de histórico) só foi tomada nesta rodada (ver `018-seo-overrides-slug-redirect/plan.md § 4`).
+> **Note (`018`, 2026-07-18):** `seoTitle`/`seoDescription`/`canonicalUrl` added to the schema (nullable) and made editable in the post edit form; `Post.previousSlug` (nullable, `@unique`) added to support the redirect — not listed above because the decision on how to implement the redirect (single column vs. history table) was made only in this round (see `018-seo-overrides-slug-redirect/plan.md § 4`).
 
-### Regras importantes
+### Important rules
 
-* todo post publicado precisa ter metadata — ✅ (`generateMetadata` roda pra qualquer slug lido);
-* slug antigo deve redirecionar para slug novo — ✅ (`018`, `previousSlug` + `post.readRedirectSlug` + `permanentRedirect` em `PostContent`; só 1 nível de histórico — ver `018-seo-overrides-slug-redirect/spec.md § 4`);
-* sitemap só inclui posts publicados — ✅ (reusa `publicVisibilityFilter()` de `014`, inclui `SCHEDULED` já vencido);
-* posts arquivados não entram no sitemap — ✅ (mesma regra).
+* every published post must have metadata — ✅ (`generateMetadata` runs for any slug read);
+* an old slug must redirect to the new slug — ✅ (`018`, `previousSlug` + `post.readRedirectSlug` + `permanentRedirect` in `PostContent`; only 1 level of history — see `018-seo-overrides-slug-redirect/spec.md § 4`);
+* the sitemap includes only published posts — ✅ (reuses `publicVisibilityFilter()` from `014`, includes `SCHEDULED` that has already elapsed);
+* archived posts do not enter the sitemap — ✅ (same rule).
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando cada post tem SEO completo e pode ser compartilhado corretamente no Discord, LinkedIn, WhatsApp, etc. **Satisfeito** — itens automáticos (`015`) e slug amigável + redirect + overrides de SEO editáveis (`018`).
+This phase is done when every post has full SEO and can be shared correctly on Discord, LinkedIn, WhatsApp, etc. **Satisfied** — automatic items (`015`) and friendly slug + redirect + editable SEO overrides (`018`).
 
-## Fase 6 — Busca e descoberta de conteúdo ✅ Concluída
+## Phase 6 — Search and content discovery ✅ Done
 
-> **Implementação:** `docs/features/016-search-content/` (RF-11). `post.search` busca por título/conteúdo (`contains`/`insensitive` do Prisma, não `tsvector` nativo — ver nota abaixo), com sugestões enquanto digita no header reusando o mesmo endpoint. `docs/features/019-search-sort-by-views/` (2026-07-18): `post.search` ganhou `sortBy: "recent" | "mostViewed"` (default `"recent"`, comportamento inalterado), com tiebreak por `id` no `orderBy` pra manter a paginação cursor-based determinística sob empate de `viewCount`; `<select>` em `/search` deixa o leitor escolher. Fechou a pendência que a Fase 7 (contador de views) desbloqueou.
+> **Implementation:** `docs/features/016-search-content/` (RF-11). `post.search` searches by title/content (Prisma `contains`/`insensitive`, not native `tsvector` — see note below), with suggestions as you type in the header, reusing the same endpoint. `docs/features/019-search-sort-by-views/` (2026-07-18): `post.search` gained `sortBy: "recent" | "mostViewed"` (default `"recent"`, unchanged behavior), with a tiebreak by `id` in `orderBy` to keep cursor-based pagination deterministic under a `viewCount` tie; a `<select>` on `/search` lets the reader choose. This closed the item that Phase 7 (view counter) unblocked.
 
-### Objetivo
+### Objective
 
-Melhorar navegação e descoberta dos posts.
+Improve navigation and discovery of posts.
 
-### Funcionalidades
+### Features
 
-* [x] busca por título (`post.search`, `016`);
-* [x] busca por conteúdo (`post.search`, `016`);
-* [x] filtro por tag (já existia via `readRecent`/`readOwn`/`readRelated`; `016` estende o mesmo parâmetro pro `search`);
-* [x] filtro por categoria (idem);
-* [x] ordenação por mais recente (`readRecent` já ordena assim; `post.search` também tem isso como default — `019`);
-* [x] ordenação por mais acessado (`post.search` com `sortBy: "mostViewed"`, `019-search-sort-by-views`, 2026-07-18 — desbloqueado pelo `Post.viewCount` da Fase 7);
-* [x] posts relacionados (`post.readRelated`, já implementado na Fase 1 — `007-posts-relacionados`);
-* [x] autocomplete opcional (`016` — sugestões no `SearchBox` do header, reusando `post.search` com `limit` pequeno, sem endpoint dedicado).
+* [x] search by title (`post.search`, `016`);
+* [x] search by content (`post.search`, `016`);
+* [x] filter by tag (already existed via `readRecent`/`readOwn`/`readRelated`; `016` extends the same parameter to `search`);
+* [x] filter by category (same);
+* [x] sort by most recent (`readRecent` already sorts this way; `post.search` also has this as the default — `019`);
+* [x] sort by most viewed (`post.search` with `sortBy: "mostViewed"`, `019-search-sort-by-views`, 2026-07-18 — unlocked by `Post.viewCount` from Phase 7);
+* [x] related posts (`post.readRelated`, already implemented in Phase 1 — `007-posts-relacionados`);
+* [x] optional autocomplete (`016` — suggestions in the header `SearchBox`, reusing `post.search` with a small `limit`, no dedicated endpoint).
 
-### Primeira implementação
+### First implementation
 
 Use PostgreSQL full-text search.
 
-Depois, se quiser evoluir:
+Later, if you want to evolve it:
 
 ```txt
 Meilisearch
@@ -385,34 +385,34 @@ Typesense
 Elasticsearch
 ```
 
-Mas eu começaria com Postgres mesmo. Menos infra, mais chance de terminar.
+But starting with Postgres itself is the way to go. Less infra, more chance of finishing.
 
-> **Nota (`016`, 2026-07-14):** a busca desta rodada usa `contains`/`insensitive` do Prisma, não `tsvector`/`ts_rank` nativo do Postgres. O test harness do projeto (`ADR-0011`) roda contra `prisma-mock`, um fake em JS sem parser SQL — `$queryRaw`/`to_tsvector` ficaria sem cobertura de teste automatizada (regra dura 1). Full-text search nativo (com ranking por relevância) fica pra quando existir teste de integração contra Postgres real (já cogitado em `ADR-0011` como candidato de Fase 9/10).
+> **Note (`016`, 2026-07-14):** the search in this round uses Prisma `contains`/`insensitive`, not native Postgres `tsvector`/`ts_rank`. The project's test harness (`ADR-0011`) runs against `prisma-mock`, a JS fake with no SQL parser — `$queryRaw`/`to_tsvector` would end up without automated test coverage (hard rule 1). Native full-text search (with relevance ranking) is deferred until there is an integration test against a real Postgres (already considered in `ADR-0011` as a Phase 9/10 candidate).
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando o usuário consegue encontrar posts facilmente sem depender só da listagem cronológica.
+This phase is done when the user can find posts easily without relying only on the chronological listing.
 
-## Fase 7 — Analytics interno ✅ Concluída
+## Phase 7 — Internal analytics ✅ Done
 
-> **Implementação:** `docs/features/017-post-view-analytics/` (RF-12). `analytics.recordView` registra visualização de post público (dedup por visitante em 24h via cookie de primeira parte + Redis, `ADR-0013`), `analytics.readDashboard` (Admin/Editor) mostra total de views e ranking de mais acessados. `docs/features/020-view-analytics-breakdown/` (2026-07-18) fechou a pendência adiada em `017-post-view-analytics/spec.md § 4`: breakdown por período (últimos 7/30 dias), origem de tráfego (classificada do header `Referer`) e navegador/SO (classificado do `User-Agent` bruto). Decisão de retenção/privacidade (owner, 2026-07-18): eventos brutos retidos 30 dias com deleção lazy no read (sem cron), nenhum IP persistido.
+> **Implementation:** `docs/features/017-post-view-analytics/` (RF-12). `analytics.recordView` records a view of a public post (dedup per visitor for 24h via a first-party cookie plus Redis, `ADR-0013`), `analytics.readDashboard` (Admin/Editor) shows total views and a most-viewed ranking. `docs/features/020-view-analytics-breakdown/` (2026-07-18) closed the item deferred in `017-post-view-analytics/spec.md § 4`: breakdown by period (last 7/30 days), traffic source (classified from the `Referer` header), and browser/OS (classified from the raw `User-Agent`). Retention/privacy decision (owner, 2026-07-18): raw events kept for 30 days with lazy deletion on read (no cron), no IP persisted.
 
-### Objetivo
+### Objective
 
-Criar um painel para acompanhar desempenho dos posts.
+Build a dashboard to track post performance.
 
-### Funcionalidades
+### Features
 
-* [x] registrar visualização de post (`017`, dedup por visitante em 24h);
-* [x] contar views totais (`017`);
-* [x] contar views por período (últimos 7/30 dias, `020-view-analytics-breakdown`, 2026-07-18);
-* [x] posts mais acessados (`017`);
-* [x] origem do tráfego (classificada do header `Referer` em direto/busca/social/outro, `020-view-analytics-breakdown`, 2026-07-18);
-* [x] user agent (categorizado em navegador/SO por regex na leitura, sem lib nova, `020-view-analytics-breakdown`, 2026-07-18);
-* [x] referrer (mesmo mecanismo do item "origem do tráfego" acima — um único breakdown, não dois separados);
-* [x] dashboard administrativo (`/analytics`, restrito a Admin/Editor via `roleProcedure`, `017`).
+* [x] record a post view (`017`, dedup per visitor for 24h);
+* [x] count total views (`017`);
+* [x] count views by period (last 7/30 days, `020-view-analytics-breakdown`, 2026-07-18);
+* [x] most-viewed posts (`017`);
+* [x] traffic source (classified from the `Referer` header into direct/search/social/other, `020-view-analytics-breakdown`, 2026-07-18);
+* [x] user agent (categorized into browser/OS by regex on read, no new library, `020-view-analytics-breakdown`, 2026-07-18);
+* [x] referrer (same mechanism as the "traffic source" item above — a single breakdown, not two separate ones);
+* [x] admin dashboard (`/analytics`, restricted to Admin/Editor via `roleProcedure`, `017`).
 
-### Modelo inicial
+### Initial model
 
 ```ts
 PostView {
@@ -426,7 +426,7 @@ PostView {
 }
 ```
 
-> Esboço original da fase, anterior à implementação — mantido por histórico. O modelo real (`020-view-analytics-breakdown/plan.md § 3`) difere por decisão de privacidade do dono: sem `ipHash`/`visitorId` na tabela (dedup já resolvido via Redis, `ADR-0013`), `referrer` vira `referrerBucket` (classificado em DIRECT/SEARCH/SOCIAL/OTHER na escrita, não guarda a URL bruta), e retenção de 30 dias com deleção lazy no read.
+> Original phase sketch, prior to implementation — kept for history. The real model (`020-view-analytics-breakdown/plan.md § 3`) differs by owner privacy decision: no `ipHash`/`visitorId` in the table (dedup already solved via Redis, `ADR-0013`), `referrer` becomes `referrerBucket` (classified into DIRECT/SEARCH/SOCIAL/OTHER on write, does not store the raw URL), and 30-day retention with lazy deletion on read.
 
 ### Dashboard
 
@@ -435,45 +435,45 @@ PostView {
 /admin/analytics/posts/:id
 ```
 
-### Métricas
+### Metrics
 
-* total de views;
-* views dos últimos 7 dias;
-* views dos últimos 30 dias;
-* posts mais acessados;
-* fontes de tráfego;
-* crescimento por período.
+* total views;
+* views in the last 7 days;
+* views in the last 30 days;
+* most-viewed posts;
+* traffic sources;
+* growth by period.
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando você consegue abrir o admin e ver quais posts estão performando melhor.
+This phase is done when you can open the admin and see which posts are performing best.
 
-Essa parte é muito boa para portfólio porque mostra que você pensa além do CRUD.
+This part is very good for a portfolio because it shows you think beyond CRUD.
 
-## Fase 8 — Upload e gerenciamento de mídia ✅ Concluída (com 1 pendência adiada)
+## Phase 8 — Media upload and management ✅ Done (with 1 item deferred)
 
-> **Implementação:** `docs/features/021-media-upload/` (RF-13, US-016). Upload real de arquivo via `media.upload` (FormData pela mesma rota tRPC — `ADR-0015`), biblioteca "minha mídia" (`media.readOwn`, Admin/Editor veem de todo mundo), apagar (`media.delete`, dono ou `media:deleteAny`), alt text opcional, validação de formato (jpeg/png/webp/gif) e tamanho (5MB default) no boundary. Imagem de capa do post passa a poder vir de uma mídia enviada — a UI só preenche o `coverImageUrl` já existente (`010-post-cover-image`), sem migration em `Post`. Pendência adiada: compressão/otimização automática de imagem (decisão do dono, 2026-07-26, `021-media-upload/spec.md § 4`) — explicitamente opcional no roadmap; se o storage final vier a ser um CDN de imagem com transformação nativa (cogitado: Cloudinary), a compressão deixa de ser necessária e a pendência fecha sozinha.
+> **Implementation:** `docs/features/021-media-upload/` (RF-13, US-016). Real file upload via `media.upload` (FormData through the same tRPC route — `ADR-0015`), a "my media" library (`media.readOwn`, Admin/Editor see everyone's), delete (`media.delete`, owner or `media:deleteAny`), optional alt text, format validation (jpeg/png/webp/gif) and size (5MB default) at the boundary. A post's cover image can now come from uploaded media — the UI just fills in the existing `coverImageUrl` (`010-post-cover-image`), no migration on `Post`. Item deferred: automatic image compression/optimization (owner decision, 2026-07-26, `021-media-upload/spec.md § 4`) — explicitly optional in the roadmap; if the final storage turns out to be an image CDN with native transformation (Cloudinary is being considered), compression stops being necessary and the item closes on its own.
 
-### Objetivo
+### Objective
 
-Permitir que o sistema lide com imagens de forma organizada.
+Let the system handle images in an organized way.
 
-### Funcionalidades
+### Features
 
-* [x] upload de imagem (`021`);
-* [x] listagem de mídias (`021`, `/media`);
-* [x] remover mídia (`021`);
-* [x] imagem de capa para post (`021`, reusa `coverImageUrl` de `010`);
+* [x] image upload (`021`);
+* [x] media listing (`021`, `/media`);
+* [x] remove media (`021`);
+* [x] cover image for a post (`021`, reuses `coverImageUrl` from `010`);
 * [x] alt text (`021`);
-* [x] validação de tamanho (`021`, 5MB default via `MEDIA_MAX_UPLOAD_SIZE_BYTES`);
-* [x] validação de formato (`021`, jpeg/png/webp/gif);
-* [ ] compressão/otimização opcional — adiada, ver nota acima.
+* [x] size validation (`021`, 5MB default via `MEDIA_MAX_UPLOAD_SIZE_BYTES`);
+* [x] format validation (`021`, jpeg/png/webp/gif);
+* [ ] optional compression/optimization — deferred, see note above.
 
-### Implementação sugerida
+### Suggested implementation
 
-Comece com armazenamento local em desenvolvimento.
+Start with local storage in development.
 
-Depois evolua para:
+Then move to:
 
 ```txt
 Cloudflare R2
@@ -481,9 +481,9 @@ AWS S3
 MinIO local
 ```
 
-> **Nota (`021`, 2026-07-26):** armazenamento local implementado (`public/uploads/`, volume Docker pra persistir entre restarts). O gateway `mediaStorage` (`ADR-0015`) é pluggável — trocar por Cloudinary/S3/R2 depois é só uma implementação nova, sem tocar domain/procedure.
+> **Note (`021`, 2026-07-26):** local storage implemented (`public/uploads/`, Docker volume to persist across restarts). The `mediaStorage` gateway (`ADR-0015`) is pluggable — swapping in Cloudinary/S3/R2 later is just a new implementation, without touching domain/procedure.
 
-### Modelo
+### Model
 
 ```ts
 Media {
@@ -499,58 +499,58 @@ Media {
 }
 ```
 
-> **Nota (`021`, 2026-07-26):** `storageKey` foi adicionado ao esboço original — identificador opaco de storage (caminho local hoje, `public_id` num CDN de imagem depois), distinto da `url` pública. Decisão registrada em `ADR-0015`.
+> **Note (`021`, 2026-07-26):** `storageKey` was added to the original sketch — an opaque storage identifier (a local path today, a `public_id` on an image CDN later), distinct from the public `url`. Decision recorded in `ADR-0015`.
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando posts conseguem usar imagens gerenciadas pelo próprio sistema. **Satisfeito** — upload, biblioteca, remoção e uso como capa (`021`); compressão/otimização fica pra quando houver demanda real ou o storage final resolver isso nativamente.
+This phase is done when posts can use images managed by the system itself. **Satisfied** — upload, library, removal, and use as cover (`021`); compression/optimization is deferred until there is real demand or the final storage handles it natively.
 
-## Fase 9 — Qualidade de produção 🟡 Parcial
+## Phase 9 — Production quality 🟡 Partial
 
-### Objetivo
+### Objective
 
-Adicionar práticas que empresas esperam de um projeto sério.
+Add practices companies expect from a serious project.
 
-### Tarefas
+### Tasks
 
-* [ ] logs estruturados (hoje é `console.log` pontual, sem lib estruturada);
-* [x] tratamento de erro padronizado — `ErrorRegistry` (`ADR-0017`, `022-error-registry`, RF-14): `DomainError` namespaced resolve `httpCode`/`message` sozinho, regra dura 15 fechada (`docs/afm.md` § 3);
-* [x] página de erro (`src/app/error.tsx`, `src/app/not-found.tsx`);
-* [ ] loading states (sem `loading.tsx` do App Router; não auditado como convenção sistemática);
-* [~] empty states — confirmado em `src/components/postFeed.tsx` ("No posts found."), não auditado em todos os componentes;
-* [x] validação com Zod (`src/server/schema/*.schema.ts`);
-* [x] testes unitários (18 arquivos `vitest` — cobertura ~8.6%, ver `docs/afm.md` § 3.1);
-* [ ] testes de integração;
-* [ ] testes e2e básicos;
-* [x] seed de desenvolvimento (`prisma/seed.ts` — 3 usuários, posts, comentários, tokens de verify/reset);
-* [x] migrations organizadas (`prisma/migrations/`);
-* [ ] rate limiting em endpoints sensíveis (ver `docs/features/001-auth-hardening/spec.md`).
+* [ ] structured logs (today it is ad hoc `console.log`, no structured library);
+* [x] standardized error handling — `ErrorRegistry` (`ADR-0017`, `022-error-registry`, RF-14): namespaced `DomainError` resolves `httpCode`/`message` on its own, closing hard rule 15 (`docs/afm.md` § 3);
+* [x] error page (`src/app/error.tsx`, `src/app/not-found.tsx`);
+* [ ] loading states (no App Router `loading.tsx`; not audited as a systematic convention);
+* [~] empty states — confirmed in `src/components/postFeed.tsx` ("No posts found."), not audited across all components;
+* [x] validation with Zod (`src/server/schema/*.schema.ts`);
+* [x] unit tests (18 `vitest` files — coverage ~8.6%, see `docs/afm.md` § 3.1);
+* [ ] integration tests;
+* [ ] basic e2e tests;
+* [x] development seed (`prisma/seed.ts` — 3 users, posts, comments, verify/reset tokens);
+* [x] organized migrations (`prisma/migrations/`);
+* [ ] rate limiting on sensitive endpoints (see `docs/features/001-auth-hardening/spec.md`).
 
-### Testes importantes
+### Important tests
 
-* criar post;
-* editar post;
-* publicar post;
-* impedir author de publicar;
-* impedir acesso ao admin sem login;
-* gerar slug único;
-* buscar posts;
-* registrar view;
-* gerar sitemap.
+* create post;
+* edit post;
+* publish post;
+* prevent an author from publishing;
+* prevent access to admin without login;
+* generate a unique slug;
+* search posts;
+* record a view;
+* generate the sitemap.
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando o projeto tem uma cobertura mínima das regras mais importantes e não depende de teste manual para tudo.
+This phase is done when the project has minimal coverage of the most important rules and does not depend on manual testing for everything.
 
-## Fase 10 — CI/CD e deploy ⬜ Não iniciada
+## Phase 10 — CI/CD and deploy ⬜ Not started
 
-### Objetivo
+### Objective
 
-Colocar o projeto no ar com pipeline minimamente profissional. Hoje não há `.github/workflows/` nem deploy configurado — validação é só via `.husky/` local (ver `docs/afm.md` § 6).
+Get the project live with an at-least-minimally professional pipeline. Today there is no `.github/workflows/` and no deploy configured — validation is only via local `.husky/` (see `docs/afm.md` § 6).
 
-### Pipeline sugerido
+### Suggested pipeline
 
-Ao abrir PR ou fazer push:
+On opening a PR or pushing:
 
 ```txt
 install
@@ -562,64 +562,64 @@ build
 
 ### Deploy
 
-Opções boas:
+Good options:
 
 ```txt
-Vercel + PostgreSQL externo
+Vercel + external PostgreSQL
 Railway
 Render
 Fly.io
-VPS com Docker
+VPS with Docker
 ```
 
-Para portfólio, Vercel + banco externo é o caminho mais simples.
+For a portfolio, Vercel + an external database is the simplest path.
 
-Para mostrar mais infra, VPS com Docker é mais interessante.
+To show more infra, a VPS with Docker is more interesting.
 
-### Docker Compose final
+### Final Docker Compose
 
 ```txt
 app
 postgres
 redis
-minio opcional
+minio optional
 ```
 
-**Pendência herdada de `001-auth-hardening` (2026-07-12):** `docker-compose.yml` de produção hoje tem credenciais Postgres hardcoded (`postgres`/`postgres`) e expõe a porta do Postgres ao host sem necessidade (app e Postgres já estão na mesma rede Docker). Endereçar junto do hardening de infra desta fase — não é regressão nova, é debt pré-existente que o hardening de aplicação (feature 001) deliberadamente não cobriu (fora de escopo, decisão do dono).
+**Item inherited from `001-auth-hardening` (2026-07-12):** the production `docker-compose.yml` today has hardcoded Postgres credentials (`postgres`/`postgres`) and exposes the Postgres port to the host without need (the app and Postgres are already on the same Docker network). Address this along with the infra hardening in this phase — not a new regression, it is pre-existing debt that the application hardening (feature 001) deliberately did not cover (out of scope, owner decision).
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando:
+This phase is done when:
 
-* o projeto está online;
-* o README explica como rodar;
-* o pipeline valida o código;
-* o banco tem migrations;
-* existe ambiente de produção minimamente estável.
+* the project is online;
+* the README explains how to run it;
+* the pipeline validates the code;
+* the database has migrations;
+* a minimally stable production environment exists.
 
-## Fase 11 — Observabilidade ⬜ Não iniciada
+## Phase 11 — Observability ⬜ Not started
 
-### Objetivo
+### Objective
 
-Mostrar maturidade técnica.
+Show technical maturity.
 
-### Funcionalidades
+### Features
 
-* [ ] logs estruturados;
+* [ ] structured logs;
 * [ ] request ID;
-* [ ] tempo de resposta das rotas;
-* [ ] tracing básico com OpenTelemetry;
-* [ ] métricas simples;
+* [ ] route response time;
+* [ ] basic tracing with OpenTelemetry;
+* [ ] simple metrics;
 * [ ] health check;
-* [ ] endpoint `/api/health` (hoje só existe `/api/trpc/[trpc]`).
+* [ ] `/api/health` endpoint (today only `/api/trpc/[trpc]` exists).
 
-### Exemplo
+### Example
 
 ```txt
 GET /api/health
 ```
 
-Retorno:
+Response:
 
 ```json
 {
@@ -629,139 +629,140 @@ Retorno:
 }
 ```
 
-### Critério de conclusão
+### Completion criterion
 
-Essa fase está pronta quando você consegue entender o que está acontecendo no sistema sem precisar ficar dando `console.log` aleatório.
+This phase is done when you can understand what is happening in the system without resorting to random `console.log` calls.
 
-## Ordem recomendada
+## Recommended order
 
-Eu faria exatamente nessa ordem:
+I would follow exactly this order:
 
 ```txt
-Fase 0 — Organização inicial
-Fase 1 — Blog público
-Fase 2 — Admin/CMS
-Fase 3 — Auth e permissões
-Fase 4 — Workflow editorial
-Fase 5 — SEO
-Fase 6 — Busca
-Fase 7 — Analytics
-Fase 8 — Mídia/upload
-Fase 9 — Qualidade de produção
-Fase 10 — CI/CD e deploy
-Fase 11 — Observabilidade
+Phase 0 — Initial setup
+Phase 1 — Public blog
+Phase 2 — Admin/CMS
+Phase 3 — Auth and permissions
+Phase 4 — Editorial workflow
+Phase 5 — SEO
+Phase 6 — Search
+Phase 7 — Analytics
+Phase 8 — Media/upload
+Phase 9 — Production quality
+Phase 10 — CI/CD and deploy
+Phase 11 — Observability
 ```
 
-## MVP mínimo
+## Minimal MVP
 
-Para não se perder, o primeiro grande objetivo deveria ser:
+To stay focused, the first big goal should be:
 
 ```txt
-Blog público + Admin + Auth + Publicação
+Public blog + Admin + Auth + Publishing
 ```
 
-Ou seja:
+In other words:
 
-* usuário loga;
-* cria post;
-* edita post;
-* publica post;
-* post aparece publicamente;
-* slug funciona;
-* banco funciona;
-* projeto roda com Docker.
+* the user logs in;
+* creates a post;
+* edits a post;
+* publishes a post;
+* the post appears publicly;
+* the slug works;
+* the database works;
+* the project runs with Docker.
 
-Isso já é uma entrega fechada.
+That is already a closed delivery.
 
-## Versão boa para portfólio
+## Portfolio-ready version
 
-Depois do MVP, mire nisso:
+After the MVP, aim for this:
 
 ```txt
-Blog público
+Public blog
 Admin/CMS
 Auth
 Roles
-Workflow editorial
-SEO completo
-Busca
+Editorial workflow
+Full SEO
+Search
 Analytics
-Upload de imagens
-Testes
+Image upload
+Tests
 CI/CD
 Deploy
-README técnico
+Technical README
 ```
 
-Essa versão já é bem forte para nível pleno.
+This version is already quite strong for a mid-level role.
 
-## Versão excelente
+## Excellent version
 
-Para deixar acima da média:
+To stand out above average:
 
 ```txt
 OpenTelemetry
-Logs estruturados
-Preview de post
-Agendamento de publicação
-Histórico de revisões
-Redirect de slug antigo
+Structured logs
+Post preview
+Publication scheduling
+Revision history
+Old-slug redirect
 RSS feed
-Dashboard de analytics
+Analytics dashboard
 Rate limiting
-Docker production-ready
+Production-ready Docker
 ```
 
-Isso já passa uma imagem muito melhor do que um CRUD comum.
+This gives a much better impression than a plain CRUD.
 
-## O que colocar no README
+## What to put in the README
 
-Quando o projeto estiver mais maduro, o README precisa vender bem o projeto.
+When the project is more mature, the README needs to sell the project well.
 
-Estrutura boa:
+Good structure:
 
 ```txt
-# Nome do projeto
+# Project name
 
-## Sobre
-## Funcionalidades
+## About
+## Features
 ## Stack
-## Arquitetura
-## Decisões técnicas
-## Como rodar localmente
-## Variáveis de ambiente
-## Scripts disponíveis
-## Testes
+## Architecture
+## Technical decisions
+## How to run locally
+## Environment variables
+## Available scripts
+## Tests
 ## Deploy
 ## Roadmap
 ## Screenshots
 ```
 
-A parte mais importante é **Decisões técnicas**.
+The most important part is **Technical decisions**.
 
-Exemplo:
+Example:
 
 ```txt
-Decidi separar regras de publicação em uma camada de domínio para evitar que regras importantes ficassem espalhadas entre rotas, componentes e chamadas diretas ao Prisma.
+I decided to separate publishing rules into a domain layer to prevent important rules from being scattered across routes, components, and direct Prisma calls.
 ```
 
-Isso mostra maturidade.
+This shows maturity.
 
-## Recomendação direta
+## Direct recommendation
 
-Não tente fazer tudo de uma vez.
+Do not try to do everything at once.
 
-Primeiro, entregue isso:
+First, deliver this:
 
 ```txt
-1. Blog público funcionando
-2. Admin funcionando
-3. Auth funcionando
-4. Publicação funcionando
-5. README decente
+1. Public blog working
+2. Admin working
+3. Auth working
+4. Publishing working
+5. Decent README
 6. Deploy online
 ```
 
-Depois você adiciona SEO, busca, analytics, workflow, testes e observabilidade.
+Then add SEO, search, analytics, workflow, tests, and observability.
 
-O projeto começa simples, mas pode virar uma aplicação bem próxima de produção. O diferencial não vai ser a ideia. Vai ser a execução.
+The project starts simple, but can become an application very close to production. The differentiator will not be the idea. It will be the execution.
+</content>

--- a/docs/rubrics/enum-vs-union-vs-branded.md
+++ b/docs/rubrics/enum-vs-union-vs-branded.md
@@ -1,30 +1,30 @@
-# Rubrica — enum vs union literal vs branded type vs Zod schema
+# Rubric — enum vs literal union vs branded type vs Zod schema
 
-## Tabela de decisão
+## Decision table
 
-| Caso | Escolha | Anti-pattern |
+| Case | Choice | Anti-pattern |
 | --- | --- | --- |
-| Valor existe no DB (status, role, plano) — **neste repo** | `enum` no `schema.prisma` pra persistência **+ union literal hand-rolled** no model do app (`src/server/models/<entity>.ts`, ex. `IPostStatus`/`IRole`), nunca o tipo gerado importado de `@prisma/client` fora de `infra/drivers/`/`test/prisma/` | Importar o tipo do Prisma client (`import { Role } from "@prisma/client"`) em domain/procedure/lib — acopla o app ao client gerado onde o resto do código já não faz isso |
-| ≤ 5 valores fechados, só vivem em código | **Union literal** (`"latest" \| "next" \| "beta"`) | Enum TS puro — gera lixo de transpilação, não tree-shakeable |
-| String aberta com regra (user-input, dist-tag livre) | **Schema parser** (Zod) + parse no boundary | Validar dentro do domain (viola regra dura 16) |
-| Primitivo com invariante semântica (sha256, userId ≠ sessionId, currency cents) | **Branded type** (`type Hash = string & { __brand: "Hash" }`) | `string` cru — perde checagem em call-site |
-| Valor opaco vindo de SDK externo (Stripe price id) | Tipo da SDK + Zod no boundary | Re-tipar como branded — duplica SDK |
+| A value exists in the DB (status, role, plan) — **in this repo** | `enum` in `schema.prisma` for persistence **+ a hand-rolled literal union** in the app model (`src/server/models/<entity>.ts`, e.g. `IPostStatus`/`IRole`), never the generated type imported from `@prisma/client` outside `infra/drivers/`/`test/prisma/` | Importing the Prisma-client type (`import { Role } from "@prisma/client"`) in domain/procedure/lib — it couples the app to the generated client where the rest of the code already does not |
+| ≤ 5 closed values, live only in code | **Literal union** (`"latest" \| "next" \| "beta"`) | A pure TS enum — it generates transpilation garbage, not tree-shakeable |
+| An open string with a rule (user-input, a free dist-tag) | **Schema parser** (Zod) + parse at the boundary | Validating inside the domain (violates hard rule 16) |
+| A primitive with a semantic invariant (sha256, userId ≠ sessionId, currency cents) | **Branded type** (`type Hash = string & { __brand: "Hash" }`) | Raw `string` — loses the check at the call site |
+| An opaque value from an external SDK (Stripe price id) | The SDK type + Zod at the boundary | Re-typing as branded — duplicates the SDK |
 
-## Quando branded type vence
+## When a branded type wins
 
-- Função aceita 2 strings com semântica diferente (`copy(from: string, to: string)`) — branded evita trocar ordem.
-- Hash, ID, currency em cents, timestamp em ms vs s — branded torna conversão explícita.
-- ID de domínio diferente (UserId vs SessionId vs OrgId) — branded evita passar UserId onde pediu OrgId.
+- A function accepts 2 strings with different semantics (`copy(from: string, to: string)`) — branded avoids swapping the order.
+- Hash, ID, currency in cents, timestamp in ms vs s — branded makes the conversion explicit.
+- A different domain ID (UserId vs SessionId vs OrgId) — branded avoids passing a UserId where it asked for an OrgId.
 
-## Quando branded type NÃO compensa
+## When a branded type is NOT worth it
 
-- String que vai pra log, UI, network — leitor não ganha nada.
-- Tipo já vem da SDK como string opaca — re-tipar duplica.
-- Função tem 1 parâmetro — sem ambiguidade pra resolver.
+- A string that goes to a log, UI, network — the reader gains nothing.
+- The type already comes from the SDK as an opaque string — re-typing duplicates.
+- A function has 1 parameter — no ambiguity to resolve.
 
-## Antiexemplos
+## Anti-examples
 
-- ❌ `enum Plan { FREE = "FREE", PRO = "PRO" }` em TS (enum de verdade, não union) quando o Prisma já tem `enum Plan { FREE, PRO }` — usa union literal (`"FREE" | "PRO"`) hand-rolled no model, não um enum TS espelhado nem o tipo importado de `@prisma/client` (ver linha da tabela acima — corrigido 2026-07-12 após achar o precedente real, `IPostStatus`/`IRole`, durante `013-role-based-permissions`).
-- ❌ `type DistTag = string` aceitando qualquer coisa — usa union literal se fechado, ou Zod se aberto com regra.
-- ❌ `copy(src: string, dst: string)` chamado como `copy(dst, src)` por engano — branded `SrcPath` e `DstPath` resolvem.
-- ❌ Branded em todo `string` "por consistência" — overhead sem ganho de checagem.
+- ❌ `enum Plan { FREE = "FREE", PRO = "PRO" }` in TS (a real enum, not a union) when Prisma already has `enum Plan { FREE, PRO }` — use a hand-rolled literal union (`"FREE" | "PRO"`) in the model, not a mirrored TS enum nor the type imported from `@prisma/client` (see the table row above — fixed 2026-07-12 after finding the real precedent, `IPostStatus`/`IRole`, during `013-role-based-permissions`).
+- ❌ `type DistTag = string` accepting anything — use a literal union if closed, or Zod if open with a rule.
+- ❌ `copy(src: string, dst: string)` called as `copy(dst, src)` by mistake — branded `SrcPath` and `DstPath` resolve it.
+- ❌ Branded on every `string` "for consistency" — overhead with no check gain.

--- a/docs/rubrics/episodic-vs-semantic-boundary.md
+++ b/docs/rubrics/episodic-vs-semantic-boundary.md
@@ -1,25 +1,25 @@
-# Rubrica — fronteira episódico vs semântico (o que decai vs o que é permanente)
+# Rubric — the episodic vs semantic boundary (what decays vs what is permanent)
 
-> Materializa o princípio invariante #1 ("se outro agente sem minha memória precisa saber, é doc") na dimensão **temporal**: nem todo artefato de `/docs/` é conhecimento permanente. v3.1.0+ (Fase 3 da iniciativa v3.2). Ancestral: CoALA (arXiv 2309.02427) — memória **episódica** (o que aconteceu) ≠ **semântica** (o que se sabe) ≠ **procedural** (como se faz).
+> Materializes invariant principle #1 ("if another agent without my memory needs to know it, it is a doc") on the **temporal** dimension: not every `/docs/` artifact is permanent knowledge. v3.1.0+ (Phase 3 of the v3.2 initiative). Ancestor: CoALA (arXiv 2309.02427) — **episodic** memory (what happened) ≠ **semantic** (what is known) ≠ **procedural** (how it is done).
 
-## Os tiers no AFM
+## The tiers in AFM
 
-| Tier | O que é | Onde vive | Decai? | Entra nos eixos A1–A7 do diagnose? |
+| Tier | What it is | Where it lives | Decays? | Enters the diagnose axes A1–A7? |
 |---|---|---|---|---|
-| **Semântico** | conhecimento durável: regras, arquitetura, decisões, surpresas | `afm.md`, `ach.md`, `prd.md`, `ust.md`, `gotchas.md`, `adr/`, `learnings/`, `rubrics/` | **Não** — supersedeável (ADR Substituída, tombstone), nunca apaga | **Sim** |
-| **Procedural** | sequências repetíveis | `procedures/` | frequência/staleness (`restructure`) | Sim (cobertura herdada) |
-| **Episódico** | o que aconteceu numa sessão: estado de trabalho, handoff | `sessions/` (handoff), `_focus.md` (foco atual) | **Sim** — handoff `open` envelhecido decai (A2); `_focus` é OVERWRITE | **NÃO** (é estado, não conhecimento) |
-| **Telemetria** | log append-only de eventos/falhas | `.afm-log/`, `.afm-log-failures/` | só por rotação/retenção; auditoria = git | **NÃO** (append-only) |
+| **Semantic** | durable knowledge: rules, architecture, decisions, surprises | `afm.md`, `ach.md`, `prd.md`, `ust.md`, `gotchas.md`, `adr/`, `learnings/`, `rubrics/` | **No** — supersedable (a Superseded ADR, a tombstone), never deleted | **Yes** |
+| **Procedural** | repeatable sequences | `procedures/` | frequency/staleness (`restructure`) | Yes (inherited coverage) |
+| **Episodic** | what happened in a session: work state, handoff | `sessions/` (handoff), `_focus.md` (current focus) | **Yes** — an aged `open` handoff decays (A2); `_focus` is OVERWRITE | **NO** (it is state, not knowledge) |
+| **Telemetry** | an append-only log of events/failures | `.afm-log/`, `.afm-log-failures/` | only by rotation/retention; audit = git | **NO** (append-only) |
 
-## Critério (decisão)
+## Criterion (decision)
 
-- **É conhecimento que outro agente sem minha memória precisa pra não quebrar?** → **semântico** (permanente, entra no diagnose, nunca decai sozinho). É o #1.
-- **É "onde eu estava" / "o que aconteceu nesta sessão"?** → **episódico** (decai, fica fora do diagnose). Dar permanência a isso infla o diagnose com ruído.
-- **Promoção episódico → semântico** é o ponto do `reconcile`: quando um episódio revela uma decisão/regra/gotcha load-bearing, propõe materializar no tier semântico (gate humano, #6). O episódio é o **buffer** de onde a evolução pesca candidatos; não é a evolução.
+- **Is it knowledge that another agent without my memory needs to not break things?** → **semantic** (permanent, enters the diagnose, never decays on its own). It is #1.
+- **Is it "where I was" / "what happened in this session"?** → **episodic** (decays, stays out of the diagnose). Giving it permanence inflates the diagnose with noise.
+- **Episodic → semantic promotion** is the point of `reconcile`: when an episode reveals a load-bearing decision/rule/gotcha, propose materializing it in the semantic tier (a human gate, #6). The episode is the **buffer** from which evolution fishes candidates; it is not the evolution.
 
-## Anti-padrões
+## Anti-patterns
 
-- ❌ **Tratar handoff/`_focus` como doc normativo** — infla o diagnose (A1–A7) com estado volátil. São episódicos.
-- ❌ **Decair conhecimento semântico** — regra/decisão/gotcha não decai por idade; supersede (ADR) ou consolida (`generalize`), nunca apaga por tempo (#5: memória institucional).
-- ❌ **`_focus.md` que cresce** — é estado pequeno e sobrescrito (regra 20), não um log.
-- ❌ **Promover episódio a semântico sem cruzar o #1** — nem todo "o que aconteceu" é "o que outro precisa saber".
+- ❌ **Treating a handoff/`_focus` as a normative doc** — inflates the diagnose (A1–A7) with volatile state. They are episodic.
+- ❌ **Decaying semantic knowledge** — a rule/decision/gotcha does not decay by age; it is superseded (an ADR) or consolidated (`generalize`), never deleted by time (#5: institutional memory).
+- ❌ **A growing `_focus.md`** — it is small, overwritten state (rule 20), not a log.
+- ❌ **Promoting an episode to semantic without crossing #1** — not every "what happened" is "what another needs to know".

--- a/docs/rubrics/error-classification.md
+++ b/docs/rubrics/error-classification.md
@@ -1,66 +1,66 @@
-# Rubrica — classificação de erros (Domain ≠ Procedure ≠ Infra)
+# Rubric — error classification (Domain ≠ Procedure ≠ Infra)
 
-## Os 3 níveis
+## The 3 levels
 
-### Domain error — regra de negócio violada
+### Domain error — a violated business rule
 
-**Quem joga:** funções `domain_*` (regra de negócio pura).
+**Who throws it:** `domain_*` functions (pure business rule).
 
-**Como representa:** `throw new AppError("<domain>.<code>")` — código namespaced do `ErrorRegistry`.
+**How it is represented:** `throw new AppError("<domain>.<code>")` — a namespaced code from the `ErrorRegistry`.
 
 ```ts
-// O domain nomeia o que aconteceu. Nada mais.
+// The domain names what happened. Nothing else.
 throw new AppError("post.not_found");
 ```
 
-O `AppError` carrega **só o código** (ADR-0019). Mensagem, `retryable` e `level` são resolvidos por quem consome, via `resolveErrorEntry(code)`; o código de transporte, via `appErrorTransport` — que vive em `src/server/`, não no catálogo.
+`AppError` carries **only the code** (ADR-0019). The message, `retryable`, and `level` are resolved by the consumer, via `resolveErrorEntry(code)`; the transport code, via `appErrorTransport` — which lives in `src/server/`, not in the catalog.
 
-**Code é literal derivado do registry** (`ErrorCode = keyof typeof Errors`) — typo quebra `tsc`, não o runtime.
+**The code is a literal derived from the registry** (`ErrorCode = keyof typeof Errors`) — a typo breaks `tsc`, not the runtime.
 
-> **`Result<T, E>` foi avaliado e rejeitado** (ADR-0017 § alternativas, reafirmado em ADR-0018): o call depth do projeto é raso (domain → 1 procedure) e as procedures são pipelines lineares, então `throw` + tradução única no boundary já é o ótimo; `Result` só adicionaria cerimônia sem operador `?` nem do-notation. Esta rubrica apresentava `Result` como opção preferida até 2026-08-22 — não é mais.
+> **`Result<T, E>` was evaluated and rejected** (ADR-0017 § alternatives, reaffirmed in ADR-0018): the project's call depth is shallow (domain → 1 procedure) and the procedures are linear pipelines, so `throw` + a single translation at the boundary is already the optimum; `Result` would only add ceremony with no `?` operator or do-notation. This rubric presented `Result` as the preferred option until 2026-08-22 — no longer.
 
-### Procedure error — boundary de transport
+### Procedure error — the transport boundary
 
-**Quem joga:** procedures (handlers tRPC / route handlers / controllers).
+**Who throws it:** procedures (tRPC handlers / route handlers / controllers).
 
-**Como representa:** `TRPCError` (ou equivalente do framework — `HTTPException` no FastAPI, `BadRequestException` no Nest).
+**How it is represented:** `TRPCError` (or the framework equivalent — `HTTPException` in FastAPI, `BadRequestException` in Nest).
 
-**Boundary é unidirecional:** o transporte CONHECE o domínio e mapeia código → código de transporte. O domínio não importa `TRPCError` (regra 15) e não declara código de transporte (regra 35).
+**The boundary is one-way:** transport KNOWS the domain and maps a code → a transport code. The domain does not import `TRPCError` (rule 15) and does not declare a transport code (rule 35).
 
-**A procedure não escreve tradução nenhuma.** Ela vive num middleware montado no `baseProcedure` (ADR-0019):
+**The procedure writes no translation.** It lives in a middleware mounted on `baseProcedure` (ADR-0019):
 
 ```ts
-// a procedure inteira — sem try/catch, sem switch
+// the whole procedure — no try/catch, no switch
 .mutation(async ({ input, ctx }) =>
   domain_createComment({ ctx, input: { ...input, userId: ctx.user.id } }),
 );
 ```
 
-Se você está escrevendo `if (error instanceof AppError) throw new TRPCError(...)` numa procedure, pare: isso é a duplicação que a feature 024 removeu de 32 lugares.
+If you are writing `if (error instanceof AppError) throw new TRPCError(...)` in a procedure, stop: that is the duplication feature 024 removed from 32 places.
 
-### Infra error — falha de recurso externo
+### Infra error — an external-resource failure
 
-**Quem joga:** ninguém intencionalmente — sobe de cliente HTTP, ORM, fila.
+**Who throws it:** nobody intentionally — it comes up from an HTTP client, ORM, queue.
 
-**Como propaga:**
-- Em **Task-like** (Trigger.dev, BullMQ): deixa subir. Retry policy do orquestrador resolve.
-- Em **Procedure-like**: cathc no boundary final, log, mapeia pra `INTERNAL_SERVER_ERROR`. Não vaza stack pro client.
+**How it propagates:**
+- In a **Task-like** (Trigger.dev, BullMQ): let it rise. The orchestrator's retry policy handles it.
+- In a **Procedure-like**: catch at the final boundary, log, map it to `INTERNAL_SERVER_ERROR`. Do not leak the stack to the client.
 
 ## Anti-patterns
 
-- ❌ **Domain importando `TRPCError`.** Domain vira acoplado ao transport. Regra dura 15: `grep -rn "TRPCError" src/server/modules/**/domain/` retorna 0.
-- ❌ **`throw new Error("string genérica")` em domain.** Sem code literal, caller não consegue tratar specificamente. Use `AppError({ code: "..." as const })`.
-- ❌ **Try/catch genérico em todo await.** Erros tipados > catch genérico. Catch só se você vai tratar (mapear, logar specificamente, fazer fallback consciente). Senão deixa subir.
-- ❌ **Procedure que retorna `{ error: "..." }` em vez de jogar.** Quebra contrato do framework, força client a checar `data.error` em vez do mecanismo padrão.
-- ❌ **Misturar Domain error e Infra error no mesmo switch.** Domain code é fechado (sei todos os casos); Infra é aberto (rede pode falhar de N formas). Trate separado.
+- ❌ **Domain importing `TRPCError`.** The domain becomes coupled to transport. Hard rule 15: `grep -rn "TRPCError" src/server/modules/**/domain/` returns 0.
+- ❌ **`throw new Error("generic string")` in domain.** With no literal code, the caller cannot handle it specifically. Use `AppError({ code: "..." as const })`.
+- ❌ **A generic try/catch on every await.** Typed errors > a generic catch. Catch only if you will handle it (map, log specifically, do a conscious fallback). Otherwise let it rise.
+- ❌ **A procedure that returns `{ error: "..." }` instead of throwing.** It breaks the framework contract, forces the client to check `data.error` instead of the standard mechanism.
+- ❌ **Mixing a Domain error and an Infra error in the same switch.** A domain code is closed (I know all the cases); Infra is open (the network can fail in N ways). Handle them separately.
 
 ## Decision flow
 
 ```
-Onde estou?
-├── domain function → throw new AppError("<domain>.<code>"); nada de transporte
-├── procedure        → não traduz nada; deixa subir (o middleware traduz)
-├── boundary novo    → resolve via resolveErrorEntry + sua própria tabela de transporte
-├── task             → leva idempotência; deixa Infra subir (retry resolve)
-└── lib pura         → AppError com code do registry
+Where am I?
+├── domain function → throw new AppError("<domain>.<code>"); no transport
+├── procedure        → translate nothing; let it rise (the middleware translates)
+├── new boundary     → resolve via resolveErrorEntry + your own transport table
+├── task             → carry idempotency; let Infra rise (retry handles it)
+└── pure lib         → AppError with a code from the registry
 ```

--- a/docs/rubrics/failure-classification.md
+++ b/docs/rubrics/failure-classification.md
@@ -1,52 +1,52 @@
-# Rubrica — classificação de falha (mecânica → procedure | conceitual → learning | transiente → nada)
+# Rubric — failure classification (mechanical → procedure | conceptual → learning | transient → nothing)
 
-> Usada pelo loop CRITIC (`ops/remediate.md`) ao remediar uma falha reconhecida e registrada em `docs/.afm-log-failures/`. O discriminador é **executável**, não "sensação". Ancestral: CRITIC (arXiv 2305.11738) — reconhecimento de falha SÓ por sinal externo; auto-crítica sem ferramenta degrada (PRINCIPLES #3).
+> Used by the CRITIC loop (`ops/remediate.md`) when remediating a recognized failure recorded in `docs/.afm-log-failures/`. The discriminator is **executable**, not a "feeling". Ancestor: CRITIC (arXiv 2305.11738) — failure recognition ONLY by an external signal; self-critique without a tool degrades (PRINCIPLES #3).
 
-## Pré-requisito (gate de entrada — comum aos três)
+## Prerequisite (entry gate — common to all three)
 
-A falha **só existe** se foi reconhecida por **sinal externo**: teste vermelho persistente (cap §5.1 esgotado), `tsc`/type-check ≠0, comando de passo ≠0, regra dura violada pós-fato (gatilho no lado errado), OU **correção explícita do user**. "Eu acho que errei" **não** é falha (CRITIC). Toda falha vira **uma linha-arquivo** em `docs/.afm-log-failures/YYYY-MM-DD-<slug>.md` com `sig=<assinatura>` (chave de recorrência).
+The failure **only exists** if it was recognized by an **external signal**: a persistent red test (§5.1 cap spent), `tsc`/type-check ≠0, a step command ≠0, a hard rule violated after the fact (a trigger on the wrong side), OR **an explicit user correction**. "I think I got it wrong" is **not** a failure (CRITIC). Every failure becomes **a one-line file** in `docs/.afm-log-failures/YYYY-MM-DD-<slug>.md` with `sig=<signature>` (the recurrence key).
 
-## Os três destinos
+## The three destinations
 
-### Mecânica → `docs/procedures/<slug>.md`
+### Mechanical → `docs/procedures/<slug>.md`
 
-**Sse os três:** (1) é uma **sequência de passos repetível** com gates 0/1 por passo; (2) reincidiu — `grep -lc "sig=<hash>" docs/.afm-log-failures/*.md` ≥ 2 (**OU** correção explícita do user, que vale por 1 — o user é o oráculo); (3) tem **gatilho mecânico de início** ("quando X, rode este runbook").
-*Exemplo:* "build quebra com `type:module` no tsdown" reincidiu → runbook "ao mexer no emit, faça A→B→C, verifica 0/1".
+**Iff all three:** (1) it is a **repeatable step sequence** with 0/1 gates per step; (2) it recurred — `grep -lc "sig=<hash>" docs/.afm-log-failures/*.md` ≥ 2 (**OR** an explicit user correction, which counts as 1 — the user is the oracle); (3) it has a **mechanical start trigger** ("when X, run this runbook").
+*Example:* "the build breaks with `type:module` in tsdown" recurred → a runbook "when you touch the emit, do A→B→C, verify 0/1".
 
-### Conceitual → `docs/learnings/<slug>.md`
+### Conceptual → `docs/learnings/<slug>.md`
 
-**Sse:** o valor está na **causa** (uma lição contraintuitiva), não numa sequência mecânica de passos. Mesmo gate de promoção (1 correção do user OU ≥2× mecânica). Carrega `**Gatilho:**` por path → o `afm-pre-edit.sh` injeta em quem editar a área.
-*Exemplo:* "assumi que o webhook chega 1×; chega 2× — sempre trate idempotente" → learning com gatilho `webhook`.
+**Iff:** the value is in the **cause** (a counterintuitive lesson), not in a mechanical step sequence. The same promotion gate (1 user correction OR ≥2× mechanical). Carries a `**Gatilho:**` by path → `afm-pre-edit.sh` injects it into whoever edits the area.
+*Example:* "I assumed the webhook arrives 1×; it arrives 2× — always handle it idempotently" → a learning with a `webhook` trigger.
 
-### Transiente → nada (fica só evidência no log)
+### Transient → nothing (stays only as evidence in the log)
 
-**Sse:** resolvida no retry §5.1 (não cruzou o terminal), OU sem antídoto durável, OU o claim **não sobrevive ao conserto da causa** ("tool X está quebrada" endurece em recusa futura depois que a tool é consertada — negative-filter). Fica como linha em `.afm-log-failures/`, **não** vira artefato. É o #5 (não inventar constraint sem caso durável) e o negative-filter da Fase 4.
+**Iff:** resolved on the §5.1 retry (did not cross the terminal), OR with no durable antidote, OR the claim **does not survive the fix of the cause** ("tool X is broken" hardens into a future refusal once the tool is fixed — negative-filter). It stays as a line in `.afm-log-failures/`, does **not** become an artifact. It is #5 (do not invent a constraint without a durable case) and the Phase 4 negative-filter.
 
 ## Decision flow
 
 ```
-Falha reconhecida por sinal externo? ── não → NÃO é falha (CRITIC). Para.
-   │ sim
+Failure recognized by an external signal? ── no → NOT a failure (CRITIC). Stop.
+   │ yes
    ▼
-Registra em docs/.afm-log-failures/ (sig=).
+Record in docs/.afm-log-failures/ (sig=).
    │
-Resolvida no retry §5.1 / sem antídoto durável / claim morre ao consertar a causa?
-   ├── sim → TRANSIENTE: fica evidência, não promove.
-   └── não
+Resolved on the §5.1 retry / no durable antidote / claim dies when the cause is fixed?
+   ├── yes → TRANSIENT: stays evidence, does not promote.
+   └── no
         │
-   1 correção do user OU sig= reincidiu ≥2×?
-        ├── não → ainda só evidência (aguarda recorrência).
-        └── sim
+   1 user correction OR sig= recurred ≥2×?
+        ├── no → still just evidence (awaits recurrence).
+        └── yes
              │
-        Sequência de passos repetível com gates 0/1 + gatilho de início?
-             ├── sim → PROCEDURE (docs/procedures/)
-             └── não → LEARNING  (docs/learnings/)
+        A repeatable step sequence with 0/1 gates + a start trigger?
+             ├── yes → PROCEDURE (docs/procedures/)
+             └── no → LEARNING  (docs/learnings/)
 ```
 
-## Anti-padrões
+## Anti-patterns
 
-- ❌ **Reconhecer falha por auto-julgamento** (sem sinal externo). CRITIC: degrada.
-- ❌ **Promover falha única mecânica** a artefato (vira ruído/constraint morta). Só ≥2× — exceto correção do user (1 basta).
-- ❌ **Promover falha transiente** resolvida no §5.1. Ela nunca chega ao terminal; não é registrada como falha.
-- ❌ **Jogar tudo em `procedures/`** (procedure é *sequência mecânica*; lição conceitual é `learning`) ou **tudo em `learnings/`** (runbook repetível é `procedure`).
-- ❌ **Procedure/learning sem citar a `sig=` de origem** (rastreabilidade — regra dura 19 / R3).
+- ❌ **Recognizing a failure by self-judgment** (no external signal). CRITIC: it degrades.
+- ❌ **Promoting a single mechanical failure** to an artifact (becomes noise/a dead constraint). Only ≥2× — except a user correction (1 is enough).
+- ❌ **Promoting a transient failure** resolved on §5.1. It never reaches the terminal; it is not recorded as a failure.
+- ❌ **Throwing everything into `procedures/`** (a procedure is a *mechanical sequence*; a conceptual lesson is a `learning`) or **everything into `learnings/`** (a repeatable runbook is a `procedure`).
+- ❌ **A procedure/learning that does not cite the origin `sig=`** (traceability — hard rule 19 / R3).

--- a/docs/rubrics/negative-filters.md
+++ b/docs/rubrics/negative-filters.md
@@ -1,29 +1,29 @@
-# Rubrica — negative-filters (o que NÃO promover a doc durável)
+# Rubric — negative-filters (what NOT to promote to a durable doc)
 
-> Checklist de **rejeição** no gate de entrada de `gotcha`/`reconcile`/`remediate`. A face negativa do princípio #5 ("não inventar"): **constraint falsa é veneno** — pior que ausência, porque endurece em recusa/erro futuro. v3.1.0+ (Fase 4 da iniciativa v3.2). Evidência de campo (ai-memory): num acervo real, ~28% das páginas eram sessões de baixo sinal que só poluíam o retrieval.
+> A **rejection** checklist at the entry gate of `gotcha`/`reconcile`/`remediate`. The negative face of principle #5 ("do not invent"): **a false constraint is poison** — worse than absence, because it hardens into a future refusal/error. v3.1.0+ (Phase 4 of the v3.2 initiative). Field evidence (ai-memory): in a real collection, ~28% of the pages were low-signal sessions that only polluted retrieval.
 
-## Rejeitar (NÃO vira gotcha/learning/regra/procedure)
+## Reject (does NOT become a gotcha/learning/rule/procedure)
 
-| Anti-padrão | Por que é veneno | O que fazer |
+| Anti-pattern | Why it is poison | What to do |
 |---|---|---|
-| **Claim negativo sobre tool** ("tool X está quebrada", "lib Y não funciona") | Endurece em **recusa fóssil**: depois que a tool é consertada, o doc faz o próximo agente evitá-la sem motivo. | Registra o *workaround* concreto (se durável), não o veredito "está quebrada". Some quando a causa é consertada → transiente. |
-| **Falha transiente** (resolvida no retry §5.1, credencial/binário ausente no momento, estado de setup) | Vira **constraint morta**: a condição já não existe; o doc mente pro futuro. | Fica evidência em `.afm-log-failures/`, não artefato. Captura o *padrão de retry/fix*, não a falha temporária. |
-| **Narrativa one-off** ("nesta sessão fiz A, B, C") | Cronologia já vive em `docs/.afm-log/`/`sessions/`; como doc normativo é ruído. | Handoff episódico (`sessions/`), não doc semântico. |
-| **Status user-visível** ("o build está passando agora", "deploy ok") | Estado momentâneo, não conhecimento. | `_focus.md` (estado) ou handoff, não `gotcha`/`adr`. |
-| **Marker de release / smoke test** ("v0.1.1 publicada", "echo ok") | Operacional, não lição reusável. | `notes`/log, nunca regra/gotcha. |
-| **Regra-vibe sem gatilho** (KISS, DRY como "regra") | Sem gatilho executável 0/1 não é regra dura (#3). | Princípio em `afm.md § 1.3`, não § 3. |
+| **A negative claim about a tool** ("tool X is broken", "lib Y does not work") | It hardens into a **fossil refusal**: once the tool is fixed, the doc makes the next agent avoid it for no reason. | Record the concrete *workaround* (if durable), not the "it is broken" verdict. It disappears when the cause is fixed → transient. |
+| **A transient failure** (resolved on the §5.1 retry, a credential/binary missing at the moment, setup state) | It becomes a **dead constraint**: the condition no longer exists; the doc lies to the future. | It stays as evidence in `.afm-log-failures/`, not an artifact. Capture the *retry/fix pattern*, not the temporary failure. |
+| **A one-off narrative** ("in this session I did A, B, C") | The chronology already lives in `docs/.afm-log/`/`sessions/`; as a normative doc it is noise. | An episodic handoff (`sessions/`), not a semantic doc. |
+| **A user-visible status** ("the build is passing now", "deploy ok") | Momentary state, not knowledge. | `_focus.md` (state) or a handoff, not a `gotcha`/`adr`. |
+| **A release marker / smoke test** ("v0.1.1 published", "echo ok") | Operational, not a reusable lesson. | `notes`/log, never a rule/gotcha. |
+| **A vibe-rule with no trigger** (KISS, DRY as a "rule") | Without an executable 0/1 trigger it is not a hard rule (#3). | A principle in `afm.md § 1.3`, not § 3. |
 
-## Teste de promoção (passa o gate SE)
+## Promotion test (passes the gate IF)
 
-1. **Tem antídoto durável?** (uma ação concreta que previne, não um veredito.)
-2. **O claim sobrevive ao conserto da causa?** (se "some quando consertam X", é transiente → rejeita.)
-3. **Outro agente sem minha memória precisa saber pra não quebrar?** (#1 — senão é memória/estado, não doc.)
-4. **Reincidiu ≥2× OU é correção do user OU doc de SDK externo?** (#5 — senão é evidência, ainda não artefato.)
+1. **Does it have a durable antidote?** (a concrete preventing action, not a verdict.)
+2. **Does the claim survive the fix of the cause?** (if "it disappears when they fix X", it is transient → reject.)
+3. **Does another agent without my memory need to know it to not break things?** (#1 — otherwise it is memory/state, not a doc.)
+4. **Did it recur ≥2× OR is it a user correction OR an external SDK doc?** (#5 — otherwise it is evidence, not yet an artifact.)
 
-Os quatro **sim** → promove. Qualquer **não** estrutural → fica evidência/estado, não doc durável.
+Four **yes** → promote. Any structural **no** → it stays evidence/state, not a durable doc.
 
-## Anti-padrões (do próprio gate)
+## Anti-patterns (of the gate itself)
 
-- ❌ **Promover por precaução** ("melhor registrar pra garantir"). Constraint falsa é pior que vazio (#5).
-- ❌ **Confundir transiente com durável** — o oráculo é "sobrevive ao conserto da causa?".
-- ❌ **Tratar todo erro como gotcha** — erro reconhecido vai pro loop CRITIC (`remediate`), que aplica este filtro.
+- ❌ **Promoting as a precaution** ("better to record it just in case"). A false constraint is worse than empty (#5).
+- ❌ **Confusing transient with durable** — the oracle is "does it survive the fix of the cause?".
+- ❌ **Treating every error as a gotcha** — a recognized error goes to the CRITIC loop (`remediate`), which applies this filter.

--- a/docs/rubrics/solid-triggers.md
+++ b/docs/rubrics/solid-triggers.md
@@ -1,23 +1,23 @@
-# Rubrica — SOLID como gatilho concreto (não como folclore)
+# Rubric — SOLID as a concrete trigger (not as folklore)
 
-SOLID é vocabulário fácil de usar como argumento e difícil de usar como gatilho. Esta rubrica converte cada princípio em **gatilho mecânico** — quando aplicar, anti-pattern, exemplo.
+SOLID is vocabulary that is easy to use as an argument and hard to use as a trigger. This rubric turns each principle into a **mechanical trigger** — when to apply, anti-pattern, example.
 
-## SRP — Single Responsibility (já é regra dura 5)
+## SRP — Single Responsibility (already hard rule 5)
 
-**Gatilho:** nome do arquivo / função tem "and"/"manager"/"utils"/"helpers" sem prefixo de domínio.
+**Trigger:** the file/function name has "and"/"manager"/"utils"/"helpers" without a domain prefix.
 
-**Aplica:** parte. Um arquivo, uma responsabilidade.
+**Apply:** split. One file, one responsibility.
 
 Anti-pattern: `notification-and-billing.ts`, `user-manager.ts`, `helpers.ts`.
 
-## OCP — Open/Closed: extensão sem modificação
+## OCP — Open/Closed: extension without modification
 
-**Gatilho:** vou adicionar **provider novo** (registry NPM/GitHub/Custom; storage S3/R2/MinIO; plano novo; método de pagamento novo; canal de notificação novo).
+**Trigger:** I am going to add a **new provider** (NPM/GitHub/Custom registry; S3/R2/MinIO storage; a new plan; a new payment method; a new notification channel).
 
-**Aplica:** **arquivo novo** implementando uma porta tipada. Registrador central injeta. **Sem** `switch (provider)` espalhado em ≥ 2 arquivos.
+**Apply:** a **new file** implementing a typed port. A central registrar injects it. **No** `switch (provider)` scattered across ≥ 2 files.
 
 ```ts
-// ✅ porta + adapters + registry
+// ✅ port + adapters + registry
 type RegistryAdapter = {
   publish(tarball: Buffer, opts: PublishOpts): Promise<PublishResult>;
 };
@@ -27,43 +27,43 @@ const adapters: Record<RegistryKind, RegistryAdapter> = {
   custom:  customAdapter,
 };
 
-// ❌ switch espalhado em 3 arquivos
+// ❌ switch scattered across 3 files
 function publish(kind: RegistryKind, ...) {
-  if (kind === "npm") { /* lógica npm */ }
-  else if (kind === "github") { /* lógica github */ }
-  // ... e idem em outras funções
+  if (kind === "npm") { /* npm logic */ }
+  else if (kind === "github") { /* github logic */ }
+  // ... and the same in other functions
 }
 ```
 
-## LSP — Liskov Substitution: implementações intercambiáveis
+## LSP — Liskov Substitution: interchangeable implementations
 
-**Gatilho:** tenho **2+ implementações da mesma porta** (RegistryAdapter, StorageAdapter, EmailAdapter).
+**Trigger:** I have **2+ implementations of the same port** (RegistryAdapter, StorageAdapter, EmailAdapter).
 
-**Aplica:** todas devolvem o **mesmo shape de resultado classificado**. Adapter A não retorna `null` em conflict enquanto B joga exception.
+**Apply:** all return the **same classified result shape**. Adapter A does not return `null` on conflict while B throws an exception.
 
 ```ts
-// ✅ todas as implementações retornam o mesmo Result discriminado
+// ✅ all implementations return the same discriminated Result
 type PublishResult =
   | { code: "PUBLISHED"; version: string }
   | { code: "CONFLICT"; existingVersion: string }
   | { code: "FAILED"; reason: string };
 
-// ❌ adapter A: retorna null em conflict
+// ❌ adapter A: returns null on conflict
 async function publishNpm(): Promise<{ version: string } | null> { ... }
-// ❌ adapter B: joga exception
+// ❌ adapter B: throws an exception
 async function publishGithub(): Promise<{ version: string }> {
   throw new ConflictError(...);
 }
 ```
 
-## ISP — Interface Segregation: porta mínima
+## ISP — Interface Segregation: the minimal port
 
-**Gatilho:** função domain recebe `ctx: TRPCContext` inteiro mas só usa `ctx.db` e `ctx.log`.
+**Trigger:** a domain function receives the whole `ctx: TRPCContext` but only uses `ctx.db` and `ctx.log`.
 
-**Aplica:** declara só o que usa: `ctx: Pick<TRPCContext, "db" | "log">`. Senão teste tem que mockar o universo.
+**Apply:** declare only what you use: `ctx: Pick<TRPCContext, "db" | "log">`. Otherwise the test has to mock the universe.
 
 ```ts
-// ✅ porta mínima
+// ✅ minimal port
 async function domain_createSessionAuth({
   ctx,
   input,
@@ -72,36 +72,36 @@ async function domain_createSessionAuth({
   input: { userId: string };
 }): Promise<Result<IssuedSession, "USER_NOT_FOUND">> { ... }
 
-// ❌ ctx inteiro, esconde dependência
+// ❌ the whole ctx, hides the dependency
 async function domain_createSessionAuth({ ctx, input }: DomainInput<...>) {
-  // só usa ctx.db, mas teste tem que mockar ctx.user, ctx.session, ctx.headers, ...
+  // only uses ctx.db, but the test has to mock ctx.user, ctx.session, ctx.headers, ...
 }
 ```
 
-## DIP — Dependency Inversion: domain não conhece infra
+## DIP — Dependency Inversion: the domain does not know infra
 
-**Gatilho:** domain function ou lib pura está prestes a importar algo de framework (`TRPCError`, `req.headers`, ORM client direto sem abstração).
+**Trigger:** a domain function or a pure lib is about to import something from a framework (`TRPCError`, `req.headers`, a raw ORM client with no abstraction).
 
-**Aplica:** inverte a direção. Domain define a interface; infra implementa. Domain importa só do que está abaixo (lib pura, tipos).
+**Apply:** invert the direction. The domain defines the interface; infra implements it. The domain imports only from what is below it (pure lib, types).
 
 ```
-✅ direção correta:
-  app/   →   server/   →   server/modules/X/   →   domain/X/   →   lib/   →   tipos
+✅ correct direction:
+  app/   →   server/   →   server/modules/X/   →   domain/X/   →   lib/   →   types
   
-  Cada camada conhece a de baixo, nunca a de cima.
+  Each layer knows the one below, never the one above.
 
-❌ inversões comuns:
-  - domain/X/ importando TRPCError (transport sobe pra domain)
-  - lib/Y/ importando do server (lib não é mais publishable)
-  - lib/Y/ importando ORM type (acopla a infra)
+❌ common inversions:
+  - domain/X/ importing TRPCError (transport rises into the domain)
+  - lib/Y/ importing from the server (the lib is no longer publishable)
+  - lib/Y/ importing an ORM type (couples it to infra)
 ```
 
-## Resumo — qual perguntar quando
+## Summary — which to ask when
 
-| Sintoma | Princípio | O que faz |
+| Symptom | Principle | What to do |
 | --- | --- | --- |
-| Arquivo crescendo, vai 2+ coisas | SRP | Parte |
-| Vou adicionar 4ª variante de algo | OCP | Porta + adapters em vez de switch |
-| 2 implementações da mesma coisa retornam shapes diferentes | LSP | Padroniza Result discriminado |
-| Função recebe ctx gigante mas usa 2 campos | ISP | Pick / interface mínima |
-| Domain quer importar coisa de cima | DIP | Inverte: domain define, infra implementa |
+| A file growing, doing 2+ things | SRP | Split |
+| I am going to add a 4th variant of something | OCP | Port + adapters instead of a switch |
+| 2 implementations of the same thing return different shapes | LSP | Standardize a discriminated Result |
+| A function receives a giant ctx but uses 2 fields | ISP | Pick / minimal interface |
+| The domain wants to import something from above | DIP | Invert: the domain defines, infra implements |

--- a/docs/rubrics/template-vs-streaming-precedence.md
+++ b/docs/rubrics/template-vs-streaming-precedence.md
@@ -1,25 +1,25 @@
-# Rubrica — template congelado (offline) vs. aprendizado streaming (online): precedência, nunca soma
+# Rubric — frozen template (offline) vs streaming learning (online): precedence, never a sum
 
-> **Achado load-bearing do AWM (arXiv:2409.07429):** conhecimento **offline** (template arquitetural congelado via `export-template`) e **online** (aprendizado que o `reconcile`/`restructure` acumulam em streaming durante a vida do projeto) são **não-aditivos — combinar os dois machuca** (o resultado fica *entre* os dois e não bate nenhum). O AFM tem as duas camadas, então precisa de uma regra explícita de **precedência + tombstone**, jamais de fusão.
+> **Load-bearing finding from AWM (arXiv:2409.07429):** **offline** knowledge (an architectural template frozen via `export-template`) and **online** knowledge (learning that `reconcile`/`restructure` accumulate in streaming during the project's life) are **non-additive — combining the two hurts** (the result lands *between* the two and matches neither). AFM has both layers, so it needs an explicit rule of **precedence + tombstone**, never fusion.
 
-A regra única: quando offline e online colidem, **escolhe UM e tombstona o outro** (proveniência preservada). Nunca mantém os dois "somados", nunca funde o conteúdo.
+The single rule: when offline and online collide, **pick ONE and tombstone the other** (provenance preserved). Never keep the two "summed", never merge the content.
 
-## Tabela de decisão
+## Decision table
 
-| Situação | Regra |
+| Situation | Rule |
 | --- | --- |
-| Projeto de **origem-template** (`docs/.template` foi a semente) E o `reconcile` quer propor regra/gotcha que **contradiz** um artefato herdado do template | **Streaming vence localmente.** Aplica a regra/gotcha nova e marca o artefato herdado com `*(overridden — ver reconcile NNN / ciclo NNN)*`. **NÃO funde** os dois (non-additivity: misturar = pior que qualquer um isolado). |
-| O **mesmo conhecimento** existe no template congelado **E** numa learning streaming (duplicata, não contradição) | **Escolhe UM** (o mais recente/local em geral) e tombstona o outro. Proibido manter as duas cópias "somadas" — vira a inflação que o `diagnose A6` depois acusa. |
-| `export-template` vai **congelar** um projeto que já acumulou learnings streaming | Consolida os learnings streaming **via `/afm:generalize` ANTES** do export — eles viram parte do template congelado (offline), não uma camada paralela. Evita congelar metade e deixar a outra metade pro reconcile do consumer colidir depois. |
+| A **template-origin** project (`docs/.template` was the seed) AND `reconcile` wants to propose a rule/gotcha that **contradicts** a template-inherited artifact | **Streaming wins locally.** Apply the new rule/gotcha and mark the inherited artifact with `*(overridden — see reconcile NNN / cycle NNN)*`. **Do NOT merge** the two (non-additivity: mixing = worse than either alone). |
+| The **same knowledge** exists in the frozen template **AND** in a streaming learning (a duplicate, not a contradiction) | **Pick ONE** (the more recent/local one in general) and tombstone the other. Keeping the two copies "summed" is forbidden — it becomes the inflation `diagnose A6` later flags. |
+| `export-template` is about to **freeze** a project that already accumulated streaming learnings | Consolidate the streaming learnings **via `/afm:generalize` BEFORE** the export — they become part of the frozen template (offline), not a parallel layer. It avoids freezing half and leaving the other half for the consumer's reconcile to collide with later. |
 
-## Por que não fundir
+## Why not merge
 
-- **AWM mediu:** offline+online combinados ficam *entre* os dois e não batem nenhum. Fusão silenciosa é o pior dos mundos.
-- **Tombstone, não deleção:** a precedência preserva a proveniência (o artefato perdedor vira nota, não some) — mesma disciplina do `generalize` (gotcha fundido vira tombstone) e do princípio #6 (deleção é bright line).
-- **`reflect`/`generalize` continuam válidos** *dentro* de cada camada — o que esta rubrica proíbe é misturar **entre** camadas sem decidir a precedência.
+- **AWM measured:** offline+online combined land *between* the two and match neither. Silent fusion is the worst of both worlds.
+- **Tombstone, not deletion:** precedence preserves provenance (the losing artifact becomes a note, does not disappear) — the same discipline as `generalize` (a merged gotcha becomes a tombstone) and principle #6 (deletion is a bright line).
+- **`reflect`/`generalize` stay valid** *within* each layer — what this rubric forbids is mixing **between** layers without deciding the precedence.
 
-## Antiexemplos
+## Anti-examples
 
-- ❌ Manter a regra herdada do template **e** a regra nova do reconcile que a contradiz, esperando que "as duas valham" — viola a non-additivity; decide a precedência.
-- ❌ `export-template` congelar com learnings streaming pendentes sem consolidar antes — o consumer herda uma camada parcial que vai brigar com o próprio reconcile.
-- ❌ Fundir o texto dos dois numa terceira versão "combinada" — é exatamente o resultado *entre os dois* que o AWM mostrou ser pior.
+- ❌ Keeping the template-inherited rule **and** the new reconcile rule that contradicts it, hoping "both hold" — it violates non-additivity; decide the precedence.
+- ❌ `export-template` freezing with pending streaming learnings without consolidating first — the consumer inherits a partial layer that will fight its own reconcile.
+- ❌ Merging the text of the two into a third "combined" version — it is exactly the *between the two* result AWM showed to be worse.

--- a/docs/rubrics/validation-boundary.md
+++ b/docs/rubrics/validation-boundary.md
@@ -1,23 +1,23 @@
-# Rubrica — onde Zod (ou parser) entra
+# Rubric — where Zod (or a parser) enters
 
-## Regra única
+## The single rule
 
-Schema parser (Zod ou equivalente do stack) **valida em exatamente 2 lugares**:
+A schema parser (Zod or the stack equivalent) **validates in exactly 2 places**:
 
-1. **Input de procedure / handler de transport** — request → tipo validado.
-2. **Parsing de payload externo** — webhook, fonte crawled, env var, fila message, JSON do DB com forma desconhecida.
+1. **A procedure / transport handler input** — request → validated type.
+2. **Parsing an external payload** — a webhook, a crawled source, an env var, a queue message, DB JSON with an unknown shape.
 
-**Domain recebe shape já validado e tipado.** Lib pura idem. Re-validar dentro do domain "por garantia" duplica fonte de verdade do schema.
+**The domain receives an already-validated, typed shape.** A pure lib idem. Re-validating inside the domain "just in case" duplicates the schema's source of truth.
 
-## Por que essa regra
+## Why this rule
 
-- **Validar 2× é desperdício** (CPU + manutenção do schema em 2 lugares).
-- **Domain testa lógica, não parsing.** Mock de input com tipo errado não compila — TS já é a barreira.
-- **Schema vive perto da fronteira** onde dados externos chegam — onde ele é necessário, não onde "podia ser bom".
+- **Validating 2× is waste** (CPU + maintaining the schema in 2 places).
+- **The domain tests logic, not parsing.** A mock input with the wrong type does not compile — TS is already the barrier.
+- **The schema lives near the boundary** where external data arrives — where it is needed, not where "it could be nice".
 
-## Exemplos
+## Examples
 
-### ✅ Procedure valida input antes de chamar domain
+### ✅ A procedure validates the input before calling the domain
 
 ```ts
 const router_apps = router({
@@ -27,29 +27,29 @@ const router_apps = router({
       schemaUrl: z.string().url(),
     }))
     .mutation(async ({ ctx, input }) => {
-      // input já é { packageName: string; schemaUrl: string }
+      // input is already { packageName: string; schemaUrl: string }
       const result = await domain_createApps({ ctx, input });
       // ...
     }),
 });
 ```
 
-### ✅ Webhook handler valida payload externo
+### ✅ A webhook handler validates the external payload
 
 ```ts
 export async function POST(req: Request) {
   const raw = await req.text();
-  const event = stripe_verifyWebhook(raw, signature);  // valida assinatura
-  const payload = zStripeEvent.parse(event);            // valida shape
+  const event = stripe_verifyWebhook(raw, signature);  // validates the signature
+  const payload = zStripeEvent.parse(event);            // validates the shape
   await domain_handleStripeEventBillings({ ctx, input: payload });
 }
 ```
 
-### ❌ Domain re-validando "por garantia"
+### ❌ The domain re-validating "just in case"
 
 ```ts
 async function domain_createApps({ ctx, input }: DomainInput<{ packageName: string; schemaUrl: string }>) {
-  // ❌ procedure já validou; isso é ruído + duplicação de schema
+  // ❌ the procedure already validated; this is noise + schema duplication
   const validated = z.object({
     packageName: z.string().min(1),
     schemaUrl: z.string().url(),
@@ -57,28 +57,28 @@ async function domain_createApps({ ctx, input }: DomainInput<{ packageName: stri
 }
 ```
 
-### ✅ Lib pura recebe shape, não valida
+### ✅ A pure lib receives a shape, does not validate
 
 ```ts
 // lib/sdk-generator/index.ts
 export function generateSdk({ schema, options }: { schema: OpenApiV3; options: GenOpts }): SdkFiles {
-  // não chama z.parse — schema chega validado de quem chamou
-  // se quem chamou passou shape errado, é bug do caller, não defesa da lib
+  // does not call z.parse — the schema arrives validated from the caller
+  // if the caller passed the wrong shape, it is the caller's bug, not the lib's defense
 }
 ```
 
-## Quando "valida no boundary" cresce
+## When "validate at the boundary" grows
 
-Se procedure tem 6 procedures parecidas todas validando o mesmo `apps` shape:
+If a procedure has 6 similar procedures all validating the same `apps` shape:
 
-- Extrai schema pra `src/server/modules/apps/schemas.ts`.
-- Cada procedure importa: `.input(zCreateAppsInput)`.
-- Schema continua sendo declarado **uma vez**, mas reutilizado.
-- Ainda é boundary — só não-duplicado.
+- Extract the schema to `src/server/modules/apps/schemas.ts`.
+- Each procedure imports it: `.input(zCreateAppsInput)`.
+- The schema is still declared **once**, but reused.
+- It is still the boundary — just not duplicated.
 
-## Anti-patterns adicionais
+## Additional anti-patterns
 
-- ❌ Validar input dentro de função domain "por DI / por defesa profunda" — TS + schema no boundary já cobrem.
-- ❌ Schema declarado dentro do arquivo de domain — sai pro `schemas.ts` ou `*.types.ts` no módulo (regra dura 7).
-- ❌ `z.unknown().parse(...)` pra escapar tipo — não valida nada, falsa segurança. Use `z.object({...})` real ou aceite o tipo upstream.
-- ❌ Validar env via `process.env.X || throw` espalhado — centraliza em `src/server/env.ts` com Zod, valida 1× no boot.
+- ❌ Validating an input inside a domain function "for DI / defense in depth" — TS + the schema at the boundary already cover it.
+- ❌ A schema declared inside the domain file — it goes to `schemas.ts` or `*.types.ts` in the module (hard rule 7).
+- ❌ `z.unknown().parse(...)` to escape a type — it validates nothing, false safety. Use a real `z.object({...})` or accept the upstream type.
+- ❌ Validating env via `process.env.X || throw` scattered around — centralize it in `src/server/env.ts` with Zod, validate 1× at boot.

--- a/docs/rubrics/when-to-create-dsl.md
+++ b/docs/rubrics/when-to-create-dsl.md
@@ -1,51 +1,51 @@
-# Rubrica — quando criar uma DSL (sugere, não constrói)
+# Rubric — when to create a DSL (suggests, does not build)
 
-> DSL aqui = qualquer mini-linguagem de domínio que colapsa boilerplate repetido de chamadas primitivas: builder fluente, pipeline de combinadores, objeto declarativo interpretado, ou linguagem parseada. **DSL-first é o complemento do Rule of Three, não o oposto do KISS:** não abstrai cedo — mas quando o boilerplate de primitivas escala E tem gramática, uma DSL paga o próprio custo. O agente **sugere** (propõe + esboça); **não constrói sozinho** (regra dura 11 — DSL é camada/abstração de 1ª classe → pára e pergunta).
+> A DSL here = any mini domain language that collapses repeated boilerplate of primitive calls: a fluent builder, a combinator pipeline, an interpreted declarative object, or a parsed language. **DSL-first is the complement of the Rule of Three, not the opposite of KISS:** it does not abstract early — but when the primitive boilerplate scales AND has a grammar, a DSL pays its own cost. The agent **suggests** (proposes + sketches); it **does not build alone** (hard rule 11 — a DSL is a first-class layer/abstraction → stop and ask).
 
-## Decisão binária
+## Binary decision
 
-**Sugere DSL quando os DOIS sinais forem verdade (ambos, não um):**
+**Suggest a DSL when BOTH signals are true (both, not one):**
 
-- ✅ **Repetição (Rule-of-Three de sequência):** ≥ 3 call-sites repetem a **mesma sequência de ≥ N chamadas primitivas em ordem fixa** (não 3 chamadas avulsas — a *sequência* que se repete). Varia só os parâmetros, não a estrutura.
-- ✅ **Boilerplate domina a intenção (ratio):** nesses sites, a maior parte das linhas é wiring/setup/glue mecânico, não a lógica de negócio real — o leitor não enxerga *o que* o código quer através do *como* ele liga as primitivas.
+- ✅ **Repetition (a Rule-of-Three of sequence):** ≥ 3 call sites repeat the **same sequence of ≥ N primitive calls in a fixed order** (not 3 loose calls — the *sequence* that repeats). Only the parameters vary, not the structure.
+- ✅ **Boilerplate dominates the intent (ratio):** at those sites, most of the lines are mechanical wiring/setup/glue, not the real business logic — the reader cannot see *what* the code wants through the *how* it wires the primitives.
 
-**E uma terceira condição que distingue DSL de "extrair função":**
+**And a third condition that distinguishes a DSL from "extract a function":**
 
-- ✅ **Há gramática reusável** — composição, ordenação obrigatória, ramificação, ou encadeamento que se repete. É isso que faz uma DSL pagar mais que um helper. Sem gramática (só "chamar 5 funções em sequência sempre igual"), **um helper nomeado vence** — não é DSL.
+- ✅ **There is a reusable grammar** — composition, mandatory ordering, branching, or chaining that repeats. That is what makes a DSL pay more than a helper. Without a grammar (just "call 5 functions in the same sequence every time"), **a named helper wins** — it is not a DSL.
 
-**NÃO sugere DSL quando:**
+**Do NOT suggest a DSL when:**
 
-- ❌ **< 3 sequências repetidas** — Rule of Three não bateu. Espera a terceira (YAGNI).
-- ❌ **Um helper/builder simples já colapsa o boilerplate** — KISS > DSL. Função nomeada (`stripe_createCheckoutSession`) ou builder de 1 nível vence a mini-linguagem. DSL só quando o helper não captura a gramática.
-- ❌ **O "boilerplate" é lógica per-site real** — variação genuína entre sites não é boilerplate; abstrair esconde diferença que importa.
-- ❌ **"Vai escalar / dá pra parametrizar tudo"** — YAGNI. Não constrói DSL especulativa pro caso geral antes dos 3 casos reais.
+- ❌ **< 3 repeated sequences** — the Rule of Three did not hit. Wait for the third (YAGNI).
+- ❌ **A simple helper/builder already collapses the boilerplate** — KISS > DSL. A named function (`stripe_createCheckoutSession`) or a 1-level builder beats the mini-language. A DSL is only when the helper does not capture the grammar.
+- ❌ **The "boilerplate" is real per-site logic** — genuine variation between sites is not boilerplate; abstracting hides a difference that matters.
+- ❌ **"It will scale / everything can be parameterized"** — YAGNI. Do not build a speculative DSL for the general case before the 3 real cases.
 
-## Por que essas regras
+## Why these rules
 
-- **Os dois sinais juntos, não um.** Repetição sem boilerplate dominante → helper resolve. Boilerplate alto sem repetição (1 site) → é só uma função grande, parte ou inline. DSL é cara (nova camada, indireção, curva de aprendizado, debugging através da abstração) — só vale no cruzamento dos dois.
-- **Gramática é o discriminador DSL-vs-helper.** Extrair função remove duplicação; DSL dá uma *linguagem* pra expressar a intenção. Se não há nada pra "compor", uma função basta — e é mais barata.
-- **Sugere, não constrói (regra 11 / autonomia #6 bright line d).** Criar DSL é introduzir camada/abstração de 1ª classe — decisão arquitetural load-bearing. O agente leva a proposta (com esboço da API + ADR candidato), o dono da arquitetura decide. Construir uma DSL autônomo seria cruzar a bright line.
+- **Both signals together, not one.** Repetition without dominant boilerplate → a helper solves it. High boilerplate without repetition (1 site) → it is just a big function, split or inline it. A DSL is expensive (a new layer, indirection, a learning curve, debugging through the abstraction) — it is only worth it at the crossing of the two.
+- **Grammar is the DSL-vs-helper discriminator.** Extracting a function removes duplication; a DSL gives a *language* to express the intent. If there is nothing to "compose", a function is enough — and cheaper.
+- **Suggests, does not build (rule 11 / autonomy #6 bright line d).** Creating a DSL is introducing a first-class layer/abstraction — a load-bearing architectural decision. The agent brings the proposal (with an API sketch + a candidate ADR), the architecture owner decides. Building a DSL autonomously would cross the bright line.
 
-## Forma — escolhe a mais leve que remove o boilerplate (KISS dentro da DSL)
+## Form — pick the lightest that removes the boilerplate (KISS inside the DSL)
 
-Em ordem crescente de custo — **pára na primeira que captura a gramática:**
+In increasing order of cost — **stop at the first that captures the grammar:**
 
-1. **Builder fluente / função de fábrica** — encadeamento simples (`q().where().limit()`). Mais barato; cobre a maioria dos casos.
-2. **Combinadores / pipeline** — funções pequenas que compõem (`pipe(parse, validate, persist)`). Quando a gramática é composição.
-3. **Objeto declarativo interpretado** — config data-driven que um runner percorre. Quando a "linguagem" é uma estrutura de dados.
-4. **Mini-linguagem parseada** (string → AST → exec) — **último recurso**, raramente justificado num app de produto. Exige parser, erros, testes do próprio parser — só quando os 3 acima genuinamente não expressam a gramática.
+1. **A fluent builder / factory function** — simple chaining (`q().where().limit()`). The cheapest; covers most cases.
+2. **Combinators / a pipeline** — small functions that compose (`pipe(parse, validate, persist)`). When the grammar is composition.
+3. **An interpreted declarative object** — data-driven config that a runner walks. When the "language" is a data structure.
+4. **A parsed mini-language** (string → AST → exec) — a **last resort**, rarely justified in a product app. It needs a parser, errors, tests of the parser itself — only when the 3 above genuinely do not express the grammar.
 
-## Antes de propor — auto-crítica (corolário de verificação #6)
+## Before proposing — self-critique (a corollary of verification #6)
 
-1. Os 3 sites repetem mesmo a *sequência*, ou só usam as mesmas primitivas em ordens diferentes? (ordens diferentes → não é uma DSL única)
-2. Um helper de 1 nível colapsaria 80% do boilerplate? Se sim, propõe o helper, não a DSL.
-3. A DSL proposta esconde diferença real entre os sites? (se sim, ela vai vazar — repensa a fronteira)
-4. Qual a forma mais leve (lista acima) que captura a gramática? Não proponha parser se um builder resolve.
+1. Do the 3 sites repeat the *sequence*, or just use the same primitives in different orders? (different orders → it is not one DSL)
+2. Would a 1-level helper collapse 80% of the boilerplate? If yes, propose the helper, not the DSL.
+3. Does the proposed DSL hide a real difference between the sites? (if yes, it will leak — rethink the boundary)
+4. What is the lightest form (the list above) that captures the grammar? Do not propose a parser if a builder solves it.
 
-## Antiexemplos
+## Anti-examples
 
-- ❌ Construir um query-DSL autônomo no 2º call-site — Rule of Three não bateu; espera o terceiro (ou usa helper).
-- ❌ Propor mini-linguagem parseada pra 3 sequências que um builder fluente de 20 linhas resolveria — forma cara demais (use o nível 1).
-- ❌ Chamar de "boilerplate" 3 handlers que validam coisas diferentes — é lógica per-site, não wiring repetido; DSL esconderia a diferença.
-- ❌ Materializar a DSL sozinho porque "é óbvio que precisa" — é regra 11: propõe + esboça a API + abre ADR candidato; o humano aprova a nova camada.
-- ❌ DSL pro caso geral ("suporta qualquer provider futuro") com 3 providers reais — YAGNI; modela os 3, generaliza quando o 4º divergir.
+- ❌ Building an autonomous query-DSL at the 2nd call site — the Rule of Three did not hit; wait for the third (or use a helper).
+- ❌ Proposing a parsed mini-language for 3 sequences that a 20-line fluent builder would solve — too expensive a form (use level 1).
+- ❌ Calling 3 handlers that validate different things "boilerplate" — it is per-site logic, not repeated wiring; a DSL would hide the difference.
+- ❌ Materializing the DSL alone because "it is obviously needed" — it is rule 11: propose + sketch the API + open a candidate ADR; the human approves the new layer.
+- ❌ A DSL for the general case ("supports any future provider") with 3 real providers — YAGNI; model the 3, generalize when the 4th diverges.

--- a/docs/rubrics/when-to-create-lib.md
+++ b/docs/rubrics/when-to-create-lib.md
@@ -1,38 +1,38 @@
-# Rubrica — quando criar `src/lib/<x>/`
+# Rubric — when to create `src/lib/<x>/`
 
-## Decisão binária
+## Binary decision
 
-**Cria lib quando QUALQUER um for verdade:**
+**Create a lib when ANY is true:**
 
-- ✅ Já tem **3 callers** do mesmo helper inline (Rule of Three confirmada).
-- ✅ É **integração externa nomeável** (Stripe, S3, Resend, Slack, GitHub) — vira `lib/<provider>/`.
-- ✅ **> ~150 linhas** de lógica pura acoplada a um consumidor único — extrai pra reduzir carga de leitura.
+- ✅ There are already **3 callers** of the same inline helper (Rule of Three confirmed).
+- ✅ It is a **nameable external integration** (Stripe, S3, Resend, Slack, GitHub) — becomes `lib/<provider>/`.
+- ✅ **> ~150 lines** of pure logic coupled to a single consumer — extract it to reduce reading load.
 
-**NÃO cria lib quando:**
+**Do NOT create a lib when:**
 
-- ❌ Tem 1 caller — inline. Espera o segundo aparecer.
-- ❌ Mistura I/O com ORM — vai pra `infra/` ou inline na procedure.
-- ❌ Helper com < 10 linhas e 2 callers — duplicação simples vence (KISS > DRY).
-- ❌ "Vou precisar mais tarde" — YAGNI. Inline até precisar.
+- ❌ There is 1 caller — inline. Wait for the second to appear.
+- ❌ It mixes I/O with the ORM — goes to `infra/` or inline in the procedure.
+- ❌ A helper with < 10 lines and 2 callers — simple duplication wins (KISS > DRY).
+- ❌ "I will need it later" — YAGNI. Inline until you need it.
 
-## Por que essas regras
+## Why these rules
 
-- **3 callers = padrão real, não coincidência.** Dois pode ser convergência espúria.
-- **Integração externa merece nome próprio** (`stripe_createCustomer` em vez de `createCustomer`) porque o leitor sabe instantaneamente que é chamada de rede. Reduz custo cognitivo no scan.
-- **150 linhas é o ponto onde "vou ler o arquivo inteiro" custa mais que "vou seguir a chamada pro helper".** Antes disso, inline é mais barato pro leitor.
+- **3 callers = a real pattern, not coincidence.** Two can be spurious convergence.
+- **An external integration deserves its own name** (`stripe_createCustomer` instead of `createCustomer`) because the reader instantly knows it is a network call. It reduces cognitive cost in the scan.
+- **150 lines is the point where "I will read the whole file" costs more than "I will follow the call to the helper".** Before that, inline is cheaper for the reader.
 
-## Onde colocar quando criar
+## Where to put it when you create it
 
-Decisão em ordem:
+Decide in order:
 
-1. **Lib pura, sem dependência de framework do app?** → `src/lib/<x>/` (publishable; zero ORM/web framework/orchestrator).
-2. **Tem regra de negócio do módulo X?** → `src/server/modules/<X>/domain/`.
-3. **Vale pra 3+ módulos?** → `src/domain/shared/`.
-4. **É wrapper de cliente externo (singleton com config)?** → `src/server/infra/`.
+1. **A pure lib, with no app-framework dependency?** → `src/lib/<x>/` (publishable; zero ORM/web framework/orchestrator).
+2. **Does it have module X's business rule?** → `src/server/modules/<X>/domain/`.
+3. **Is it worth it for 3+ modules?** → `src/domain/shared/`.
+4. **Is it an external-client wrapper (a singleton with config)?** → `src/server/infra/`.
 
-## Antiexemplos
+## Anti-examples
 
-- ❌ `src/lib/utils/format-date.ts` com 1 caller — inline na page que precisa.
-- ❌ `src/lib/auth/get-user.ts` que importa o ORM — vai pra `src/server/modules/auth/`, não é lib pura.
-- ❌ `src/lib/email-and-notifications/` — mistura responsabilidade. Divide em `src/lib/email/` e `src/lib/slack/`.
-- ❌ `src/lib/stripe/` com `class StripeManager { 12 métodos }` — vira `src/lib/stripe/checkout.ts`, `src/lib/stripe/portal.ts`, etc, com funções nomeadas (`stripe_createCheckoutSession`).
+- ❌ `src/lib/utils/format-date.ts` with 1 caller — inline in the page that needs it.
+- ❌ `src/lib/auth/get-user.ts` that imports the ORM — goes to `src/server/modules/auth/`, it is not a pure lib.
+- ❌ `src/lib/email-and-notifications/` — mixes responsibility. Split into `src/lib/email/` and `src/lib/slack/`.
+- ❌ `src/lib/stripe/` with `class StripeManager { 12 methods }` — becomes `src/lib/stripe/checkout.ts`, `src/lib/stripe/portal.ts`, etc, with named functions (`stripe_createCheckoutSession`).

--- a/docs/rubrics/when-to-create-module.md
+++ b/docs/rubrics/when-to-create-module.md
@@ -1,30 +1,30 @@
-# Rubrica — quando criar módulo top-level em `server/modules/`
+# Rubric — when to create a top-level module in `server/modules/`
 
-## Decisão binária
+## Binary decision
 
-**Cria módulo novo quando TODOS forem verdade:**
+**Create a new module when ALL are true:**
 
-- ✅ Tem **entidade própria** (model novo, não campo num model existente).
-- ✅ Já tem **≥ 2 procedures** previstas (não 1 isolada).
-- ✅ Tem **estado próprio com lifecycle** (não é só lookup table estática).
+- ✅ It has its **own entity** (a new model, not a field on an existing model).
+- ✅ It already has **≥ 2 procedures** foreseen (not 1 isolated one).
+- ✅ It has **its own state with a lifecycle** (not just a static lookup table).
 
-**Senão é sub-feature de módulo existente.** Ex: `notifications` que só serve `auth` mora como `src/server/modules/auth/notifications/`, não como módulo top-level.
+**Otherwise it is a sub-feature of an existing module.** E.g.: `notifications` that only serves `auth` lives as `src/server/modules/auth/notifications/`, not as a top-level module.
 
-## Por que essas regras
+## Why these rules
 
-- **Entidade própria** define a fronteira natural do módulo. Sem entidade, é só feature de outro módulo (campo, comportamento extra).
-- **≥ 2 procedures** garante que o módulo tem superfície de uso suficiente. Procedure isolada não justifica diretório próprio + router próprio + domain próprio.
-- **Lifecycle** distingue "domínio com estado" de "configuração estática". Plano (FREE/PRO) é enum + lookup table → não é módulo `plans/`, é parte de `billings/`.
+- **Its own entity** defines the module's natural boundary. Without an entity, it is just another module's feature (a field, extra behavior).
+- **≥ 2 procedures** ensures the module has enough usage surface. An isolated procedure does not justify its own directory + its own router + its own domain.
+- **Lifecycle** distinguishes "a domain with state" from "static configuration". A plan (FREE/PRO) is an enum + a lookup table → it is not a `plans/` module, it is part of `billings/`.
 
-## Antes de criar — pergunta de revisão
+## Before creating — a review question
 
-1. Esse conceito existe em algum módulo atual? Se sim, é sub-feature.
-2. Vai compartilhar `domain/`, `infra/`, ou tipos com outro módulo? Se sim, considera `src/domain/shared/` em vez de módulo novo.
-3. Vai durar > 6 meses sem ser tocado? Se sim e não cresce, talvez seja só helper, não módulo.
+1. Does this concept exist in a current module? If yes, it is a sub-feature.
+2. Will it share `domain/`, `infra/`, or types with another module? If yes, consider `src/domain/shared/` instead of a new module.
+3. Will it last > 6 months untouched? If yes and it does not grow, maybe it is just a helper, not a module.
 
-## Antiexemplos
+## Anti-examples
 
-- ❌ Criar `modules/notifications/` quando só auth dispara notification — fica em `modules/auth/notifications/`.
-- ❌ Criar `modules/plans/` pra hospedar `PLAN_CONFIG` constante — fica em `modules/billings/plan-config.ts`.
-- ❌ Criar `modules/utils/` pra agregar helpers cross-module — não existe módulo `utils`, helpers vão pra `lib/` ou inline.
-- ❌ Criar `modules/admin/` cedo "porque vai ter painel admin depois" — YAGNI. Espera primeira procedure admin aparecer.
+- ❌ Creating `modules/notifications/` when only auth triggers a notification — it stays in `modules/auth/notifications/`.
+- ❌ Creating `modules/plans/` to host the `PLAN_CONFIG` constant — it stays in `modules/billings/plan-config.ts`.
+- ❌ Creating `modules/utils/` to aggregate cross-module helpers — there is no `utils` module, helpers go to `lib/` or inline.
+- ❌ Creating `modules/admin/` early "because there will be an admin panel later" — YAGNI. Wait for the first admin procedure to appear.

--- a/docs/rubrics/when-to-evolve-methodology.md
+++ b/docs/rubrics/when-to-evolve-methodology.md
@@ -1,47 +1,47 @@
-# Rubrica — ciclo de evolução (`evolve`) vs. mecanismo único vs. fix pontual
+# Rubric — the evolution cycle (`evolve`) vs a single mechanism vs a point fix
 
-> **O que "evolução" significa aqui:** refinar a **documentação local deste projeto** (a instância materializada da metodologia em `<consumer>/docs/`) — deixá-la mais enxuta, clara, atual e eficiente. **Nunca** o plugin AFM em si (`framework-template/`); ao plugin, só se **sugere** via `/afm:promote`. Toda menção a "metodologia"/"saúde da metodologia" abaixo é a doc local.
+> **What "evolution" means here:** refining **this project's local documentation** (the materialized instance of the methodology in `<consumer>/docs/`) — making it leaner, clearer, more current, and more efficient. **Never** the AFM plugin itself (`framework-template/`); to the plugin, you only **suggest** via `/afm:promote`. Every mention of "methodology"/"methodology health" below is the local doc.
 
-> Decisão em **3 vias**: o que apareceu pede (1) o **ciclo inteiro** do `/afm:evolve` (orquestrador: coleta de evidência → proposta → gate único → aplicação → registro), (2) **um mecanismo único à-la-carte** (`/afm:diagnose`, `/afm:reflect`, `/afm:generalize`, `/afm:restructure`), ou (3) **um fix pontual** que o `reconcile` propõe direto via skill atômica (`/afm:gotcha`, `/afm:rule`, `/afm:adr`)? Custo decrescente: o ciclo é o mais caro (compõe múltiplos mecanismos, gate consolidado, registro em `docs/evolution/`); o mecanismo único é escopado; o fix pontual é barato. Não rode o ciclo pra o que cabe num mecanismo, nem um mecanismo pra o que cabe num edit.
+> A **3-way** decision: does what appeared call for (1) the **whole cycle** of `/afm:evolve` (orchestrator: evidence collection → proposal → single gate → application → record), (2) **a single à-la-carte mechanism** (`/afm:diagnose`, `/afm:reflect`, `/afm:generalize`, `/afm:restructure`), or (3) **a point fix** that `reconcile` proposes directly via an atomic skill (`/afm:gotcha`, `/afm:rule`, `/afm:adr`)? Decreasing cost: the cycle is the most expensive (composes several mechanisms, a consolidated gate, a record in `docs/evolution/`); the single mechanism is scoped; the point fix is cheap. Do not run the cycle for what fits a mechanism, nor a mechanism for what fits an edit.
 
-## As 3 vias
+## The 3 ways
 
-### 1. Ciclo `evolve` — quando os DOIS forem verdade:
+### 1. The `evolve` cycle — when BOTH are true:
 
-- ✅ **O problema é da instância como um todo, não de um eixo isolado** — múltiplos achados de saúde, ou achados que cruzam modalidades (refs mortas **e** regra ambígua vivida **e** inflação espalhada). É um *sweep de saúde* que se beneficia do gate consolidado + lineage num só lugar.
-- ✅ **Há evidência observável de "fora do 100%"** — sinal mecânico (do `diagnose`) OU comportamental (do `reflect`) OU sintoma articulado pelo user ("os docs estão uma bagunça"). Sem sinal, não roda (instância saudável → ciclo rende ~zero; cooldown recusa).
+- ✅ **The problem is the instance as a whole, not an isolated axis** — several health findings, or findings that cross modalities (dead refs **and** a lived ambiguous rule **and** scattered inflation). It is a *health sweep* that benefits from a consolidated gate + lineage in one place.
+- ✅ **There is observable evidence of "off 100%"** — a mechanical signal (from `diagnose`) OR a behavioral one (from `reflect`) OR a symptom the user articulates ("the docs are a mess"). Without a signal, do not run it (a healthy instance → the cycle yields ~zero; the cooldown refuses).
 
-### 2. Mecanismo único à-la-carte — quando você sabe exatamente qual lente precisa:
+### 2. A single à-la-carte mechanism — when you know exactly which lens you need:
 
-- 🔍 **`/afm:diagnose`** — só o **relatório de saúde** (scan mecânico dos 7 eixos, read-only). "Como está a saúde da metodologia aqui?" sem querer propor/aplicar nada.
-- 🪞 **`/afm:reflect`** — **um doc específico guiou mal** em apply-time (regra ambígua, seção que não guiou). Refino de instrutividade, evidência comportamental da sessão.
-- 🧬 **`/afm:generalize`** — **≥2 gotchas similares** acumularam e pedem fusão numa regra abstrata (episódica→semântica). Anti-inflação na raiz.
-- 🗂️ **`/afm:restructure`** — **staleness** (doc desatualizado vs código) ou **findability/partição** (info mal-localizada, doc que escalou).
+- 🔍 **`/afm:diagnose`** — only the **health report** (a mechanical scan of the 7 axes, read-only). "How is the methodology health here?" without wanting to propose/apply anything.
+- 🪞 **`/afm:reflect`** — **a specific doc guided badly** at apply-time (an ambiguous rule, a section that did not guide). Instructiveness refinement, behavioral evidence from the session.
+- 🧬 **`/afm:generalize`** — **≥2 similar gotchas** accumulated and call for fusion into an abstract rule (episodic→semantic). Anti-inflation at the root.
+- 🗂️ **`/afm:restructure`** — **staleness** (a doc outdated vs the code) or **findability/partition** (badly located info, a doc that scaled).
 
-> O mecanismo único ainda **auto-verifica e gateia** o que propõe (reflect/generalize/restructure têm gate próprio; diagnose é read-only). A diferença pro ciclo é o **escopo**: uma lente, não o sweep; sem o overhead de compor todos + registro de ciclo.
+> The single mechanism still **self-verifies and gates** what it proposes (reflect/generalize/restructure have their own gate; diagnose is read-only). The difference from the cycle is the **scope**: one lens, not the sweep; without the overhead of composing all + a cycle record.
 
-### 3. Fix pontual (reconcile → skill atômica) — quando é aditivo e local:
+### 3. A point fix (reconcile → atomic skill) — when it is additive and local:
 
-- ❌ **Aprendeu um fato/decisão/gotcha NOVO** — `/afm:adr` (decisão arquitetural), `/afm:rule` (regra de uma correção), `/afm:gotcha` (surpresa que mordeu 2×). O `reconcile` já cobre isso no fim do turn; abrir mecanismo/ciclo é overhead. (Distinção: `reconcile`/`gotcha`/`rule` **adicionam** conhecimento; `reflect`/`generalize`/`restructure` **refinam/consolidam/reorganizam** o que já existe.)
-- ❌ **Validação de UMA feature** — coverage/consistência spec↔plan↔tasks → `/afm:analyze` (read-only, per-feature).
-- ❌ **Entrega de feature** → `/afm:deliver`.
-- ❌ **Promover aprendizado pro plugin** → `/afm:promote`.
+- ❌ **You learned a NEW fact/decision/gotcha** — `/afm:adr` (an architectural decision), `/afm:rule` (a rule from a correction), `/afm:gotcha` (a surprise that bit 2×). `reconcile` already covers this at the end of the turn; opening a mechanism/cycle is overhead. (Distinction: `reconcile`/`gotcha`/`rule` **add** knowledge; `reflect`/`generalize`/`restructure` **refine/consolidate/reorganize** what already exists.)
+- ❌ **Validating ONE feature** — coverage/consistency spec↔plan↔tasks → `/afm:analyze` (read-only, per-feature).
+- ❌ **A feature delivery** → `/afm:deliver`.
+- ❌ **Promoting a learning to the plugin** → `/afm:promote`.
 
-## Por que essas regras
+## Why these rules
 
-- **Sinal observável é obrigatório** (vias 1 e 2). Problema sistêmico sem evidência vira o agente auditando texto com base em texto (loop de auto-referência) — proibido. Mecânico (`diagnose`) e comportamental (`reflect`) são as duas modalidades de evidência (os dois lados do φ do Self-Harness); ambas valem.
-- **Sinal > ritual** (Self-Harness / Autogenesis): em docs saudáveis o ciclo rende quase nada. Gatilho adaptativo por evidência bate budget/calendário fixo. O cooldown do `evolve` recusa ciclo sem sinal novo (o mecanismo único, sendo escopado e — no caso do diagnose — read-only, não tem cooldown).
-- **Escopo decide a via** (ciclo vs mecanismo): se você sabe a lente, use o mecanismo; se é um sweep multi-modalidade que merece um gate consolidado, use o ciclo. Não componha todos os mecanismos (evolve) pra resolver um eixo só.
-- **Diagnóstico vazio é resultado válido**: se o scan/reflexão não acha nada, reporta "100%" e encerra — **não** fabrica doença pra justificar a invocação.
-- **Tamanho de doc é sinal de consolidação, nunca de poda** (ACE × Configuring): um doc core acima de ~500 linhas (`afm-health.sh` A6 tier soft) roteia pra **revisão de consolidação** — `/afm:generalize` (funde redundância) ou `/afm:restructure` (particiona por temperatura) —, **jamais** corte por tamanho. ACE: poda redundância, não linha; brevity bias joga fora detalhe load-bearing. O número é gatilho de revisão, não veredito de deleção.
+- **An observable signal is mandatory** (ways 1 and 2). A systemic problem without evidence turns the agent into auditing text based on text (a self-reference loop) — forbidden. Mechanical (`diagnose`) and behavioral (`reflect`) are the two modalities of evidence (the two sides of the Self-Harness φ); both count.
+- **Signal > ritual** (Self-Harness / Autogenesis): on healthy docs the cycle yields almost nothing. An adaptive trigger by evidence beats a fixed budget/calendar. The `evolve` cooldown refuses a cycle with no new signal (the single mechanism, being scoped and — for diagnose — read-only, has no cooldown).
+- **Scope decides the way** (cycle vs mechanism): if you know the lens, use the mechanism; if it is a multi-modality sweep that deserves a consolidated gate, use the cycle. Do not compose all the mechanisms (evolve) to solve a single axis.
+- **An empty diagnosis is a valid result**: if the scan/reflection finds nothing, report "100%" and close — do **not** fabricate a disease to justify the invocation.
+- **Doc size is a signal of consolidation, never of pruning** (ACE × Configuring): a core doc above ~500 lines (`afm-health.sh` A6 soft tier) routes to a **consolidation review** — `/afm:generalize` (merges redundancy) or `/afm:restructure` (partitions by temperature) — **never** a cut by size. ACE: prune redundancy, not a line; a brevity bias throws away load-bearing detail. The number is a review trigger, not a deletion verdict.
 
-## Antiexemplos
+## Anti-examples
 
-- ❌ **Rodar `/afm:evolve` semanalmente por ritual** — roda por sinal, não por calendário.
-- ❌ **Abrir o ciclo pra registrar um gotcha novo** — é aditivo e local; `/afm:gotcha` (ou o reconcile propondo) resolve.
-- ❌ **Rodar o ciclo inteiro só pra ver a saúde** — isso é `/afm:diagnose` (read-only, sem gate).
-- ❌ **Achado "o doc parece inflado" sem `wc -l`/grep de duplicata** — sem evidência observável não é achado (#5).
-- ❌ **`generalize` a partir de 1 gotcha** — sem batch (≥2) não há generalização; é fabricar abstração sem evidência.
-- ❌ **`reflect` abrandar uma regra porque ela me constrangeu** — violação ≠ regra-errada; "agente em não-conformidade" é hipótese rival obrigatória.
-- ❌ **`restructure` forçar tiering em doc pequeno** — partição por temperatura é opt-in, só quando o doc escalou (YAGNI).
-- ❌ **Rodar de novo sem nada ter mudado** — cooldown (no ciclo); mecanismo sem sinal novo é teatro.
+- ❌ **Running `/afm:evolve` weekly by ritual** — run by signal, not by calendar.
+- ❌ **Opening the cycle to record a new gotcha** — it is additive and local; `/afm:gotcha` (or reconcile proposing it) solves it.
+- ❌ **Running the whole cycle just to see the health** — that is `/afm:diagnose` (read-only, no gate).
+- ❌ **A finding "the doc looks inflated" with no `wc -l`/duplicate grep** — with no observable evidence it is not a finding (#5).
+- ❌ **`generalize` from 1 gotcha** — with no batch (≥2) there is no generalization; it is fabricating an abstraction with no evidence.
+- ❌ **`reflect` softening a rule because it constrained me** — a violation ≠ a wrong rule; "the agent is non-compliant" is a mandatory rival hypothesis.
+- ❌ **`restructure` forcing tiering on a small doc** — partition by temperature is opt-in, only when the doc scaled (YAGNI).
+- ❌ **Running it again with nothing changed** — the cooldown (in the cycle); a mechanism with no new signal is theater.

--- a/docs/ust.md
+++ b/docs/ust.md
@@ -1,712 +1,712 @@
 # UST — User Stories
 
-> Backlog vivo de stories. Toda feature/mudança nova nasce como uma US.
-> Status flui: `draft` → `ready` → `in_progress` → `done` (ou `cancelled` com motivo).
+> Live backlog of stories. Every new feature/change starts as a US.
+> Status flows: `draft` → `ready` → `in_progress` → `done` (or `cancelled` with a reason).
 >
-> Stories abaixo foram **reverse-engineered de tests existentes** (`controller.test.ts`) na adoção retroativa via `/afm:refactor` em 2026-06-30. Persona em `[A DEFINIR]` — vem da entrevista.
+> The stories below were **reverse-engineered from existing tests** (`controller.test.ts`) during the retroactive adoption via `/afm:refactor` on 2026-06-30. Persona is `[A DEFINIR]` — comes from the interview.
 
-## Convenções
+## Conventions
 
-- **ID:** `US-NNN` (3 dígitos, zero-padded — `US-001` até `US-999`).
-- **Referência cruzada:** sempre por ID (`RF-NN`, `RNF-NN`, `US-NNN`).
-- **Critérios:** Gherkin (`Given/When/Then`). 1+ cenário por US.
-- **Status:** atualizado in-place no commit que muda o estado real.
+- **ID:** `US-NNN` (3 digits, zero-padded — `US-001` through `US-999`).
+- **Cross-reference:** always by ID (`RF-NN`, `RNF-NN`, `US-NNN`).
+- **Criteria:** Gherkin (`Given/When/Then`). 1+ scenario per US.
+- **Status:** updated in place in the commit that changes the real state.
 
-## Sumário
+## Summary
 
-| ID | Título | Categoria | RF | Status |
+| ID | Title | Category | RF | Status |
 | --- | --- | --- | --- | --- |
-| US-001 | Registro de usuário | Autenticação | RF-01 | done |
-| US-002 | Login e criação de sessão | Autenticação | RF-01 | done |
-| US-003 | Refresh e logout de sessão | Autenticação | RF-01 | done |
-| US-004 | Verificação de email por token | Autenticação | RF-02 | done |
-| US-005 | Recuperação de senha via token | Autenticação | RF-03 | done |
-| US-006 | Criar e ler post | Posts | RF-04 | done |
-| US-007 | Atualizar, revalidar (ISR) e deletar post | Posts | RF-04 | done |
-| US-008 | Criar, listar, atualizar e deletar comentário | Comentários | RF-05 | done |
-| US-009 | Ver e editar perfil de usuário | Perfil | RF-06 | done |
-| US-010 | Atuar conforme papel (Admin/Editor/Author) | Autenticação | RF-08 | done |
-| US-011 | Publicar post via workflow de revisão | Posts | RF-09 | done |
-| US-012 | Compartilhar e indexar post com SEO completo | Posts | RF-10 | done |
-| US-013 | Busca posts por título ou conteúdo | Posts | RF-11 | done |
-| US-014 | Analytics de visualizações por post | Analytics | RF-12 | done |
-| US-015 | Autor/Editor customiza SEO e URL amigável do post | Posts | RF-10 | done |
-| US-016 | Usuário autenticado envia e gerencia mídia | Mídia | RF-13 | done |
-| US-017 | Dev resolve erro de domínio sem código duplicado por procedure | Qualidade de Sistema | RF-14 | done |
+| US-001 | User registration | Authentication | RF-01 | done |
+| US-002 | Login and session creation | Authentication | RF-01 | done |
+| US-003 | Session refresh and logout | Authentication | RF-01 | done |
+| US-004 | Email verification via token | Authentication | RF-02 | done |
+| US-005 | Password recovery via token | Authentication | RF-03 | done |
+| US-006 | Create and read post | Posts | RF-04 | done |
+| US-007 | Update, revalidate (ISR), and delete post | Posts | RF-04 | done |
+| US-008 | Create, list, update, and delete comment | Comments | RF-05 | done |
+| US-009 | View and edit user profile | Profile | RF-06 | done |
+| US-010 | Act according to role (Admin/Editor/Author) | Authentication | RF-08 | done |
+| US-011 | Publish post via review workflow | Posts | RF-09 | done |
+| US-012 | Share and index post with full SEO | Posts | RF-10 | done |
+| US-013 | Search posts by title or content | Posts | RF-11 | done |
+| US-014 | View analytics per post | Analytics | RF-12 | done |
+| US-015 | Author/Editor customizes post SEO and friendly URL | Posts | RF-10 | done |
+| US-016 | Authenticated user uploads and manages media | Media | RF-13 | done |
+| US-017 | Dev resolves domain error without duplicated code per procedure | System Quality | RF-14 | done |
 
-## Pendências Técnicas
+## Technical Pending Items
 
-- ~~Investigar se o mesmo padrão de transport pluggável usado no mailer pode ser aplicado ao Prisma, para reduzir duplicação entre runtime, testes e outros adaptadores.~~ **Resolvido em 2026-07-06** — adotado `prisma-mock` (fake do PrismaClient gerado do schema) no seam do driver; fakes à mão de `src/test/repositories/` deletados. Ver ADR-0011 e `docs/research/001-teste-prisma-sem-banco-real.md`.
-- ~~Investigar por que o token enviado nos emails não está funcionando quando o link é aberto. O fluxo de cadastro/verificação parece montar o link corretamente, mas a rota final não completa a ação esperada.~~ **Resolvido em 2026-07-11** — bug de mismatch entre o link montado (`?token=`, query param) e a rota `src/app/(smal)/auth/verify/[token]/page.tsx` (path param); corrigido em `register.ts` e `resendVerificationEmail.ts` pra montar o link como `/auth/verify/${token}`, no mesmo padrão já usado pelo fluxo de reset de senha (`sendResetPasswordEmail.ts`). Testes de regressão adicionados nos dois `controller.test.ts`.
-- ~~`src/context/trpc/fetcher.ts` (`customFetcher`) reimplementava na mão o parsing do envelope de erro do `httpBatchLink` (array + `error.json.message` do superjson) pra decidir se refaz a sessão.~~ **Resolvido em 2026-07-12** — lógica movida pra `src/context/trpc/sessionRefreshLink.ts`, um link customizado do tRPC (`opts.next(op)`) que recebe o erro já tipado (`TRPCClientError.data.code`/`.message`) em vez de JSON cru; `fetcher.ts` deletado. Ver `docs/features/008-trpc-error-link/`. Tratado como item avulso (não dobrado em `001-auth-hardening`, que segue `draft` e cobre um escopo de segurança diferente — ver `008-trpc-error-link/spec.md` § 6).
-- `/post/[slug]` (`docs/features/002-post-slug/`) agora chama `notFound()` corretamente quando o slug não existe (**2026-07-11**, antes caía no `error.tsx` genérico — ver commit `a620cde`), mas o status HTTP da resposta continua `200`, não `404`. **Investigado e reclassificado em 2026-07-12** (`docs/features/009-post-404-status/`): a hipótese original ("tirar o post de dentro do `<Suspense>` resolve, só perde o fallback de loading") **estava errada** — com `cacheComponents: true` (`next.config.ts`), Next.js exige um `<Suspense>` em volta de qualquer leitura dinâmica não-cacheada; removê-lo quebra o `next build` inteiro (`Uncached data was accessed outside of <Suspense>`), não é uma troca de UX. Não existe mais `export const dynamic = "force-dynamic"` como escape hatch (removido junto do Cache Components no Next 16). Ver `docs/gotchas.md` § Cache Components. Corrigir de verdade exigiria checagem de slug **fora** do pipeline de Cache Components (ex: `middleware`/`proxy` no Edge) — infra nova, não fix pontual. **Decisão do dono (2026-07-12): aceitar como limitação conhecida por ora**, sem investir na infra nova; reabrir se virar bloqueio real (ex. SEO passar a exigir 404 de verdade). Relevante pra Fase 5 (SEO) do roadmap — bots que checam status HTTP não veem 404 real.
+- ~~Investigate whether the same pluggable-transport pattern used in the mailer can be applied to Prisma, to reduce duplication between runtime, tests, and other adapters.~~ **Resolved on 2026-07-06** — adopted `prisma-mock` (a PrismaClient fake generated from the schema) at the driver seam; hand-written fakes in `src/test/repositories/` deleted. See ADR-0011 and `docs/research/001-teste-prisma-sem-banco-real.md`.
+- ~~Investigate why the token sent in emails does not work when the link is opened. The registration/verification flow seems to build the link correctly, but the final route does not complete the expected action.~~ **Resolved on 2026-07-11** — mismatch bug between the built link (`?token=`, query param) and the route `src/app/(smal)/auth/verify/[token]/page.tsx` (path param); fixed in `register.ts` and `resendVerificationEmail.ts` to build the link as `/auth/verify/${token}`, matching the pattern already used by the password reset flow (`sendResetPasswordEmail.ts`). Regression tests added in both `controller.test.ts` files.
+- ~~`src/context/trpc/fetcher.ts` (`customFetcher`) reimplemented by hand the parsing of the `httpBatchLink` error envelope (array + `error.json.message` from superjson) to decide whether to refresh the session.~~ **Resolved on 2026-07-12** — logic moved to `src/context/trpc/sessionRefreshLink.ts`, a custom tRPC link (`opts.next(op)`) that receives the already-typed error (`TRPCClientError.data.code`/`.message`) instead of raw JSON; `fetcher.ts` deleted. See `docs/features/008-trpc-error-link/`. Treated as a standalone item (not folded into `001-auth-hardening`, which remains `draft` and covers a different security scope — see `008-trpc-error-link/spec.md` § 6).
+- `/post/[slug]` (`docs/features/002-post-slug/`) now correctly calls `notFound()` when the slug does not exist (**2026-07-11**, previously it fell through to the generic `error.tsx` — see commit `a620cde`), but the HTTP status of the response is still `200`, not `404`. **Investigated and reclassified on 2026-07-12** (`docs/features/009-post-404-status/`): the original hypothesis ("taking the post out of the `<Suspense>` fixes it, at the cost of losing the loading fallback") **was wrong** — with `cacheComponents: true` (`next.config.ts`), Next.js requires a `<Suspense>` boundary around any uncached dynamic read; removing it breaks the entire `next build` (`Uncached data was accessed outside of <Suspense>`), it is not a UX trade-off. `export const dynamic = "force-dynamic"` no longer exists as an escape hatch (removed together with Cache Components in Next 16). See `docs/gotchas.md` § Cache Components. A real fix would require checking the slug **outside** the Cache Components pipeline (e.g. `middleware`/`proxy` on the Edge) — new infrastructure, not a point fix. **Owner decision (2026-07-12): accept as a known limitation for now**, without investing in the new infrastructure; reopen if it becomes a real blocker (e.g. SEO starts requiring a real 404). Relevant for roadmap Phase 5 (SEO) — bots that check HTTP status will not see a real 404.
 
 ---
 
-## Épico Autenticação
+## Authentication Epic
 
-### US-001 — [Persona] registra uma conta nova
+### US-001 — [Persona] registers a new account
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]`, quero criar uma conta com email/senha/nome para publicar posts e comentar.
+- **Story:** As a `[persona]`, I want to create an account with email/password/name so I can publish posts and comment.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Registro bem-sucedido
-  Given um email ainda não cadastrado
-  When o usuário registra com email, senha e nome válidos
-  Then a conta é criada e um email de verificação é enviado
+Scenario: Successful registration
+  Given an email not yet registered
+  When the user registers with a valid email, password, and name
+  Then the account is created and a verification email is sent
 
-Scenario: Email de verificação falha ao enviar
-  Given um registro válido
-  When o envio do email de verificação falha
-  Then o registro ainda é concluído com sucesso (falha de envio não bloqueia o cadastro)
+Scenario: Verification email fails to send
+  Given a valid registration
+  When sending the verification email fails
+  Then the registration still completes successfully (a send failure does not block signup)
 
-Scenario: Email já cadastrado
-  Given um email já existente
-  When o usuário tenta registrar com esse email
-  Then a operação é rejeitada com erro de conflito
+Scenario: Email already registered
+  Given an email that already exists
+  When the user tries to register with that email
+  Then the operation is rejected with a conflict error
 ```
 
 **Metadata:** RF-01. *Test ref:* `src/server/features/user/register/controller.test.ts`.
 
 ---
 
-### US-002 — [Persona] faz login
+### US-002 — [Persona] logs in
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]`, quero logar com email/senha para criar uma sessão autenticada.
+- **Story:** As a `[persona]`, I want to log in with email/password so I can create an authenticated session.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Login com credenciais válidas
-  Given um usuário existente com senha correta
-  When o usuário faz login
-  Then uma sessão é retornada
+Scenario: Login with valid credentials
+  Given an existing user with the correct password
+  When the user logs in
+  Then a session is returned
 
-Scenario: Login com usuário inexistente
-  Given um email não cadastrado
-  When o usuário tenta logar
-  Then a operação é rejeitada
+Scenario: Login with a nonexistent user
+  Given an email that is not registered
+  When the user tries to log in
+  Then the operation is rejected
 ```
 
 **Metadata:** RF-01. *Test ref:* `src/server/features/user/login/controller.test.ts`. *Spec:* `docs/features/001-auth-hardening/spec.md`.
 
 ---
 
-### US-003 — [Persona] atualiza (refresh) ou termina (logout) a sessão
+### US-003 — [Persona] refreshes or ends (logout) the session
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]`, quero renovar minha sessão automaticamente e poder sair (logout) explicitamente.
+- **Story:** As a `[persona]`, I want my session to renew automatically, and I want to be able to log out explicitly.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Refresh de sessão válida
-  Given uma sessão existente com refresh token válido
-  When o cliente solicita refresh
-  Then uma nova sessão é emitida
+Scenario: Refresh of a valid session
+  Given an existing session with a valid refresh token
+  When the client requests a refresh
+  Then a new session is issued
 
-Scenario: Refresh com token inválido
-  Given um refresh token inválido
-  When o cliente solicita refresh
-  Then a operação é rejeitada
+Scenario: Refresh with an invalid token
+  Given an invalid refresh token
+  When the client requests a refresh
+  Then the operation is rejected
 
 Scenario: Logout
-  Given uma sessão autenticada
-  When o usuário faz logout
-  Then a sessão é encerrada
+  Given an authenticated session
+  When the user logs out
+  Then the session is ended
 
-Scenario: Logout com sessão ou usuário inexistente
-  Given uma sessão ou usuário que não existe mais
-  When o logout é solicitado
-  Then a operação é rejeitada com erro apropriado
+Scenario: Logout with a nonexistent session or user
+  Given a session or user that no longer exists
+  When logout is requested
+  Then the operation is rejected with the appropriate error
 ```
 
 **Metadata:** RF-01. *Test ref:* `src/server/features/auth/session/controller.test.ts`. *Spec:* `docs/features/001-auth-hardening/spec.md`.
 
 ---
 
-### US-004 — [Persona] verifica o email da conta
+### US-004 — [Persona] verifies the account email
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]`, quero verificar meu email via token para desbloquear a conta, e reenviar o token se necessário.
+- **Story:** As a `[persona]`, I want to verify my email via token to unlock the account, and resend the token if needed.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Verificação bem-sucedida
-  Given um token de verificação válido e não usado
-  When o usuário verifica o token
-  Then a conta é marcada como verificada
+Scenario: Successful verification
+  Given a valid, unused verification token
+  When the user verifies the token
+  Then the account is marked as verified
 
-Scenario: Token não encontrado / já usado / expirado
-  Given um token inválido, já usado, ou expirado
-  When o usuário tenta verificar
-  Then a operação é rejeitada com o erro correspondente
+Scenario: Token not found / already used / expired
+  Given an invalid, already-used, or expired token
+  When the user tries to verify
+  Then the operation is rejected with the corresponding error
 
-Scenario: Reenvio de token de verificação
-  Given um usuário não verificado
-  When o usuário solicita reenvio
-  Then um novo email de verificação é enviado
+Scenario: Resend of a verification token
+  Given an unverified user
+  When the user requests a resend
+  Then a new verification email is sent
 
-Scenario: Reenvio com email inexistente
-  Given um email não cadastrado
-  When o reenvio é solicitado
-  Then a operação é rejeitada
+Scenario: Resend with a nonexistent email
+  Given an email that is not registered
+  When a resend is requested
+  Then the operation is rejected
 ```
 
 **Metadata:** RF-02. *Test ref:* `src/server/features/auth/verifyToken/controller.test.ts`.
 
 ---
 
-### US-005 — [Persona] recupera a senha esquecida
+### US-005 — [Persona] recovers a forgotten password
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]`, quero solicitar um reset de senha por email e definir uma nova senha via token.
+- **Story:** As a `[persona]`, I want to request a password reset by email and set a new password via token.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Solicitação de reset bem-sucedida
-  Given um usuário existente
-  When o usuário solicita reset de senha
-  Then um token de reset é criado e um email é enviado
+Scenario: Successful reset request
+  Given an existing user
+  When the user requests a password reset
+  Then a reset token is created and an email is sent
 
-Scenario: Solicitação com usuário inexistente
-  Given um email não cadastrado
-  When o reset é solicitado
-  Then a operação é rejeitada
+Scenario: Request with a nonexistent user
+  Given an email that is not registered
+  When the reset is requested
+  Then the operation is rejected
 
-Scenario: Reset de senha bem-sucedido
-  Given um token de reset válido e senhas coincidentes
-  When o usuário define a nova senha
-  Then a senha é atualizada
+Scenario: Successful password reset
+  Given a valid reset token and matching passwords
+  When the user sets the new password
+  Then the password is updated
 
-Scenario: Reset com token inválido, usado, expirado, ou senhas não coincidentes
-  Given qualquer uma dessas condições
-  When o usuário tenta resetar
-  Then a operação é rejeitada com o erro correspondente
+Scenario: Reset with an invalid, used, or expired token, or mismatched passwords
+  Given any of these conditions
+  When the user tries to reset
+  Then the operation is rejected with the corresponding error
 ```
 
 **Metadata:** RF-03. *Test ref:* `src/server/features/auth/resetToken/controller.test.ts`.
 
 ---
 
-### US-010 — [Persona] atua conforme seu papel (Admin/Editor/Author)
+### US-010 — [Persona] acts according to their role (Admin/Editor/Author)
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]` com um papel (`ADMIN`/`EDITOR`/`AUTHOR`), quero que o sistema só me deixe fazer o que meu papel permite — e deixe Admin/Editor agirem sobre conteúdo de qualquer usuário quando o Author só age sobre o próprio.
+- **Story:** As a `[persona]` with a role (`ADMIN`/`EDITOR`/`AUTHOR`), I want the system to only let me do what my role allows — and let Admin/Editor act on any user's content, while Author can only act on their own.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Admin edita post de outro usuário
-  Given um post de outro usuário
-  When um Admin chama a edição
-  Then a operação é aceita
+Scenario: Admin edits another user's post
+  Given a post belonging to another user
+  When an Admin calls the edit
+  Then the operation is accepted
 
-Scenario: Author tenta editar post de outro usuário
-  Given um post de outro usuário
-  When um Author (não dono) chama a edição
-  Then a operação é rejeitada
+Scenario: Author tries to edit another user's post
+  Given a post belonging to another user
+  When an Author (not the owner) calls the edit
+  Then the operation is rejected
 
-Scenario: Author cria categoria
-  Given um usuário com papel Author
-  When ele tenta criar uma categoria
-  Then a operação é rejeitada
+Scenario: Author creates a category
+  Given a user with the Author role
+  When they try to create a category
+  Then the operation is rejected
 
-Scenario: Admin promove outro usuário
-  Given um usuário com papel Admin
-  When ele troca o papel de outro usuário
-  Then o papel é atualizado
+Scenario: Admin promotes another user
+  Given a user with the Admin role
+  When they change another user's role
+  Then the role is updated
 ```
 
 **Metadata:** RF-08. *Test ref:* `src/lib/permissions/__test__/matrix.ts`, `src/server/features/post/domain/__test__/*`, `src/server/features/category/procedures/__test__/create.ts`, `src/server/features/user/procedures/__test__/updateRole.ts`. *Spec:* `docs/features/013-role-based-permissions/spec.md`.
 
 ---
 
-## Épico Posts
+## Posts Epic
 
-### US-011 — [Persona] publica post via workflow de revisão
+### US-011 — [Persona] publishes a post via review workflow
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]` com um papel (`ADMIN`/`EDITOR`/`AUTHOR`), quero que a publicação de um post siga um workflow de revisão — Author envia pra revisão, Admin/Editor aprova/rejeita/publica/agenda/arquiva — em vez de qualquer dono publicar/arquivar o próprio post livremente.
+- **Story:** As a `[persona]` with a role (`ADMIN`/`EDITOR`/`AUTHOR`), I want publishing a post to follow a review workflow — Author submits for review, Admin/Editor approves/rejects/publishes/schedules/archives — instead of any owner freely publishing/archiving their own post.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Author cria post e ele nasce DRAFT
-  Given um usuário com papel AUTHOR
-  When ele cria um post sem informar status
-  Then o post é persistido como DRAFT
+Scenario: Author creates a post and it starts as DRAFT
+  Given a user with the AUTHOR role
+  When they create a post without specifying a status
+  Then the post is persisted as DRAFT
 
-Scenario: Author envia o próprio rascunho pra revisão
-  Given um post DRAFT pertencente ao usuário logado
-  When ele envia o post pra revisão
-  Then o post fica IN_REVIEW
+Scenario: Author submits their own draft for review
+  Given a DRAFT post belonging to the logged-in user
+  When they submit the post for review
+  Then the post becomes IN_REVIEW
 
-Scenario: Editor aprova e publica um post em revisão
-  Given um post IN_REVIEW
-  When um Editor aprova o post sem data de agendamento
-  Then o post fica PUBLISHED imediatamente
+Scenario: Editor approves and publishes a post under review
+  Given an IN_REVIEW post
+  When an Editor approves the post without a scheduled date
+  Then the post becomes PUBLISHED immediately
 
-Scenario: Admin agenda a publicação de um post em revisão
-  Given um post IN_REVIEW
-  When um Admin aprova o post informando uma data futura
-  Then o post fica SCHEDULED, e passa a aparecer publicamente só quando a data chega
+Scenario: Admin schedules the publication of a post under review
+  Given an IN_REVIEW post
+  When an Admin approves the post with a future date
+  Then the post becomes SCHEDULED, and only appears publicly once that date arrives
 
-Scenario: Editor rejeita um post em revisão com motivo
-  Given um post IN_REVIEW
-  When um Editor rejeita informando um motivo
-  Then o post volta pra DRAFT e o motivo fica visível pro dono
+Scenario: Editor rejects a post under review with a reason
+  Given an IN_REVIEW post
+  When an Editor rejects it with a reason
+  Then the post goes back to DRAFT and the reason is visible to the owner
 
-Scenario: Admin arquiva um post de qualquer usuário
-  Given um post de outro usuário
-  When um Admin arquiva o post
-  Then o post fica ARCHIVED
+Scenario: Admin archives another user's post
+  Given a post belonging to another user
+  When an Admin archives the post
+  Then the post becomes ARCHIVED
 
-Scenario: Author tenta publicar ou arquivar o próprio post direto
-  Given um post pertencente ao usuário logado (papel AUTHOR)
-  When ele tenta publicar ou arquivar esse post diretamente
-  Then a operação é rejeitada (FORBIDDEN)
+Scenario: Author tries to publish or archive their own post directly
+  Given a post belonging to the logged-in user (AUTHOR role)
+  When they try to publish or archive that post directly
+  Then the operation is rejected (FORBIDDEN)
 ```
 
 **Metadata:** RF-09. *Test ref:* `src/server/features/post/procedures/__test__/{submitForReview,publish,reject,archive,readReviewComments}.ts`. *Spec:* `docs/features/014-post-review-workflow/spec.md`.
 
 ---
 
-### US-012 — [Persona] compartilha e indexa um post com SEO completo
+### US-012 — [Persona] shares and indexes a post with full SEO
 
-- **Persona:** `[A DEFINIR]` (leitor externo/buscador — não um papel autenticado do sistema).
-- **Story:** Como leitor que compartilha um link de post (Discord/LinkedIn/WhatsApp) ou como buscador indexando o site, quero que cada post publicado tenha metadata completa (canonical, Open Graph com imagem, Twitter Card, schema.org) e que o site exponha sitemap/robots/RSS, pra que o preview seja rico e a indexação funcione.
+- **Persona:** `[A DEFINIR]` (external reader/search engine — not an authenticated role in the system).
+- **Story:** As a reader sharing a post link (Discord/LinkedIn/WhatsApp) or as a search engine indexing the site, I want every published post to have complete metadata (canonical, Open Graph with image, Twitter Card, schema.org) and the site to expose sitemap/robots/RSS, so previews are rich and indexing works.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Sitemap lista só posts publicamente visíveis
-  Given um post PUBLISHED, um DRAFT, um IN_REVIEW, um ARCHIVED, um SCHEDULED no futuro e um SCHEDULED no passado
-  When o sitemap é gerado
-  Then aparecem só o PUBLISHED e o SCHEDULED no passado
+Scenario: Sitemap lists only publicly visible posts
+  Given a PUBLISHED post, a DRAFT, an IN_REVIEW, an ARCHIVED, a SCHEDULED post in the future, and a SCHEDULED post in the past
+  When the sitemap is generated
+  Then only the PUBLISHED post and the past SCHEDULED post appear
 
-Scenario: Robots.txt bloqueia rotas privadas
-  When robots.txt é gerado
-  Then rotas de criar/editar/meus-posts, perfil, auth e api aparecem em Disallow
-  And o robots.txt referencia a URL do sitemap
+Scenario: Robots.txt blocks private routes
+  When robots.txt is generated
+  Then the create/edit/my-posts, profile, auth, and api routes appear under Disallow
+  And robots.txt references the sitemap URL
 
-Scenario: RSS feed reflete posts recentes publicados
-  Given 3 posts PUBLISHED e 1 DRAFT
-  When o feed.xml é lido
-  Then contém os 3 posts publicados, não contém o DRAFT
+Scenario: RSS feed reflects recently published posts
+  Given 3 PUBLISHED posts and 1 DRAFT
+  When feed.xml is read
+  Then it contains the 3 published posts, and does not contain the DRAFT
 
-Scenario: Post compartilhado tem preview rico
-  Given um post PUBLISHED com imagem de capa
-  When a página do post é carregada
-  Then a metadata inclui canonical, Open Graph com imagem, Twitter Card summary_large_image e JSON-LD Article válido
+Scenario: Shared post has a rich preview
+  Given a PUBLISHED post with a cover image
+  When the post page is loaded
+  Then the metadata includes canonical, Open Graph with image, Twitter Card summary_large_image, and valid JSON-LD Article
 ```
 
 **Metadata:** RF-10. *Test ref:* `src/server/models/__test__/prismaModels.ts` (`readAllPublicSlugs`), `src/server/features/post/procedures/__test__/readSitemapEntries.ts`, `src/server/http/__test__/{buildRssXml,buildArticleJsonLd}.ts`. *Spec:* `docs/features/015-seo-metadata/spec.md`.
 
 ---
 
-### US-013 — [Persona] busca posts por título ou conteúdo
+### US-013 — [Persona] searches posts by title or content
 
-- **Persona:** `[A DEFINIR]` (leitor do blog público — não um papel autenticado do sistema).
-- **Story:** Como leitor navegando o blog, quero buscar posts por uma palavra-chave presente no título ou no conteúdo, com sugestões enquanto digito, pra encontrar um post específico sem depender de rolar a listagem cronológica.
+- **Persona:** `[A DEFINIR]` (public blog reader — not an authenticated role in the system).
+- **Story:** As a reader browsing the blog, I want to search posts by a keyword present in the title or content, with suggestions as I type, so I can find a specific post without scrolling the chronological listing.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Busca encontra post pelo título
-  Given um post PUBLISHED com título "Guia de Prisma"
-  When o leitor busca por "prisma"
-  Then o post aparece no resultado
+Scenario: Search finds a post by title
+  Given a PUBLISHED post titled "Guia de Prisma"
+  When the reader searches for "prisma"
+  Then the post appears in the results
 
-Scenario: Busca encontra post pelo conteúdo
-  Given um post PUBLISHED cujo conteúdo menciona "tsvector" mas o título não
-  When o leitor busca por "tsvector"
-  Then o post aparece no resultado
+Scenario: Search finds a post by content
+  Given a PUBLISHED post whose content mentions "tsvector" but the title does not
+  When the reader searches for "tsvector"
+  Then the post appears in the results
 
-Scenario: Busca não vaza posts não-públicos
-  Given um post DRAFT com título "Rascunho Secreto"
-  When o leitor busca por "secreto"
-  Then o post não aparece no resultado
+Scenario: Search does not leak non-public posts
+  Given a DRAFT post titled "Rascunho Secreto"
+  When the reader searches for "secreto"
+  Then the post does not appear in the results
 
-Scenario: Busca é paginada
-  Given 15 posts PUBLISHED cujo título contém "teste"
-  When o leitor busca por "teste" com limit 10
-  Then a primeira página retorna 10 posts e um nextCursor não nulo
+Scenario: Search is paginated
+  Given 15 PUBLISHED posts whose title contains "teste"
+  When the reader searches for "teste" with limit 10
+  Then the first page returns 10 posts and a non-null nextCursor
 
-Scenario: Busca ordenada por mais acessado
-  Given um post PUBLISHED com título "A" e viewCount 5
-  And um post PUBLISHED com título "B" (mesmo termo de busca) e viewCount 20
-  When o leitor busca pelo termo comum com sortBy "mostViewed"
-  Then o post "B" aparece antes do post "A"
+Scenario: Search sorted by most viewed
+  Given a PUBLISHED post titled "A" with viewCount 5
+  And a PUBLISHED post titled "B" (same search term) with viewCount 20
+  When the reader searches for the shared term with sortBy "mostViewed"
+  Then post "B" appears before post "A"
 ```
 
 **Metadata:** RF-11. *Test ref:* `src/server/features/post/procedures/__test__/search.ts`, `src/server/models/__test__/prismaModels.ts` (`search`). *Spec:* `docs/features/016-search-content/spec.md`, `docs/features/019-search-sort-by-views/spec.md`.
 
 ---
 
-### US-014 — Admin/Editor acompanha visualizações de post
+### US-014 — Admin/Editor tracks post views
 
-- **Persona:** Admin/Editor (papel autenticado do sistema, ver `013-role-based-permissions`).
-- **Story:** Como Admin/Editor, quero ver quantas visualizações cada post recebeu (total e ranking de mais acessados), a partir de views registradas automaticamente quando um leitor abre a página pública de um post, pra entender quais conteúdos performam melhor.
+- **Persona:** Admin/Editor (authenticated role in the system, see `013-role-based-permissions`).
+- **Story:** As an Admin/Editor, I want to see how many views each post received (total and a ranking of most viewed), from views recorded automatically when a reader opens a post's public page, so I can understand which content performs best.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Visualização de post público é registrada
-  Given um post PUBLISHED
-  When um leitor abre a página do post
-  Then uma view é registrada para aquele post
+Scenario: A view of a public post is recorded
+  Given a PUBLISHED post
+  When a reader opens the post page
+  Then a view is recorded for that post
 
-Scenario: View de post não-público não é registrada
-  Given um post DRAFT ou ARCHIVED
-  When alguém abre a URL do post (ex: preview do próprio dono)
-  Then nenhuma view pública é registrada pra aquele acesso
+Scenario: A view of a non-public post is not recorded
+  Given a DRAFT or ARCHIVED post
+  When someone opens the post URL (e.g. the owner's own preview)
+  Then no public view is recorded for that access
 
-Scenario: Admin/Editor vê o total de views de um post
-  Given um post com N views registradas
-  When um Admin/Editor abre o dashboard de analytics
-  Then o total de views daquele post aparece
+Scenario: Admin/Editor sees the total view count of a post
+  Given a post with N recorded views
+  When an Admin/Editor opens the analytics dashboard
+  Then the total view count for that post appears
 
-Scenario: Dashboard lista posts mais acessados
-  Given múltiplos posts com contagens de view diferentes
-  When um Admin/Editor abre o dashboard de analytics
-  Then os posts aparecem ordenados por número de views, do mais pro menos acessado
+Scenario: Dashboard lists the most viewed posts
+  Given multiple posts with different view counts
+  When an Admin/Editor opens the analytics dashboard
+  Then the posts appear sorted by view count, from most to least viewed
 
-Scenario: Dashboard é restrito a Admin/Editor
-  Given um usuário Author autenticado (sem papel Admin/Editor)
-  When ele tenta acessar o dashboard de analytics
-  Then o acesso é negado
+Scenario: Dashboard is restricted to Admin/Editor
+  Given an authenticated Author user (without the Admin/Editor role)
+  When they try to access the analytics dashboard
+  Then access is denied
 
-Scenario: Dashboard mostra views dos últimos 7 e 30 dias
-  Given um post com views registradas em datas diferentes, algumas há mais de 30 dias
-  When um Admin/Editor abre o dashboard de analytics
-  Then o dashboard mostra a contagem de views dos últimos 7 dias e dos últimos 30 dias
-  And views com mais de 30 dias não entram nessas contagens
+Scenario: Dashboard shows views for the last 7 and 30 days
+  Given a post with views recorded on different dates, some more than 30 days old
+  When an Admin/Editor opens the analytics dashboard
+  Then the dashboard shows the view count for the last 7 days and the last 30 days
+  And views older than 30 days are not included in those counts
 
-Scenario: Dashboard mostra origem de tráfego
-  Given visitas com header Referer de busca, de rede social, sem Referer (direto) e de outro site
-  When um Admin/Editor abre o dashboard de analytics
-  Then o dashboard mostra a contagem de views por categoria de origem (direto/busca/social/outro)
+Scenario: Dashboard shows traffic source
+  Given visits with a search-engine Referer header, a social-network Referer, no Referer (direct), and another site's Referer
+  When an Admin/Editor opens the analytics dashboard
+  Then the dashboard shows the view count per source category (direct/search/social/other)
 
-Scenario: Dashboard mostra breakdown de navegador/SO
-  Given visitas de diferentes User-Agents
-  When um Admin/Editor abre o dashboard de analytics
-  Then o dashboard mostra a contagem de views por navegador/SO reconhecido
+Scenario: Dashboard shows a browser/OS breakdown
+  Given visits from different User-Agents
+  When an Admin/Editor opens the analytics dashboard
+  Then the dashboard shows the view count per recognized browser/OS
 
-Scenario: Views antigas não contam mais pro breakdown (retenção)
-  Given uma view registrada há mais de 30 dias
-  When o dashboard de analytics é lido novamente
-  Then essa view não aparece em nenhum dos breakdowns nem é recontada nas métricas de período
+Scenario: Old views no longer count toward the breakdown (retention)
+  Given a view recorded more than 30 days ago
+  When the analytics dashboard is read again
+  Then that view does not appear in any breakdown and is not counted in the period metrics
 ```
 
 **Metadata:** RF-12. *Test ref:* `src/server/features/analytics/domain/__test__/{recordView,readDashboard}.ts`, `src/server/features/analytics/procedures/__test__/{recordView,readDashboard}.ts`, `src/server/integrations/gateway/viewCounter/implementations/__test__/{redis,inMemory}.ts`, `src/server/models/__test__/postView.ts`, `src/lib/{referrerClassifier,userAgentClassifier}/__test__/regex.ts`. *Spec:* `docs/features/017-post-view-analytics/spec.md`, `docs/features/020-view-analytics-breakdown/spec.md`.
 
 ---
 
-### US-015 — Autor/Editor customiza SEO e URL amigável do post
+### US-015 — Author/Editor customizes post SEO and friendly URL
 
-- **Persona:** Autor/Editor (dono do post ou quem tem `post:editAny` — mesma regra de `post.update` hoje).
-- **Story:** Como Autor/Editor, quero poder sobrescrever o title/description/canonical usados no SEO de um post (quando o título/conteúdo não são o ideal pra compartilhamento ou o post é republicado de outro lugar) e poder corrigir o slug de um post já publicado sem quebrar links antigos, pra ter controle editorial completo sobre como o post é indexado e compartilhado (`docs/roadmap.md` Fase 5, pendências adiadas em `015-seo-metadata/spec.md § 4`).
+- **Persona:** Author/Editor (post owner or anyone with `post:editAny` — same rule as `post.update` today).
+- **Story:** As an Author/Editor, I want to be able to override the title/description/canonical used in a post's SEO (when the title/content are not ideal for sharing, or the post is republished from elsewhere), and to be able to fix the slug of an already-published post without breaking old links, so I have full editorial control over how the post is indexed and shared (`docs/roadmap.md` Phase 5, items deferred in `015-seo-metadata/spec.md § 4`).
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Override de SEO é usado na metadata em vez do conteúdo do post
-  Given um post com seoTitle/seoDescription/canonicalUrl preenchidos
-  When a página do post é carregada
-  Then <title>, meta description, Open Graph e canonical usam os valores de override, não title/content/URL própria
+Scenario: SEO override is used in metadata instead of the post's content
+  Given a post with seoTitle/seoDescription/canonicalUrl filled in
+  When the post page is loaded
+  Then <title>, meta description, Open Graph, and canonical use the override values, not the post's own title/content/URL
 
-Scenario: Sem override, comportamento atual é preservado
-  Given um post sem seoTitle/seoDescription/canonicalUrl (campos vazios)
-  When a página do post é carregada
-  Then a metadata é computada de title/content/URL própria, igual antes de 018
+Scenario: Without an override, current behavior is preserved
+  Given a post without seoTitle/seoDescription/canonicalUrl (empty fields)
+  When the post page is loaded
+  Then the metadata is computed from the post's own title/content/URL, same as before 018
 
-Scenario: Editar o slug de um post gera um novo slug válido e único
-  Given um post existente com slug "como-fiz-x"
-  When o Autor/Editor edita o slug pra "como-fiz-x-de-verdade"
-  Then o post passa a responder em "/post/como-fiz-x-de-verdade"
-  And o slug antigo "como-fiz-x" fica registrado como slug anterior
+Scenario: Editing a post's slug generates a new, valid, unique slug
+  Given an existing post with slug "como-fiz-x"
+  When the Author/Editor edits the slug to "como-fiz-x-de-verdade"
+  Then the post now responds at "/post/como-fiz-x-de-verdade"
+  And the old slug "como-fiz-x" is recorded as a previous slug
 
-Scenario: Slug antigo redireciona pro slug novo
-  Given um post cujo slug mudou de "como-fiz-x" pra "como-fiz-x-de-verdade"
-  When alguém acessa "/post/como-fiz-x"
-  Then a resposta é um redirect permanente (301) pra "/post/como-fiz-x-de-verdade"
+Scenario: The old slug redirects to the new slug
+  Given a post whose slug changed from "como-fiz-x" to "como-fiz-x-de-verdade"
+  When someone accesses "/post/como-fiz-x"
+  Then the response is a permanent redirect (301) to "/post/como-fiz-x-de-verdade"
 
-Scenario: Novo slug colide com um já existente
-  Given um post publicado com slug "titulo-legal"
-  When o Autor/Editor edita outro post pro mesmo slug "titulo-legal"
-  Then o post editado recebe um sufixo numérico ("titulo-legal-2"), mesmo padrão do slug gerado na criação
+Scenario: The new slug collides with an existing one
+  Given a published post with slug "titulo-legal"
+  When the Author/Editor edits another post to the same slug "titulo-legal"
+  Then the edited post receives a numeric suffix ("titulo-legal-2"), the same pattern used for slug generation at creation time
 ```
 
 **Metadata:** RF-10. *Test ref:* `docs/features/018-seo-overrides-slug-redirect/`. *Spec:* `docs/features/018-seo-overrides-slug-redirect/spec.md`.
 
 ---
 
-### US-006 — [Persona] cria e lê posts
+### US-006 — [Persona] creates and reads posts
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]`, quero publicar um post e poder lê-lo (individualmente ou entre os recentes).
+- **Story:** As a `[persona]`, I want to publish a post and be able to read it (individually or among recent posts).
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Criar post
-  Given um usuário autenticado e verificado
-  When o usuário cria um post com título e conteúdo
-  Then o post é persistido com o `userId` do autor
+Scenario: Create a post
+  Given an authenticated, verified user
+  When the user creates a post with a title and content
+  Then the post is persisted with the author's `userId`
 
-Scenario: Ler post por ID
-  Given um post existente
-  When o post é lido por ID
-  Then os dados do post são retornados
+Scenario: Read a post by ID
+  Given an existing post
+  When the post is read by ID
+  Then the post data is returned
 
-Scenario: Ler post inexistente
-  Given um ID que não existe
-  When o post é lido
-  Then a operação é rejeitada
+Scenario: Read a nonexistent post
+  Given an ID that does not exist
+  When the post is read
+  Then the operation is rejected
 
-Scenario: Listar posts recentes
-  When os posts recentes são solicitados
-  Then até 30 posts recentes são retornados
+Scenario: List recent posts
+  When recent posts are requested
+  Then up to 30 recent posts are returned
 
-Scenario: Ler post por slug
-  Given um post existente com slug "como-fiz-x"
-  When o post é lido pelo slug "como-fiz-x"
-  Then os dados do post são retornados
+Scenario: Read a post by slug
+  Given an existing post with slug "como-fiz-x"
+  When the post is read by the slug "como-fiz-x"
+  Then the post data is returned
 
-Scenario: Ler post por slug inexistente
-  Given um slug que não corresponde a nenhum post
-  When o post é lido por esse slug
-  Then a operação é rejeitada com "post não encontrado"
+Scenario: Read a post by a nonexistent slug
+  Given a slug that does not match any post
+  When the post is read by that slug
+  Then the operation is rejected with "post not found"
 
-Scenario: Criar post gera slug derivado do título
-  Given um usuário autenticado e verificado
-  When ele cria um post com título "Como fiz X"
-  Then o post persistido tem um slug no formato "como-fiz-x"
+Scenario: Creating a post generates a slug derived from the title
+  Given an authenticated, verified user
+  When they create a post titled "Como fiz X"
+  Then the persisted post has a slug in the format "como-fiz-x"
 
-Scenario: Título duplicado gera slug com sufixo
-  Given um post existente com slug "como-fiz-x"
-  When um novo post é criado com o mesmo título "Como fiz X"
-  Then o novo post recebe o slug "como-fiz-x-2"
+Scenario: A duplicate title generates a slug with a suffix
+  Given an existing post with slug "como-fiz-x"
+  When a new post is created with the same title "Como fiz X"
+  Then the new post receives the slug "como-fiz-x-2"
 ```
 
-**Metadata:** RF-04. *Test ref:* `src/server/features/post/create/controller.test.ts`, `post/read`, `post/readRecent`, `post/readBySlug`. *Spec:* `docs/features/002-post-slug/spec.md` (amend — leitura por slug, `in_progress`).
+**Metadata:** RF-04. *Test ref:* `src/server/features/post/create/controller.test.ts`, `post/read`, `post/readRecent`, `post/readBySlug`. *Spec:* `docs/features/002-post-slug/spec.md` (amend — read by slug, `in_progress`).
 
 ---
 
-### US-007 — [Persona] atualiza, revalida e deleta um post
+### US-007 — [Persona] updates, revalidates, and deletes a post
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]`, quero editar, revalidar (ISR) ou remover meus próprios posts.
+- **Story:** As a `[persona]`, I want to edit, revalidate (ISR), or remove my own posts.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Atualizar post próprio
-  Given um post pertencente ao usuário autenticado
-  When o usuário atualiza título/conteúdo
-  Then o post é atualizado
+Scenario: Update own post
+  Given a post belonging to the authenticated user
+  When the user updates the title/content
+  Then the post is updated
 
-Scenario: Atualizar post de outro usuário
-  Given um post que não pertence ao usuário autenticado
-  When o usuário tenta atualizar
-  Then a operação é rejeitada como não autorizada
+Scenario: Update another user's post
+  Given a post that does not belong to the authenticated user
+  When the user tries to update it
+  Then the operation is rejected as unauthorized
 
-Scenario: Revalidar post (ISR)
-  Given um post pertencente ao usuário
-  When o usuário solicita revalidação
-  Then a página do post é revalidada
+Scenario: Revalidate a post (ISR)
+  Given a post belonging to the user
+  When the user requests revalidation
+  Then the post page is revalidated
 
-Scenario: Deletar post próprio
-  Given um post pertencente ao usuário
-  When o usuário deleta
-  Then o post é removido
+Scenario: Delete own post
+  Given a post belonging to the user
+  When the user deletes it
+  Then the post is removed
 
-Scenario: Post inexistente ou de outro usuário
-  Given essas condições em update/revalidate/delete
-  When a operação é tentada
-  Then é rejeitada com o erro correspondente
+Scenario: Nonexistent post or another user's post
+  Given these conditions in update/revalidate/delete
+  When the operation is attempted
+  Then it is rejected with the corresponding error
 ```
 
 **Metadata:** RF-04. *Test ref:* `src/server/features/post/update`, `post/revalidate`, `post/delete` `controller.test.ts`.
 
 ---
 
-## Épico Comentários
+## Comments Epic
 
-### US-008 — [Persona] comenta em posts
+### US-008 — [Persona] comments on posts
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]`, quero criar, listar, atualizar e deletar comentários em posts.
+- **Story:** As a `[persona]`, I want to create, list, update, and delete comments on posts.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Criar comentário
-  Given um usuário autenticado e um post existente
-  When o usuário comenta
-  Then o comentário é persistido
+Scenario: Create a comment
+  Given an authenticated user and an existing post
+  When the user comments
+  Then the comment is persisted
 
-Scenario: Listar comentários de um post
-  Given um post com ou sem comentários
-  When os comentários são listados
-  Then a lista (ou lista vazia) é retornada
+Scenario: List comments on a post
+  Given a post with or without comments
+  When the comments are listed
+  Then the list (or an empty list) is returned
 
-Scenario: Atualizar comentário próprio
-  Given um comentário do usuário autenticado
-  When o usuário atualiza o conteúdo
-  Then o comentário é atualizado
+Scenario: Update own comment
+  Given a comment from the authenticated user
+  When the user updates the content
+  Then the comment is updated
 
-Scenario: Deletar comentário próprio
-  Given um comentário do usuário autenticado
-  When o usuário deleta
-  Then o comentário é removido
+Scenario: Delete own comment
+  Given a comment from the authenticated user
+  When the user deletes it
+  Then the comment is removed
 
-Scenario: Comentário inexistente ou de outro usuário
-  Given essas condições em update/delete
-  When a operação é tentada
-  Then é rejeitada com o erro correspondente
+Scenario: Nonexistent comment or another user's comment
+  Given these conditions in update/delete
+  When the operation is attempted
+  Then it is rejected with the corresponding error
 ```
 
 **Metadata:** RF-05. *Test ref:* `src/server/features/comment/{create,readAll,update,delete}/controller.test.ts`.
 
 ---
 
-## Épico Perfil de Usuário
+## User Profile Epic
 
-### US-009 — [Persona] visualiza e edita o próprio perfil
+### US-009 — [Persona] views and edits their own profile
 
 - **Persona:** `[A DEFINIR]`.
-- **Story:** Como `[persona]`, quero ver meu perfil (com posts/comentários) e editar nome/bio.
+- **Story:** As a `[persona]`, I want to see my profile (with posts/comments) and edit my name/bio.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Ler perfil de usuário
-  Given um usuário existente
-  When o perfil é solicitado
-  Then os dados do perfil são retornados
+Scenario: Read a user's profile
+  Given an existing user
+  When the profile is requested
+  Then the profile data is returned
 
-Scenario: Perfil de usuário inexistente
-  Given um ID que não existe
-  When o perfil é solicitado
-  Then a operação é rejeitada
+Scenario: Profile of a nonexistent user
+  Given an ID that does not exist
+  When the profile is requested
+  Then the operation is rejected
 
-Scenario: Atualizar perfil próprio
-  Given um usuário autenticado
-  When o usuário atualiza nome/bio
-  Then o perfil é atualizado
+Scenario: Update own profile
+  Given an authenticated user
+  When the user updates name/bio
+  Then the profile is updated
 
-Scenario: Listar posts do usuário
-  Given um usuário com ou sem posts
-  When os posts do usuário são solicitados
-  Then a lista (ou lista vazia) é retornada
+Scenario: List a user's posts
+  Given a user with or without posts
+  When the user's posts are requested
+  Then the list (or an empty list) is returned
 
-Scenario: Listar comentários do usuário
-  Given um usuário com ou sem comentários
-  When os comentários do usuário são solicitados
-  Then a lista (ou lista vazia) é retornada
+Scenario: List a user's comments
+  Given a user with or without comments
+  When the user's comments are requested
+  Then the list (or an empty list) is returned
 ```
 
 **Metadata:** RF-06. *Test ref:* `src/server/features/user/{profile,posts,comments}/controller.test.ts`.
 
 ---
 
-## Épico Mídia
+## Media Epic
 
-### US-016 — Usuário autenticado envia e gerencia mídia
+### US-016 — Authenticated user uploads and manages media
 
-- **Persona:** Autor/Editor/Admin (qualquer usuário autenticado, ver `013-role-based-permissions`).
-- **Story:** Como usuário autenticado, quero enviar um arquivo de imagem, ver a minha biblioteca de mídia, apagar o que enviei e descrever a imagem com texto alternativo, pra poder usar uma imagem própria como capa de post sem depender de uma URL externa (`docs/roadmap.md` Fase 8). Admin/Editor também enxergam e removem mídia enviada por qualquer usuário, mesmo padrão de bypass de `post:deleteAny` (RF-08).
+- **Persona:** Author/Editor/Admin (any authenticated user, see `013-role-based-permissions`).
+- **Story:** As an authenticated user, I want to upload an image file, see my media library, delete what I uploaded, and describe the image with alt text, so I can use my own image as a post cover without depending on an external URL (`docs/roadmap.md` Phase 8). Admin/Editor can also see and remove media uploaded by any user, the same bypass pattern as `post:deleteAny` (RF-08).
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Upload de imagem válida
-  Given um usuário autenticado
-  When ele envia um arquivo JPEG de 2MB com texto alternativo "foto do evento"
-  Then a mídia é salva e aparece na biblioteca do usuário com a URL pública
+Scenario: Upload a valid image
+  Given an authenticated user
+  When they upload a 2MB JPEG file with alt text "foto do evento"
+  Then the media is saved and appears in the user's library with the public URL
 
-Scenario: Upload rejeitado por formato inválido
-  Given um usuário autenticado
-  When ele envia um arquivo .pdf
-  Then o upload é rejeitado antes de tocar o storage
+Scenario: Upload rejected due to invalid format
+  Given an authenticated user
+  When they upload a .pdf file
+  Then the upload is rejected before touching storage
 
-Scenario: Upload rejeitado por tamanho excedido
-  Given um usuário autenticado
-  When ele envia uma imagem de 8MB (acima do limite configurado)
-  Then o upload é rejeitado antes de tocar o storage
+Scenario: Upload rejected due to size limit exceeded
+  Given an authenticated user
+  When they upload an 8MB image (above the configured limit)
+  Then the upload is rejected before touching storage
 
-Scenario: Usuário vê só a própria biblioteca
-  Given dois usuários, cada um com mídia enviada
-  When um deles lista a própria biblioteca
-  Then só a mídia que ele mesmo enviou aparece
+Scenario: User sees only their own library
+  Given two users, each with uploaded media
+  When one of them lists their own library
+  Then only the media they uploaded themselves appears
 
-Scenario: Dono apaga a própria mídia
-  Given um usuário dono de uma mídia
-  When ele apaga essa mídia
-  Then o registro e o arquivo físico deixam de existir
+Scenario: Owner deletes their own media
+  Given a user who owns a media item
+  When they delete that media
+  Then the record and the physical file no longer exist
 
-Scenario: Usuário sem permissão não apaga mídia de outro
-  Given um usuário Author sem bypass de permissão
-  When ele tenta apagar mídia enviada por outro usuário
-  Then a operação é rejeitada
+Scenario: User without permission cannot delete another user's media
+  Given an Author user without a permission bypass
+  When they try to delete media uploaded by another user
+  Then the operation is rejected
 
-Scenario: Admin/Editor apaga mídia de qualquer usuário
-  Given um usuário com papel Admin ou Editor
-  When ele apaga mídia enviada por outro usuário
-  Then a mídia é removida normalmente
+Scenario: Admin/Editor deletes any user's media
+  Given a user with the Admin or Editor role
+  When they delete media uploaded by another user
+  Then the media is removed normally
 
-Scenario: Mídia enviada vira capa do post
-  Given um usuário com uma mídia já enviada
-  When ele escolhe essa mídia como capa ao criar/editar um post
-  Then o post passa a usar a URL pública da mídia como coverImageUrl
+Scenario: Uploaded media becomes a post cover
+  Given a user with already-uploaded media
+  When they choose that media as the cover while creating/editing a post
+  Then the post starts using the media's public URL as coverImageUrl
 ```
 
 **Metadata:** RF-13. *Spec:* `docs/features/021-media-upload/spec.md`.
 
 ---
 
-## Épico Qualidade de Sistema
+## System Quality Epic
 
-### US-017 — Dev resolve erro de domínio sem código duplicado por procedure
+### US-017 — Dev resolves domain error without duplicated code per procedure
 
-- **Persona:** Dev mantenedor do projeto (item de qualidade interna, não de produto — `docs/roadmap.md` Fase 9).
-- **Story:** Como dev mantendo o backend, quero que todo erro de domínio já carregue seu próprio código HTTP e mensagem (via `ErrorRegistry`, `ADR-0017`), pra escrever/ler qualquer procedure sem precisar de switch/if-chain repetido traduzindo `AppError` em `TRPCError`, e sem perder a granularidade que o frontend (`getErrorMessage`) já depende pra mostrar a mensagem certa.
+- **Persona:** Dev maintaining the project (internal quality item, not a product item — `docs/roadmap.md` Phase 9).
+- **Story:** As a dev maintaining the backend, I want every domain error to already carry its own HTTP code and message (via `ErrorRegistry`, `ADR-0017`), so I can write/read any procedure without a repeated switch/if-chain translating `AppError` into `TRPCError`, and without losing the granularity that the frontend (`getErrorMessage`) already relies on to show the right message.
 
-**Critérios de aceitação:**
+**Acceptance criteria:**
 
 ```gherkin
-Scenario: Domain lança erro namespaced e a procedure não traduz nada
-  Given uma função domain_* que detecta uma violação de regra de negócio
-  When ela lança `new AppError("auth.invalid_credentials")`
-  Then a procedure não carrega bloco de tradução nenhum — nem switch, nem if-chain, nem try/catch
-  And o middleware do baseProcedure relança um TRPCError com o código de transporte (appErrorTransport) e a mensagem (resolveErrorEntry) resolvidos fora do domínio
+Scenario: Domain throws a namespaced error and the procedure translates nothing
+  Given a domain_* function that detects a business-rule violation
+  When it throws `new AppError("auth.invalid_credentials")`
+  Then the procedure carries no translation block at all — no switch, no if-chain, no try/catch
+  And the baseProcedure middleware re-throws a TRPCError with the transport code (appErrorTransport) and message (resolveErrorEntry) resolved outside the domain
 
-Scenario: Dois domínios não podem reivindicar o mesmo namespace
-  Given dois arquivos de erro diferentes chamando defineDomainErrors com o mesmo nome de domínio
-  When o segundo módulo é carregado
-  Then o ErrorRegistry lança um erro de duplicação, falhando o boot em vez de sobrescrever silenciosamente
+Scenario: Two domains cannot claim the same namespace
+  Given two different error files calling defineDomainErrors with the same domain name
+  When the second module is loaded
+  Then ErrorRegistry throws a duplication error, failing the boot instead of silently overwriting
 
-Scenario: Typo no código de erro quebra o build, não o runtime
-  Given um domain_* referenciando um AppError com um code inexistente no registry
-  When o projeto roda tsc --noEmit
-  Then o build falha, porque ErrorCode é o union literal derivado de keyof typeof Errors
+Scenario: A typo in the error code breaks the build, not the runtime
+  Given a domain_* referencing an AppError with a code that does not exist in the registry
+  When the project runs tsc --noEmit
+  Then the build fails, because ErrorCode is the literal union derived from keyof typeof Errors
 
-Scenario: Frontend continua resolvendo a mensagem certa por código granular
-  Given múltiplos erros de domínio que mapeiam pro mesmo httpCode (ex: vários BAD_REQUEST em auth)
-  When cada um ocorre
-  Then o frontend exibe a mensagem específica correta, não uma mensagem genérica de status
+Scenario: Frontend keeps resolving the right message by granular code
+  Given multiple domain errors that map to the same httpCode (e.g. several BAD_REQUEST in auth)
+  When each of them occurs
+  Then the frontend shows the correct specific message, not a generic status message
 ```
 
-**Metadata:** RF-14. *Spec:* `docs/features/022-error-registry/spec.md`; estendida por `023-error-metadata-classification` e **fechada de fato** por `024-error-boundary-centralization` (2026-08-22) — a 022 entregou o registry, mas a duplicação que a story cita ("sem switch/if-chain repetido") só saiu do código na 024, quando a tradução virou middleware. Ver ADR-0019.
+**Metadata:** RF-14. *Spec:* `docs/features/022-error-registry/spec.md`; extended by `023-error-metadata-classification` and **effectively closed** by `024-error-boundary-centralization` (2026-08-22) — 022 delivered the registry, but the duplication the story refers to ("without repeated switch/if-chain") only left the code in 024, when the translation became middleware. See ADR-0019.
 
 ---
 
-*Adicionar US nova: copia o bloco acima abaixo do épico correspondente. Se o épico não existe, cria H2 novo. Numera o ID sequencialmente do último em uso.*
+*Adding a new US: copy the block above below the corresponding epic. If the epic does not exist, create a new H2. Number the ID sequentially from the last one in use.*


### PR DESCRIPTION
## What

Finishes the ADR-0021 conversion of the live normative core to **English, STE-spirit**. This PR bundles the remaining 17 docs (owner asked for a single PR; ADR-0021's "one PR per doc" is intentionally bundled here).

Already merged separately: `afm.md` (#220), `prd.md` (#221), `gotchas.md` (#222).

**In this PR:**
- `ach.md` (architecture)
- `ust.md` (user stories / backlog)
- `roadmap.md` (phase plan)
- `rubrics/*.md` (12 decision docs)
- `protocols/{p1,p2,p3}.md` (3 autonomy presets)

## Method — prose only, byte-exact everything else

Each doc was verified: the sorted set of backtick code-spans is diffed between `develop:<file>` and the translation. **Only prose-in-backtick placeholders/examples may differ**; every real command, path, identifier, `[A DEFINIR]` marker, RF/US/RNF ID, rule number, ADR/feature ref, arXiv ref, date, and URL is preserved unchanged. `ust.md` and `roadmap.md` were translated by parallel Sonnet subagents and re-verified independently.

## Measurement (per doc)

| Doc | words (orig → new) | chars |
| --- | --- | ---: |
| `ach.md` | 4463 → 4528 | +0.3% |
| `rubrics/` (12) + `protocols/` (3) | 6584 → 7124 (agg) | ~neutral |
| `ust.md` | 4488 → 4571 | +0.9% |
| `roadmap.md` | 4967 → 5007 | −1.5% |

Consistent with the whole effort: real normative docs are **reference/identifier-dense**, so STE-spirit translation is **token-neutral**. The delivered value is **English consistency**, not token savings (the −26% seen on a pure-prose excerpt does not survive real docs).

## Byte-exact notes

- `ach.md`: only 4 angle-bracket placeholders differ (`<Entidade>Model` → `<Entity>Model`, etc.).
- `ust.md`: zero code-span changes.
- `roadmap.md`: 2 quoted example step names translated (`aprovar` → `approve`, `enviar pra revisão` → `submit for review`); 20 feature-dir refs intact.
- `rubrics/`: only illustrative example strings/placeholders differ (`sig=<assinatura>` → `sig=<signature>`, `12 métodos` → `12 methods`).

## Preserved faithfully — reconcile follow-up (NOT fixed here)

To keep this a pure translation (clean byte-exact diff), pre-existing staleness was preserved verbatim:
- Stale identifiers from the ADR-0020 rename (`DomainError`, `withDomainErrors`, `domainErrorToTRPCError`, `<Domínio>ErrorCode`) in `ach.md`.
- Rubrics referencing `src/server/modules/` (the pre-ADR-0006 folder name; the code uses `src/server/features/`).
- Cross-doc section anchors to not-yet-converted or Portuguese docs kept literal (`docs/ust.md § Pendências Técnicas`, `CLAUDE.md § Doutrina`).

A follow-up `/afm:reconcile` should fan-out the rename and refresh these anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)