### PR TITLE
test: cover backend guard branches (mop-up to ~91%)

### DIFF
--- a/src/lib/userAgentClassifier/__test__/regex.ts
+++ b/src/lib/userAgentClassifier/__test__/regex.ts
@@ -12,6 +12,8 @@ const UA = {
 		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
 	chromeAndroid:
 		"Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36",
+	safariMac:
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
 };
 
 describe("RegexUserAgentClassifier Unitary Testing", () => {
@@ -49,6 +51,13 @@ describe("RegexUserAgentClassifier Unitary Testing", () => {
 		expect(classifier.classify(UA.chromeAndroid)).toEqual({
 			browser: "Chrome",
 			os: "Android",
+		});
+	});
+
+	test("Should classify Safari on macOS", () => {
+		expect(classifier.classify(UA.safariMac)).toEqual({
+			browser: "Safari",
+			os: "macOS",
 		});
 	});
 

--- a/src/server/features/analytics/domain/__test__/recordView.ts
+++ b/src/server/features/analytics/domain/__test__/recordView.ts
@@ -1,9 +1,13 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { AppError } from "@/shared/error/appError";
 import { createTestContext } from "@/test/context";
 import { domain_recordView } from "../recordView";
 
 describe("domain_recordView", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	test("records a view for a PUBLISHED post", async () => {
 		const ctx = createTestContext();
 		const user = await ctx.createNewUser();
@@ -98,5 +102,22 @@ describe("domain_recordView", () => {
 		expect(events[post.id]).toEqual([
 			{ referrerBucket: "DIRECT", userAgent: "" },
 		]);
+	});
+
+	test("degrades to counted:false when the view counter backend fails", async () => {
+		const ctx = createTestContext();
+		const user = await ctx.createNewUser();
+		const post = await ctx.createPost({ userId: user.id, status: "PUBLISHED" });
+
+		vi.spyOn(ctx.gateways.viewCounter, "recordView").mockRejectedValue(
+			new Error("counter backend unreachable"),
+		);
+
+		const result = await domain_recordView({
+			ctx,
+			input: { postId: post.id, visitorId: "visitor-1" },
+		});
+
+		expect(result).toEqual({ counted: false });
 	});
 });

--- a/src/server/features/auth/domain/__test__/sessionAndToken.ts
+++ b/src/server/features/auth/domain/__test__/sessionAndToken.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { AppError } from "@/shared/error/appError";
 import { createAuthenticatedContext, createTestContext } from "@/test/context";
 import { domain_createAuthSession } from "../createAuthSession";
@@ -11,6 +11,10 @@ import { domain_reCreateToken } from "../reCreateToken";
 import { domain_refreshSession } from "../refreshSession";
 
 describe("auth session and token domains", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	test("creates auth sessions for existing users", async () => {
 		const ctx = await createAuthenticatedContext();
 
@@ -31,6 +35,17 @@ describe("auth session and token domains", () => {
 		await expect(
 			domain_createAuthSession({ ctx, input: { userId: "missing-user" } }),
 		).rejects.toMatchObject(new AppError("user.not_found"));
+	});
+
+	test("surfaces session_create_error when the store returns no session", async () => {
+		const ctx = await createAuthenticatedContext();
+		vi.spyOn(ctx.repositories.session, "create").mockResolvedValueOnce(
+			null as never,
+		);
+
+		await expect(
+			domain_createAuthSession({ ctx, input: { userId: ctx.user.id } }),
+		).rejects.toMatchObject(new AppError("session.session_create_error"));
 	});
 
 	test("creates verification tokens with a future expiration", async () => {
@@ -192,6 +207,23 @@ describe("auth session and token domains", () => {
 		expect(refreshedSession.accessToken).not.toBe(ctx.user.session.accessToken);
 		expect(refreshedSession.refreshToken).not.toBe(originalRefreshToken);
 		expect(refreshedSession.previousRefreshToken).toBe(originalRefreshToken);
+	});
+
+	test("surfaces session_update_error when the store returns no session", async () => {
+		const ctx = await createAuthenticatedContext();
+		vi.spyOn(ctx.repositories.session, "update").mockResolvedValueOnce(
+			null as never,
+		);
+
+		await expect(
+			domain_refreshSession({
+				ctx,
+				input: {
+					id: ctx.user.session.id,
+					currentRefreshToken: ctx.user.session.refreshToken,
+				},
+			}),
+		).rejects.toMatchObject(new AppError("session.session_update_error"));
 	});
 
 	test("rejects reuse of a rotated-out refresh token and revokes the session", async () => {

--- a/src/server/features/post/procedures/__test__/archive.ts
+++ b/src/server/features/post/procedures/__test__/archive.ts
@@ -49,4 +49,13 @@ describe("Archive Post Controller Unitary Testing", () => {
 			message: "This action is not valid for the post's current status.",
 		});
 	});
+
+	test("Should throw NOT_FOUND when the post does not exist", async () => {
+		await expect(
+			PostRouter.createCaller(adminCtx).archive({ id: "does-not-exist" }),
+		).rejects.toMatchObject({
+			code: "NOT_FOUND",
+			message: "Post not found.",
+		});
+	});
 });

--- a/src/server/features/post/procedures/__test__/publish.ts
+++ b/src/server/features/post/procedures/__test__/publish.ts
@@ -91,4 +91,13 @@ describe("Publish Post Controller Unitary Testing", () => {
 			message: "This action is not valid for the post's current status.",
 		});
 	});
+
+	test("Should throw NOT_FOUND when the post does not exist", async () => {
+		await expect(
+			PostRouter.createCaller(adminCtx).publish({ id: "does-not-exist" }),
+		).rejects.toMatchObject({
+			code: "NOT_FOUND",
+			message: "Post not found.",
+		});
+	});
 });

--- a/src/server/features/post/procedures/__test__/reject.ts
+++ b/src/server/features/post/procedures/__test__/reject.ts
@@ -62,4 +62,16 @@ describe("Reject Post Controller Unitary Testing", () => {
 			message: "This action is not valid for the post's current status.",
 		});
 	});
+
+	test("Should throw NOT_FOUND when the post does not exist", async () => {
+		await expect(
+			PostRouter.createCaller(editorCtx).reject({
+				id: "does-not-exist",
+				comment: "Ghost post.",
+			}),
+		).rejects.toMatchObject({
+			code: "NOT_FOUND",
+			message: "Post not found.",
+		});
+	});
 });

--- a/src/server/features/user/domain/__test__/readProfile.ts
+++ b/src/server/features/user/domain/__test__/readProfile.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+import { AppError } from "@/shared/error/appError";
+import { createTestContext } from "@/test/context";
+import { domain_readUserProfile } from "../readProfile";
+
+// The procedure short-circuits when a user reads their own profile, so this
+// domain only runs for "read someone else's profile". It must expose the
+// public fields and nothing sensitive (no password).
+describe("domain_readUserProfile", () => {
+	test("returns the public profile fields for an existing user", async () => {
+		const ctx = createTestContext();
+		const user = await ctx.createNewUser();
+
+		const profile = await domain_readUserProfile({
+			ctx,
+			input: { id: user.id },
+		});
+
+		expect(profile).toEqual({
+			id: user.id,
+			name: user.name,
+			email: user.email,
+			verified: user.verified,
+			role: user.role,
+			createdAt: user.createdAt,
+			updatedAt: user.updatedAt,
+			bio: user.bio,
+		});
+	});
+
+	test("never exposes the password hash", async () => {
+		const ctx = createTestContext();
+		const user = await ctx.createNewUser();
+
+		const profile = await domain_readUserProfile({
+			ctx,
+			input: { id: user.id },
+		});
+
+		expect("password" in profile).toBe(false);
+	});
+
+	test("throws when the user does not exist", async () => {
+		const ctx = createTestContext();
+
+		await expect(
+			domain_readUserProfile({ ctx, input: { id: "missing-user" } }),
+		).rejects.toMatchObject(new AppError("user.not_found"));
+	});
+});

--- a/src/shared/error/__test__/registry.ts
+++ b/src/shared/error/__test__/registry.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { resolveErrorEntry } from "../index";
+import { defineDomainErrors } from "../registry";
 
 // The registry is where the defaults live, not the consumer. If each caller
 // had to write `entry.retryable ?? false`, the boilerplate this feature is
@@ -35,5 +36,21 @@ describe("resolveErrorEntry", () => {
 			retryable: true,
 			level: "warn",
 		});
+	});
+});
+
+// The Set guard is what makes a duplicated `defineDomainErrors("post", ...)`
+// fail loudly at import time instead of silently shadowing a live catalog.
+describe("defineDomainErrors", () => {
+	test("rejects registering the same domain twice", () => {
+		defineDomainErrors("registry_dup_probe", {
+			boom: { message: "First registration." },
+		});
+
+		expect(() =>
+			defineDomainErrors("registry_dup_probe", {
+				boom: { message: "Second registration." },
+			}),
+		).toThrow('domain "registry_dup_probe" already registered');
 	});
 });


### PR DESCRIPTION
## Why

A coverage measurement (v8, not previously wired) showed the backend was already at **~90.5% lines**, not the stale "8.6%" the docs claimed (corrected in #226). The remaining backend gaps were a handful of **uncovered guard branches** — real breakage points, not glue. This PR closes them with regression tests, in the spirit of afm.md § 1.3 ("test the limits where the function can break") and explicitly **not** coverage padding (afm.md § 3.1: "a test that only raises coverage % — delete it").

## What each test locks

| Target | Behavior asserted |
|---|---|
| `post` archive/publish/reject | `NOT_FOUND` when the post id does not exist (the `post.not_found` guard ran before permission/status checks) |
| `ErrorRegistry.defineDomainErrors` | registering the same domain twice throws (prevents a catalog silently shadowing another) |
| `RegexUserAgentClassifier` | Safari on macOS — the untested OS branch |
| `domain_readUserProfile` | the "read **another** user's profile" path (the procedure short-circuits self-view) returns public fields and **never** the password |
| `domain_recordView` | when the view-counter backend throws, it degrades to `{ counted: false }` instead of failing the request |
| `createAuthSession` / `refreshSession` | if the session store returns no record, the domain surfaces a classified `AppError` (`session_create_error`/`session_update_error`) rather than leaking `undefined` |

## Result

- Backend lines coverage **90.5% → 91.2%**, branches **88.8% → 90.3%**.
- **422 tests pass** (was 411), `tsc --noEmit` and `biome check` clean.
- No production code changed — tests only. The ambient append-only ledger (`docs/.afm-log/`) is intentionally left out (rule 18).

> Depends on nothing; independent of #226 (docs). Part of the Phase 9 test-coverage effort (unit → integration → e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)