### PR TITLE
chore: upgrade ioredis 5.5.0 -> 6.0.0 (fix DEP0169 url.parse)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"dotenv": "^17.0.1",
 				"framer-motion": "11.13.1",
 				"intl-messageformat": "^10.5.0",
-				"ioredis": "^5.5.0",
+				"ioredis": "^6.0.0",
 				"lucide-react": "^0.514.0",
 				"next": "^16.2.10",
 				"next-themes": "^0.4.4",
@@ -2088,9 +2088,9 @@
 			}
 		},
 		"node_modules/@ioredis/commands": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-			"integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-2.0.0.tgz",
+			"integrity": "sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==",
 			"license": "MIT"
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -5632,9 +5632,9 @@
 			}
 		},
 		"node_modules/cluster-key-slot": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-			"integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+			"integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=0.10.0"
@@ -6003,9 +6003,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -7259,23 +7259,20 @@
 			}
 		},
 		"node_modules/ioredis": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.5.0.tgz",
-			"integrity": "sha512-7CutT89g23FfSa8MDoIFs2GYYa0PaNiW/OrT+nRyjRXHDZd17HmIgy+reOQ/yhh72NznNjGuS8kbCAcA4Ro4mw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-6.0.0.tgz",
+			"integrity": "sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==",
 			"license": "MIT",
 			"dependencies": {
-				"@ioredis/commands": "^1.1.1",
-				"cluster-key-slot": "^1.1.0",
-				"debug": "^4.3.4",
-				"denque": "^2.1.0",
-				"lodash.defaults": "^4.2.0",
-				"lodash.isarguments": "^3.1.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0",
-				"standard-as-callback": "^2.1.0"
+				"@ioredis/commands": "2.0.0",
+				"cluster-key-slot": "1.1.1",
+				"debug": "4.4.3",
+				"denque": "2.1.0",
+				"redis-errors": "1.2.0",
+				"standard-as-callback": "2.1.0"
 			},
 			"engines": {
-				"node": ">=12.22.0"
+				"node": ">=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -9296,18 +9293,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/lodash.defaults": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-			"license": "MIT"
-		},
-		"node_modules/lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-			"license": "MIT"
-		},
 		"node_modules/log-update": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -11181,18 +11166,6 @@
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
 			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
 			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"license": "MIT",
-			"dependencies": {
-				"redis-errors": "^1.0.0"
-			},
 			"engines": {
 				"node": ">=4"
 			}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"dotenv": "^17.0.1",
 		"framer-motion": "11.13.1",
 		"intl-messageformat": "^10.5.0",
-		"ioredis": "^5.5.0",
+		"ioredis": "^6.0.0",
 		"lucide-react": "^0.514.0",
 		"next": "^16.2.10",
 		"next-themes": "^0.4.4",


### PR DESCRIPTION
## What

Upgrade `ioredis` from `5.5.0` to `6.0.0`.

## Why

ioredis 5.x parses `REDIS_URL` with the legacy Node `url.parse()`, which emits
`DEP0169` ("`url.parse()` behavior is not standardized… security implications").
The warning fired once per Turbopack worker process at Redis client init, flooding
`npm run dev` output. ioredis 6.0.0 replaces it with the WHATWG `new URL()`
(`node_modules/ioredis/built/utils/index.js` `parseURL`), removing the warning at
the root.

## Impact / risk

- **Node engine:** v6 requires `node >=20`; the project runs on 26. ✓
- **Sole consumer:** `RedisViewCounterGateway`
  (`src/server/integrations/gateway/viewCounter/implementations/redis.ts`) uses
  only core commands — `sadd`/`expire`/`incr`/`rpush`/`keys`/`get`/`del`/`lrange`
  and `new Redis(url)`. None changed in 5→6. Low risk; the only behavioral
  surface touched is URL parsing, and our `redis://host:port/db` format parses
  identically under `new URL()`.
- `package-lock.json` shrinks (v6 dropped legacy transitive deps).

## Verification

- `tsc --noEmit` clean.
- Full test suite **395/395** green.
- **Live smoke** against the local Redis (docker `cache`): a script exercising the
  exact gateway commands returned `{ added: 1, pending: "1", events: ["{…}"] }`,
  with **zero `DEP0169`** under `--trace-deprecation` (ioredis actually loaded and
  `parseURL` exercised).

## Notes

- Lockfile updated via **npm** (`package-lock.json` — the tracked lockfile). A
  stray `yarn.lock` was avoided.
- Follow-up unrelated to this PR: `.husky/` hooks call `yarn` while the repo tracks
  `package-lock.json` — a package-manager inconsistency worth reconciling separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
