### PR TITLE
test(026): integration test harness — Testcontainers + real Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # Node 22, not 20 like the other jobs: testcontainers@12 pulls
+          # undici@8 which requires node >=22.19 (it crashes on 20 with
+          # "webidl.util.markAsUncloneable is not a function"). Integration is
+          # test infra, so its runtime need not match prod's Node 20.
+          node-version: 22
           cache: npm
       - run: npm ci
       # Testcontainers boots its own postgres:16 via the runner's Docker daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,16 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      # Testcontainers boots its own postgres:16 via the runner's Docker daemon
+      # (globalSetup applies the migrations); no `services:` block needed.
+      - run: npm run test:integration

--- a/docs/ach.md
+++ b/docs/ach.md
@@ -276,9 +276,11 @@ integrations/**/implementations/* → implements the port; may receive config/en
 | **Integration** | [A DEFINIR — not found in the scan] | — | — |
 | **E2E** | [A DEFINIR — not found in the scan] | — | — |
 
-Current coverage (proxy `tests/src`): 23 test files / 205 `.ts`/`.tsx` files in `src/` (~11.2%). See `afm.md` § 3.1 forward-only.
+Current backend coverage ~90% (measured 2026-08-25, v8: `src/server`+`lib`+`shared` ~90.5% lines, `server/features` domain+procedures 98.9%; 85 test files / 411 tests). Whole-repo ~52% is dragged down by the untested frontend (`src/app`/`src/components` ~0%, deferred with the frontend refactor). See `afm.md` § 3.1 forward-only.
 
 Procedure tests run without Postgres/Redis: vitest mocks the Prisma driver globally (`src/test/setup.ts`) with a **`prisma-mock`** client generated from `schema.prisma` (`src/test/prisma/` — ADR-0011), so production models run intact against an in-memory database with unique constraints enforced; `createTestContext()` injects only the fake gateways (`src/test/gateways/`). Per-test isolation via `resetPrismaMock()` (do not use `$clear()` — see the comment in the seam). The pre-push hook runs `yarn test` directly.
+
+A complementary **integration** suite (`npm run test:integration`, ADR-0026, feature 026) runs the same domain/repository layer against a **real Postgres** via Testcontainers — covering what `prisma-mock` cannot (raw SQL, `to_tsvector`, the real migration set). It reuses the same driver seam (`DATABASE_URL` → the unmodified `src/server/infra/drivers/prisma.ts`, no mock), boots one `postgres:16` container in `src/test/integration/globalSetup.ts` (applies migrations), TRUNCATEs between tests (`setup.ts`), and lives in `*.integration.ts` files outside `__test__/` (own config `vitest.integration.config.ts`, own CI job). `prisma-mock` does correctly fake unique constraints and `mode: "insensitive"`, so the gap it fills is raw-SQL/migration fidelity, not constraints.
 
 ### 4.2 Hard TDD + types-as-test
 

--- a/docs/adr/0026-integration-tests-testcontainers.md
+++ b/docs/adr/0026-integration-tests-testcontainers.md
@@ -1,0 +1,40 @@
+# ADR-0026 — Integration tests against real Postgres via Testcontainers
+
+> **Status:** Accepted and implemented
+> **Date:** 2026-08-26
+> **Decided by:** product owner
+> **Extends:** [ADR-0011](./0011-prisma-mock-para-testes.md) (which anticipated a thin real-database integration layer as a Phase 9/10 item)
+
+## Context
+
+The unit suite runs the domain/procedure/repository layer against `prisma-mock` (ADR-0011) — an in-memory fake with **no SQL engine**. It is fast and covers business logic well (~91% backend, 411 tests), but by construction it cannot validate anything that only a real engine runs: raw SQL (`$queryRaw`), Postgres full-text search (`to_tsvector`/`ts_rank`, deferred in Phase 6 exactly because the mock cannot test it), and whether the real migration set applies cleanly. A broken migration passes every unit test and only fails in production.
+
+An integration test — the domain/repository layer against a **real Postgres** — closes that seam. Following the unit → integration → e2e order (e2e is deferred with the frontend refactor).
+
+Empirical note (2026-08-26): `prisma-mock` *does* correctly fake unique constraints (P2002) and `mode: "insensitive"`, so those are **not** the gap; raw SQL and the migration set are.
+
+## Decision
+
+Adopt **Testcontainers** (`testcontainers` + `@testcontainers/postgresql`, devDependencies) for a **separate** integration suite, kept apart from the fast unit suite:
+
+- **One container per run.** `src/test/integration/globalSetup.ts` starts a `postgres:16` container, applies the real migrations with `prisma migrate deploy` against its connection URI, and exposes that URI via `DATABASE_URL`.
+- **Reuses the existing driver seam.** The unmodified Prisma driver (`src/server/infra/drivers/prisma.ts`) reads `DATABASE_URL`, so models/domains/procedures run **intact** against the container — no separate repository construction. This is the same seam the unit suite mocks (`src/test/setup.ts`), pointed at a real engine instead of the mock.
+- **Real reset between tests.** `src/test/integration/setup.ts` `TRUNCATE`s every table (except `_prisma_migrations`) in `beforeEach` — the integration analogue of `resetPrismaMock`.
+- **Separate config + script.** `vitest.integration.config.ts` (glob `src/**/*.integration.ts`, `pool: forks`, `maxWorkers: 1`, no driver mock); `npm run test:integration`. The plain `npm test` is untouched.
+- **CI job.** A dedicated `integration` job runs `npm run test:integration`; Testcontainers boots its own container via the runner's Docker daemon (no `services:` block).
+
+## Alternatives considered
+
+- **Reuse the CI `services: postgres` for a shared DB** — rejected as the primary mechanism: it works only in CI, so local and CI would diverge; Testcontainers gives one consistent path in both, and manages lifecycle/teardown (Ryuk) itself.
+- **PGlite / in-process Postgres** — rejected: ADR-0011 already recorded PGlite breaks `prisma migrate` (P1017); the point here is to test the *real* migration set.
+- **Transaction-rollback isolation** instead of TRUNCATE — deferred: TRUNCATE is simpler and the suite is small/serial; revisit if the suite grows and speed matters.
+- **Migrate the whole suite to real Postgres** — rejected: the mock stays the default for logic (fast); integration covers only what the mock cannot.
+
+## Consequence
+
+- **Easy now:** raw SQL / migration / real-engine behavior is testable; native full-text search (feature 027) is unblocked — a `to_tsvector`/`plainto_tsquery` smoke already runs green here.
+- **Harder / watch out:**
+  - Needs a **Docker daemon** (local dev and CI). No Docker → the integration suite cannot run; the unit suite is unaffected.
+  - `DATABASE_URL` must reach the worker: the config uses `pool: forks` for that (globalSetup sets it before workers fork).
+  - Integration tests use the `*.integration.ts` suffix and live **outside** `__test__/` so the unit glob never picks them up.
+- **Load-bearing:** rule 30 gains `src/test/integration/` and the `*.integration.ts` files as a data-layer exception (they may import the real `prisma` driver), alongside the `src/test/prisma/` exception from ADR-0011.

--- a/docs/adr/0026-integration-tests-testcontainers.md
+++ b/docs/adr/0026-integration-tests-testcontainers.md
@@ -35,6 +35,7 @@ Adopt **Testcontainers** (`testcontainers` + `@testcontainers/postgresql`, devDe
 - **Easy now:** raw SQL / migration / real-engine behavior is testable; native full-text search (feature 027) is unblocked — a `to_tsvector`/`plainto_tsquery` smoke already runs green here.
 - **Harder / watch out:**
   - Needs a **Docker daemon** (local dev and CI). No Docker → the integration suite cannot run; the unit suite is unaffected.
+  - Needs **Node ≥ 22.19**: `testcontainers@12` pulls `undici@8` (`engines: node >=22.19`), which crashes on Node 20 (`webidl.util.markAsUncloneable is not a function`). The integration CI job runs Node 22; the other jobs stay on Node 20 (prod parity). Run it locally on Node ≥ 22 too.
   - `DATABASE_URL` must reach the worker: the config uses `pool: forks` for that (globalSetup sets it before workers fork).
   - Integration tests use the `*.integration.ts` suffix and live **outside** `__test__/` so the unit glob never picks them up.
 - **Load-bearing:** rule 30 gains `src/test/integration/` and the `*.integration.ts` files as a data-layer exception (they may import the real `prisma` driver), alongside the `src/test/prisma/` exception from ADR-0011.

--- a/docs/features/026-integration-test-harness/plan.md
+++ b/docs/features/026-integration-test-harness/plan.md
@@ -1,0 +1,37 @@
+# Feature 026 — Plan
+
+> **Spec:** [`./spec.md`](./spec.md) · **ADR:** [ADR-0026](../../adr/0026-integration-tests-testcontainers.md)
+
+## 1. Approach
+
+Reuse the **same driver seam** the unit suite mocks. The unit suite `vi.mock`s `@/server/infra/drivers/prisma` with `prisma-mock`; the integration suite instead sets `DATABASE_URL` to a Testcontainers Postgres and lets the **unmodified** driver connect to it. Models/domains/procedures run intact against a real engine. One container per run (globalSetup), TRUNCATE between tests, separate config/script so the fast unit suite is untouched.
+
+## 2. Components
+
+| Component | File | Kind |
+| --- | --- | --- |
+| Container boot + migrate | `src/test/integration/globalSetup.ts` | test infra |
+| Per-test reset | `src/test/integration/setup.ts` | test infra |
+| Integration Vitest config | `vitest.integration.config.ts` | config |
+| First integration tests | `src/server/features/post/__itest__/post.integration.ts` | test |
+| Script + devDeps | `package.json` (`test:integration`, `testcontainers`, `@testcontainers/postgresql`) | config |
+| CI job | `.github/workflows/ci.yml` (`integration`) | CI |
+
+## 3. Key decisions
+
+- **`pool: forks` + `maxWorkers: 1`** — forks so `DATABASE_URL` set in globalSetup reaches the worker; single serial worker so tests share the one container without racing on TRUNCATE. (`poolOptions.forks.singleFork` is not in Vitest 4's type; `maxWorkers: 1` is the type-valid equivalent already used by the unit config.)
+- **TRUNCATE reset** (not transaction-rollback) — simplest for a small serial suite; revisit if it grows.
+- **`postgres:16`** — matches the CI `build` job's Postgres service.
+- **`*.integration.ts` outside `__test__/`** — keeps them off the unit glob (`src/**/__test__/**/*.ts`) while the integration glob (`src/**/*.integration.ts`) picks them up.
+- **CI: Testcontainers boots its own container** (no `services:` block) — one consistent path local and CI.
+
+## 4. Boundary contracts
+
+- `globalSetup` sets `process.env.DATABASE_URL` → the driver's `env.databaseUrl` reads it at import in the worker.
+- Integration tests may import the real `prisma` driver for raw assertions — a data-layer exception to rule 30 (like `src/test/prisma/`), recorded in ADR-0026.
+
+## 5. Validation against afm.md § 3
+
+- Rule 30 (domain/procedure ≠ PrismaClient): intact — the real client lives in the driver + test infra; domains still use `ctx.repositories`. The `__itest__` file is neither domain nor procedure.
+- Rule 6 (≤300 lines), Rule 2 (no any/unknown): all harness files small and typed.
+- Rule 1 (test for new code): the harness's value is proven by the integration tests it runs (green against real Postgres).

--- a/docs/features/026-integration-test-harness/spec.md
+++ b/docs/features/026-integration-test-harness/spec.md
@@ -1,0 +1,35 @@
+# Feature 026 — Integration test harness (Testcontainers + Postgres)
+
+> **Spec:** the what and the why. Technology decision in [ADR-0026](../../adr/0026-integration-tests-testcontainers.md).
+> **Related:** Roadmap Phase 9 (integration tests) — unblocks Phase 6 (native full-text search, feature 027).
+> **Status:** done
+> **Opened:** 2026-08-26
+
+## 1. Problem (from the roadmap)
+
+Phase 9 lists integration tests as a gap. The unit suite runs against `prisma-mock` (ADR-0011), which has no SQL engine — so raw SQL (`$queryRaw`), Postgres full-text search (`to_tsvector`/`ts_rank`), and whether the real migration set applies are all untested. A broken migration passes all 411 unit tests and only fails in production. Native full-text search (Phase 6) stayed deferred precisely because the mock cannot test it.
+
+## 2. Scope
+
+**In:**
+- A **separate** integration suite (own config + `npm run test:integration`) that boots a real `postgres:16` via Testcontainers, applies the real migrations, and runs the domain/repository layer against it — reusing the existing driver seam (no separate repository construction).
+- First integration tests on `post`: round-trip persistence, the real search query against real SQL, raw `$queryRaw`, and a `to_tsvector`/`plainto_tsquery` smoke that proves feature 027 is unblocked.
+- A CI `integration` job.
+
+**Out (explicit):**
+- Native `tsvector` search rewrite → **feature 027** (this harness unblocks it).
+- E2E tests → deferred with the frontend refactor.
+- Migrating the unit suite to real Postgres → the mock stays the default for logic.
+- A coverage gate → rejected by the owner (coverage is a metric, not a goal).
+
+## 3. Acceptance criteria
+
+- `npm run test:integration` boots a real Postgres, applies migrations, runs green, and tears the container down.
+- `npm test` (unit, prisma-mock) is unchanged and still green (85 files / 411 tests) — the `*.integration.ts` files are never picked up by the unit glob.
+- The suite proves at least one thing the mock cannot: raw SQL runs, and `to_tsvector`/`plainto_tsquery` are available on the real engine.
+- CI runs the integration job on every PR/push.
+- `tsc --noEmit` and `biome check` clean.
+
+## 4. Notes
+
+- Discovery correction (2026-08-26): the plan assumed `prisma-mock` could not enforce unique constraints or `mode: "insensitive"`. Empirically it does both correctly — so the genuine gap is **raw SQL / migrations**, and the tests target that instead. ADR-0011's claim ("unique constraints enforced, P2002") was right.

--- a/docs/features/026-integration-test-harness/tasks.md
+++ b/docs/features/026-integration-test-harness/tasks.md
@@ -1,0 +1,28 @@
+# Feature 026 — Tasks
+
+> **Spec:** [`./spec.md`](./spec.md) · **Plan:** [`./plan.md`](./plan.md)
+> `[P]` = parallelizable. Each task is a § 2 cycle. Refs Phase 9 (integration tests).
+
+## Setup
+
+- [X] **T001** `package.json` — add devDeps `testcontainers` + `@testcontainers/postgresql` (`^12.1.0`) and script `test:integration`; regenerate `package-lock.json` with Node 20 (avoid the npm-version lock divergence).
+
+## Foundation — the harness (`src/test/integration/`)
+
+- [X] **T002** `src/test/integration/globalSetup.ts` — start a `postgres:16` container, `getConnectionUri()` → `DATABASE_URL`, run `prisma migrate deploy` against it; `teardown` stops the container.
+- [X] **T003** `src/test/integration/setup.ts` — `beforeEach` TRUNCATE all tables except `_prisma_migrations` (real reset); `afterAll` `$disconnect`.
+- [X] **T004** `vitest.integration.config.ts` — glob `src/**/*.integration.ts`, `globalSetup` + `setupFiles`, `pool: forks`, `maxWorkers: 1`, no driver mock, generous timeouts.
+
+## Boundary — the first tests
+
+- [X] **T005** `src/server/features/post/__itest__/post.integration.ts` — round-trip persistence, the real `post.search` against real SQL, a raw `$queryRaw` count, and a `to_tsvector`/`plainto_tsquery` smoke (proves 027 is unblocked). RED→GREEN against the real container.
+- [X] **T006** Verify the unit suite is untouched (`npm test` → 85 files / 411 tests green; the `.integration.ts` file is not picked up by the unit glob).
+
+## CI
+
+- [X] **T007** `.github/workflows/ci.yml` — add the `integration` job (Node 20, `npm ci`, `npm run test:integration`; Testcontainers uses the runner's Docker).
+
+## Reconciliation (§ 8.5)
+
+- [X] **T008** ADR-0026 (extends ADR-0011); this feature folder (spec/plan/tasks).
+- [X] **T009** Update `roadmap.md` Phase 9 (integration tests → done) + note Phase 6 native search unblocked; `ach.md` (integration harness component); `ust.md` status. Correct `resumo-25` (mock does fake unique/insensitive).

--- a/docs/learn/resumo-25-unit-integracao-e2e.html
+++ b/docs/learn/resumo-25-unit-integracao-e2e.html
@@ -1,0 +1,264 @@
+<!doctype html>
+<!-- learn · template de output (web components). Vocabulário e fluxo de geração: ver SKILL.md do plugin learn. -->
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Unit vs Integração vs E2E — o modelo mental (resumo)</title>
+<style>
+  body{margin:0;background:#0d1117;color:#e6edf3;
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased}
+  l-doc{display:block;max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  l-head{display:block;border-bottom:1px solid #2b3340;padding-bottom:24px;margin-bottom:32px}
+  l-sec,l-steps,l-tldr,l-fig{display:block}
+  l-fig{margin:22px 0}
+  l-apply{display:block;background:linear-gradient(180deg,#16221b,#13191c);
+    border:1px solid #2b6e3a;border-left:5px solid #3fb950;border-radius:10px;padding:4px 22px 16px;margin:22px 0}
+  l-note{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #f0883e;
+    border-radius:8px;padding:10px 16px;margin:18px 0}
+  l-note[kind=info]{border-left-color:#58a6ff}
+  l-card{display:block;background:#161b22;border:1px solid #2b3340;border-left:4px solid #a371f7;
+    border-radius:8px;padding:8px 16px 4px;margin:14px 0}
+  l-data{display:grid;grid-template-columns:max-content 1fr;margin:14px 0;
+    border:1px solid #2b3340;border-radius:8px;overflow:hidden}
+  l-row{display:contents}
+  /* conteúdo de autoria (light DOM) */
+  p{margin:0 0 14px}
+  ul,ol{margin:0 0 14px;padding-left:22px}
+  li{margin:0 0 9px}
+  strong{color:#fff}
+  a{color:#58a6ff}
+  code{background:#1c2330;border:1px solid #2b3340;border-radius:5px;padding:1px 6px;
+    font:13px/1.5 ui-monospace,"SFMono-Regular",Consolas,monospace;color:#ffa657}
+  table{width:100%;border-collapse:collapse;margin:8px 0 18px;font-size:14px}
+  th,td{padding:8px 11px;text-align:left;border-bottom:1px solid #2b3340}
+  th{background:#1c2330;color:#58a6ff;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.num,th.num,.num{color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+  td.num,th.num{text-align:right}
+</style>
+<script>
+  const CSS = `:host{display:block}
+    a{color:#58a6ff;text-decoration:none} a:hover{text-decoration:underline}
+    h1{font-size:28px;line-height:1.25;margin:0 0 12px}
+    .b{display:inline-block;background:linear-gradient(90deg,#58a6ff,#7ee787);color:#0d1117;font-weight:800;font-size:12px;letter-spacing:.06em;text-transform:uppercase;padding:5px 11px;border-radius:999px;margin-bottom:14px}
+    .au{color:#9aa7b4;font-size:14px;margin:0 0 8px}
+    .me{color:#9aa7b4;font-size:13px;margin:0}
+    h2.s{font-size:21px;margin:40px 0 12px;padding-bottom:8px;border-bottom:1px solid #2b3340}
+    h2.s i{font-style:normal;color:#58a6ff;font-variant-numeric:tabular-nums;margin-right:8px}
+    h2.a{font-size:20px;margin:10px 0 8px;color:#7ee787}
+    b.nt{display:block;color:#fff;margin:0 0 6px}
+    ol{margin:0;padding-left:20px} ul.td{list-style:none;margin:0;padding:0}
+    figure{margin:0;background:#161b22;border:1px solid #2b3340;border-radius:10px;padding:12px}
+    img{display:block;max-width:100%;border-radius:6px;margin:0 auto}
+    figcaption{color:#9aa7b4;font-size:13px;margin-top:8px}
+    .k{padding:8px 12px;border-bottom:1px solid #2b3340;color:#cbd5e1}
+    .v{padding:8px 12px;border-bottom:1px solid #2b3340;text-align:right;color:#ffd866;font-weight:700;font-variant-numeric:tabular-nums}
+    .q{color:#fff;font-weight:600;margin:0}
+    summary{cursor:pointer;color:#58a6ff;font-size:13px;margin-top:4px;list-style:none}
+    .ans{margin:8px 0 0}
+    .cite{color:#9aa7b4;font-size:12px;margin:6px 0 0}`;
+  const esc = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  const def = (tag, render) => customElements.define(tag, class extends HTMLElement{
+    connectedCallback(){
+      if(this._r) return; this._r = 1;
+      const a = n => this.getAttribute(n) || '';
+      this.attachShadow({mode:'open'}).innerHTML = '<style>'+CSS+'</style>' + render(a);
+    }
+  });
+  def('l-head', a => (a('badge')?`<span class="b">${esc(a('badge'))}</span>`:'')
+    + `<h1>${esc(a('title'))}</h1>`
+    + (a('authors')?`<p class="au">${esc(a('authors'))}</p>`:'')
+    + (a('src')?`<p class="me">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src'))}</a>`:esc(a('src'))}</p>`:''));
+  def('l-sec',  a => `<h2 class="s"><i>${esc(a('n'))}</i>${esc(a('title'))}</h2><slot></slot>`);
+  def('l-apply',a => `<h2 class="a">\u{1F3AF} ${esc(a('title')||'Aplicar no contexto')}</h2><slot></slot>`);
+  def('l-note', a => `<b class="nt">${esc(a('title')||'Cuidado')}</b><slot></slot>`);
+  def('l-steps',() => `<ol><slot></slot></ol>`);
+  def('l-tldr', () => `<ul class="td"><slot></slot></ul>`);
+  def('l-data', () => `<slot></slot>`);
+  def('l-row',  a => `<span class="k">${esc(a('k'))}</span><span class="v">${esc(a('v'))}</span>`);
+  def('l-fig',  a => `<figure><img src="${esc(a('src'))}" loading="lazy" alt="${esc(a('cap'))}">`
+    + ((a('cap')||a('href'))?`<figcaption>${esc(a('cap'))} ${a('href')?`<a href="${esc(a('href'))}">fonte</a>`:''}</figcaption>`:'')
+    + `</figure>`);
+  def('l-card', a => `<p class="q">${esc(a('q'))}</p>`
+    + `<details><summary>Mostrar resposta</summary><div class="ans"><slot></slot></div>`
+    + ((a('src')||a('href'))?`<p class="cite">${a('href')?`<a href="${esc(a('href'))}">${esc(a('src')||'fonte')}</a>`:esc(a('src'))}</p>`:'')
+    + `</details>`);
+</script>
+</head>
+<body>
+<l-doc>
+<l-head
+  badge="Testes"
+  title="Unit vs Integração vs E2E — o modelo mental"
+  authors="Síntese de 5 fontes (2010–2020): M. Fowler, H. Vocke, K. C. Dodds, Software Engineering at Google"
+  src="martinfowler.com · kentcdodds.com · abseil.io/resources/swe-book"
+  href="https://martinfowler.com/articles/practical-test-pyramid.html"></l-head>
+
+<l-note kind="info" title="Método">
+  <p>Comparação conceitual + Q&amp;A de discriminação. O objetivo aqui não é decorar
+  definições — é você <strong>situar cada camada no espaço de design</strong> e nunca mais
+  confundir integração com e2e. Tudo abaixo é ancorado nas fontes citadas; onde uma fonte não
+  afirma algo, está marcado.</p>
+</l-note>
+
+<l-sec n="1" title="A resposta direta à sua pergunta">
+  <p>Você vê integração como "um e2e menos completo". A confusão some quando você troca o eixo:
+  <strong>a diferença não é "quão completo", é o que cada teste valida e até onde ele vai.</strong></p>
+  <ul>
+    <li><strong>Unit</strong> — a <strong>lógica de uma unidade</strong>, isolada. É o que você já entende.</li>
+    <li><strong>Integração</strong> — a <strong>costura entre o seu código e UMA dependência externa real</strong>
+      (o banco, sobretudo). Uma <strong>fatia</strong> do sistema, não o todo, e <strong>não pela UI</strong>.</li>
+    <li><strong>E2E</strong> — o <strong>sistema inteiro pelo ponto de entrada real</strong> (browser/HTTP),
+      como um usuário faria.</li>
+  </ul>
+  <p>Integração e e2e diferem em <strong>escopo</strong> (uma junção vs. o sistema todo), não em completude.
+  Um teste de integração pode ser tão pequeno em escopo quanto um unit — só que toca algo real.</p>
+  <p>A moldura é a <strong>pirâmide de testes</strong> (Fowler/Vocke), com duas regras: <em>"write tests with
+  different granularity"</em> e <em>"the more high-level you get the fewer tests you should have"</em>. Em uma
+  frase: <em>"Write lots of small and fast unit tests. Write some more coarse-grained tests and very few
+  high-level tests that test your application from end to end."</em></p>
+</l-sec>
+
+<l-sec n="2" title="As três camadas, definidas pelas fontes">
+  <p><strong>Unit.</strong> O que é uma "unidade"? Fowler: em linguagem funcional, <em>"a unit will most likely
+  be a single function"</em>; em OO, <em>"a unit can range from a single method to an entire class"</em>.
+  Duas variantes (termos cunhados por <strong>Jay Fields</strong>): <strong>solitary</strong> (troca todos os
+  colaboradores por test doubles, isolamento total) e <strong>sociable</strong> (usa colaboradores reais,
+  só stubando as partes lentas como banco/rede). Detalhe honesto: "unit" é mal-definido — Fowler cita um
+  especialista que <em>"cobre 24 definições diferentes de unit test"</em> num treino. Dodds resume:
+  <em>"Verify that individual, isolated parts work as expected."</em></p>
+
+  <p><strong>Integração.</strong> Dodds: <em>"Verify that several units work together in harmony."</em>
+  Aqui mora o nó que te confunde — Fowler diz que há <em>"(at least) two different notions of what
+  constitutes an integration test"</em>:</p>
+  <ul>
+    <li><strong>Narrow integration test</strong> — <em>"exercise only that portion of the code in my service
+      that talks to a separate service"</em>, usa test doubles, e é <em>"often no larger in scope than a unit
+      test"</em>. O exemplo de banco é literal: <em>"start a database, connect your application to the database,
+      trigger a function within your code that writes data to the database, check that the expected data has
+      been written."</em></li>
+    <li><strong>Broad integration test</strong> — <em>"require live versions of all services... exercise code
+      paths through all services, not just code responsible for interactions."</em> E o ponto que fecha a sua
+      dúvida, nas palavras do Fowler: <em>"If I talk about broad integration tests, I prefer to use 'system
+      test' or 'end-to-end test.'"</em></li>
+  </ul>
+  <p>Ou seja: o "e2e menos completo" que você imagina é, na verdade, o <strong>narrow</strong>. O broad
+  <strong>é</strong> e2e — o próprio Fowler prefere não chamar de integração.</p>
+
+  <p><strong>E2E.</strong> Dodds: <em>"A helper robot that behaves like a user to click around the app and
+  verify that it functions correctly."</em> Por que poucos? Fowler/Vocke: e2e são <em>"notoriously flaky and
+  often fail for unexpected and unforeseeable reasons"</em>, exigem muita manutenção e rodam devagar — daí
+  <em>"you should aim to reduce the number of end-to-end tests to a bare minimum"</em>.</p>
+</l-sec>
+
+<l-sec n="3" title="A lente do Google: tamanho, não escopo">
+  <p><strong>Software Engineering at Google</strong> (cap. 11) evita os nomes ambíguos e classifica por
+  <strong>tamanho</strong>, porque <em>"the most important qualities we want from our test suite are speed and
+  determinism, regardless of the scope of the test."</em></p>
+  <ul>
+    <li><strong>Small</strong> — <em>"must run in a single process"</em>; sem I/O, rede, disco ou sleep. (≈ unit)</li>
+    <li><strong>Medium</strong> — <em>"can span multiple processes, use threads, and can make blocking calls,
+      including network calls, to <code>localhost</code>"</em>, mas <em>"aren't allowed to make network calls to
+      any system other than localhost"</em>. (≈ integração — inclui um <strong>banco local</strong>)</li>
+    <li><strong>Large</strong> — <em>"remove the localhost restriction... allowing the test and the system being
+      tested to span across multiple machines."</em> (≈ e2e/sistema)</li>
+  </ul>
+  <p>É essa definição que dissolve de vez a sua dúvida: <strong>um teste de integração ≈ um Medium test = o seu
+  código + uma dependência real em <code>localhost</code></strong> (ex.: um container Postgres). O Google mira a
+  proporção <em>"80% narrow-scoped unit tests, 15% medium-scoped integration tests, 5% end-to-end tests"</em>.</p>
+</l-sec>
+
+<l-sec n="4" title="Quadro comparativo">
+  <table>
+    <thead>
+      <tr><th>Camada</th><th>O que valida</th><th>Até onde vai</th><th>Deps reais?</th><th>Quantidade</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Unit</strong></td><td>lógica de uma unidade</td><td>uma função/classe, isolada</td><td>não (doubles)</td><td>muitos</td></tr>
+      <tr><td><strong>Integração (narrow)</strong></td><td>a costura código ↔ 1 dependência</td><td>uma fatia (ex.: repo + banco)</td><td>sim, 1 (o banco)</td><td>alguns</td></tr>
+      <tr><td><strong>E2E (= broad)</strong></td><td>uma jornada do usuário</td><td>o sistema todo, pelo entrypoint real</td><td>sim, todas</td><td>pouquíssimos</td></tr>
+    </tbody>
+  </table>
+  <p class="me" style="color:#9aa7b4;font-size:13px">Escopo e "deps reais" são de Fowler (narrow/broad) e do Google
+  (small/medium/large); a coluna "quantidade" reflete a forma da pirâmide (Fowler/Vocke).</p>
+</l-sec>
+
+<l-apply title="Aplicar no bearboo">
+  <p><strong>Onde você está hoje.</strong> O suite roda a camada domain/procedure contra <code>prisma-mock</code>
+  (ADR-0011) — um <strong>fake JS sem engine SQL</strong>. Traduzindo pro vocabulário acima: os seus ~91% de
+  cobertura backend são testes <strong>small/solitary</strong> — validam a <strong>lógica</strong>, mas o mock
+  <strong>não é Postgres</strong>.</p>
+  <p><strong>O buraco exato.</strong> Tudo que depende de <strong>semântica SQL real</strong> está sem teste,
+  porque o mock não tem parser SQL — ele "mente":</p>
+  <ul>
+    <li>full-text search nativo (<code>to_tsvector</code>/<code>ts_rank</code>) — o item adiado da Fase 6;</li>
+    <li><code>$queryRaw</code> e qualquer query crua (o mock não tem parser SQL);</li>
+    <li>se as <strong>migrations</strong> aplicam limpo num Postgres real (o mock nunca migra).</li>
+  </ul>
+  <p><strong>O que é integração aqui.</strong> É o <em>narrow integration test</em> do Fowler / <em>Medium test</em>
+  do Google: subir um <strong>Postgres real</strong> (a CI já sobe um serviço <code>postgres:16</code> no job
+  <code>build</code>), conectar o <strong>repositório/domain</strong> nele, exercer a query e checar o resultado.
+  <strong>Não passa pelo browser, não sobe o app inteiro</strong> — é uma fatia <code>código ↔ Postgres</code>.
+  Por isso <strong>não é "um e2e menor"</strong>: é a validação dirigida de uma costura que o mock não alcança.</p>
+  <p><strong>Por que essa ordem (unit → integração → e2e).</strong> O e2e (o "robô-usuário" clicando no app
+  inteiro) vem por último e está <strong>adiado com o refactor de frontend</strong> — tocá-lo agora testaria uma
+  UI que vai ser reescrita. A integração é o próximo degrau porque fecha o buraco do <code>prisma-mock</code>
+  e <strong>desbloqueia o full-text nativo</strong> que a Fase 6 deixou pendente (o ADR-0011 já anteviu isto
+  como item de Fase 9/10).</p>
+</l-apply>
+
+<l-note kind="warn" title="Cuidados">
+  <ul>
+    <li>"Integração" é palavra <strong>ambígua</strong> (Fowler). Quando alguém disser, pergunte:
+      <strong>narrow ou broad?</strong> No bearboo queremos narrow (código + Postgres), não broad (= e2e).</li>
+    <li>O inverso também pega: um unit <strong>sociable</strong> que fala com o banco real <strong>já é</strong>,
+      na prática, um teste de integração (mais lento, menos determinístico) — o Google o classificaria como
+      <strong>Medium</strong>, não Small.</li>
+    <li>Não persiga a forma da pirâmide por si só. O critério útil é <strong>"o que o mock não consegue
+      testar"</strong> — coerente com a decisão que já tomamos (coverage é métrica, não meta).</li>
+  </ul>
+</l-note>
+
+<l-sec n="5" title="TL;DR">
+  <l-tldr>
+    <li><strong>Unit</strong>: a lógica de uma unidade, isolada, rápida — muitos.</li>
+    <li><strong>Integração (narrow)</strong>: seu código + <strong>uma</strong> dependência real (o banco),
+      uma fatia — não o app todo, não pela UI.</li>
+    <li><strong>E2E (= broad integration)</strong>: o sistema inteiro pelo entrypoint real, como um usuário —
+      poucos, lentos, frágeis.</li>
+    <li>Integração vs e2e = <strong>escopo</strong> (uma costura vs. o sistema todo), não "quão completo".</li>
+    <li>No bearboo: integração = <strong>repositório/domain contra Postgres real</strong>, pra testar o SQL que
+      o <code>prisma-mock</code> não consegue.</li>
+  </l-tldr>
+</l-sec>
+
+<l-sec n="6" title="Recall">
+  <l-card q="Em uma frase: o que um teste de integração valida que um unit não valida?"
+    src="Fowler — Practical Test Pyramid" href="https://martinfowler.com/articles/practical-test-pyramid.html">
+    A costura com uma dependência externa real (o banco).</l-card>
+  <l-card q="Integração vs e2e — a diferença é 'quão completo'?"
+    src="Fowler — IntegrationTest" href="https://martinfowler.com/bliki/IntegrationTest.html">
+    Não: é escopo — uma fatia vs. o sistema todo.</l-card>
+  <l-card q="Como Fowler chama o teste que sobe todos os serviços vivos?"
+    src="Fowler — IntegrationTest" href="https://martinfowler.com/bliki/IntegrationTest.html">
+    Broad integration = system/end-to-end test.</l-card>
+  <l-card q="No modelo do Google, um teste que fala só com localhost + banco é de que tamanho?"
+    src="Software Engineering at Google, cap. 11" href="https://abseil.io/resources/swe-book/html/ch11.html">
+    Medium.</l-card>
+  <l-card q="Quem cunhou os termos 'solitary' e 'sociable'?"
+    src="Fowler — UnitTest" href="https://martinfowler.com/bliki/UnitTest.html">
+    Jay Fields.</l-card>
+  <l-card q="Por que o prisma-mock não cobre o full-text search do Postgres?"
+    src="bearboo — ADR-0011">
+    É um fake JS sem engine SQL.</l-card>
+  <l-card q="Proporção de testes que o SE@Google mira?"
+    src="Software Engineering at Google, cap. 11" href="https://abseil.io/resources/swe-book/html/ch11.html">
+    ~80% unit / 15% integração / 5% e2e.</l-card>
+  <l-card q="No bearboo, um teste de integração passa pelo browser?"
+    src="síntese — narrow integration">
+    Não: é a fatia repositório/domain ↔ Postgres.</l-card>
+</l-sec>
+</l-doc>
+</body>
+</html>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -520,7 +520,7 @@ Add practices companies expect from a serious project.
 * [~] empty states — confirmed in `src/components/postFeed.tsx` ("No posts found."), not audited across all components;
 * [x] validation with Zod (`src/server/schema/*.schema.ts`);
 * [x] unit tests (18 `vitest` files — coverage ~8.6%, see `docs/afm.md` § 3.1);
-* [ ] integration tests;
+* [x] integration tests — harness via Testcontainers + real Postgres (`docs/features/026-integration-test-harness/`, ADR-0026): boots `postgres:16`, applies the real migrations, runs the domain/repository layer against a real engine (raw SQL / `to_tsvector` — what `prisma-mock` cannot). Unblocks native full-text search (Phase 6, feature 027);
 * [ ] basic e2e tests;
 * [x] development seed (`prisma/seed.ts` — 3 users, posts, comments, verify/reset tokens);
 * [x] organized migrations (`prisma/migrations/`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
 				"@react-types/shared": "3.25.0",
 				"@tailwindcss/postcss": "^4.1.11",
 				"@tailwindcss/typography": "^0.5.16",
+				"@testcontainers/postgresql": "^12.1.0",
 				"@types/bcrypt": "^5.0.2",
 				"@types/node": "^20.19.0",
 				"@types/nodemailer": "^6.4.17",
@@ -69,6 +70,7 @@
 				"prisma-mock": "^1.1.0",
 				"tailwind-variants": "0.1.20",
 				"tailwindcss": "^4.1.11",
+				"testcontainers": "^12.1.0",
 				"typescript": "^5.8.3",
 				"vite": "^8.1.3",
 				"vitest": "^4.1.9"
@@ -638,6 +640,13 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@balena/dockerignore": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+			"integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/@bcoe/v8-coverage": {
 			"version": "0.2.3",
@@ -1609,6 +1618,324 @@
 				"tslib": "2"
 			}
 		},
+		"node_modules/@grpc/grpc-js": {
+			"version": "1.14.4",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+			"integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@grpc/proto-loader": "^0.8.0",
+				"@js-sdsl/ordered-map": "^4.4.2"
+			},
+			"engines": {
+				"node": ">=12.10.0"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+			"integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lodash.camelcase": "^4.3.0",
+				"long": "^5.0.0",
+				"protobufjs": "^7.5.5",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@grpc/grpc-js/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/yargs": {
+			"version": "17.7.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@grpc/proto-loader": {
+			"version": "0.7.15",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+			"integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lodash.camelcase": "^4.3.0",
+				"long": "^5.0.0",
+				"protobufjs": "^7.2.5",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@grpc/proto-loader/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@grpc/proto-loader/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@grpc/proto-loader/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@grpc/proto-loader/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@grpc/proto-loader/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@grpc/proto-loader/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@grpc/proto-loader/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@grpc/proto-loader/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@grpc/proto-loader/node_modules/yargs": {
+			"version": "17.7.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@hookform/resolvers": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
@@ -2092,6 +2419,67 @@
 			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-2.0.0.tgz",
 			"integrity": "sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==",
 			"license": "MIT"
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -2793,6 +3181,27 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@js-sdsl/ordered-map": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+			"integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/js-sdsl"
+			}
+		},
+		"node_modules/@kwsites/file-exists": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1"
+			}
+		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -2956,6 +3365,17 @@
 				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@prisma/client": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.5.0.tgz",
@@ -3076,6 +3496,72 @@
 			"dependencies": {
 				"@prisma/debug": "6.5.0"
 			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@radix-ui/primitive": {
 			"version": "1.1.4",
@@ -4467,6 +4953,16 @@
 				"react": "^18 || ^19"
 			}
 		},
+		"node_modules/@testcontainers/postgresql": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-12.1.0.tgz",
+			"integrity": "sha512-Pjf2VSVNirEPfz36nidyrVAnZvc2YhajOznY4VgyEsvfTd5qiMNOuPq96drREvxAUtXl5SFLX7vXj7sSq4aTcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"testcontainers": "^12.1.0"
+			}
+		},
 		"node_modules/@trpc/client": {
 			"version": "11.18.0",
 			"resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.18.0.tgz",
@@ -4641,6 +5137,29 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/docker-modem": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+			"integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/ssh2": "*"
+			}
+		},
+		"node_modules/@types/dockerode": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+			"integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/docker-modem": "*",
+				"@types/node": "*",
+				"@types/ssh2": "*"
+			}
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -4772,6 +5291,43 @@
 			"dependencies": {
 				"@types/react": "*"
 			}
+		},
+		"node_modules/@types/ssh2": {
+			"version": "1.15.5",
+			"resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+			"integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^18.11.18"
+			}
+		},
+		"node_modules/@types/ssh2-streams": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+			"integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/ssh2/node_modules/@types/node": {
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@types/ssh2/node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
@@ -4996,6 +5552,19 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "8.20.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -5070,6 +5639,105 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/archiver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+			"integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"archiver-utils": "^5.0.2",
+				"async": "^3.2.4",
+				"buffer-crc32": "^1.0.0",
+				"readable-stream": "^4.0.0",
+				"readdir-glob": "^1.1.2",
+				"tar-stream": "^3.0.0",
+				"zip-stream": "^6.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/archiver-utils": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+			"integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"glob": "^10.0.0",
+				"graceful-fs": "^4.2.0",
+				"is-stream": "^2.0.1",
+				"lazystream": "^1.0.0",
+				"lodash": "^4.17.15",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/brace-expansion": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5089,6 +5757,16 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5098,6 +5776,20 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/babel-jest": {
 			"version": "29.7.0",
@@ -5282,8 +5974,128 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
+		},
+		"node_modules/bare-events": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.2.tgz",
+			"integrity": "sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"bare-abort-controller": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-fs": {
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.1.tgz",
+			"integrity": "sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.5.4",
+				"bare-path": "^3.0.0",
+				"bare-stream": "^2.6.4",
+				"bare-url": "^2.2.2",
+				"fast-fifo": "^1.3.2"
+			},
+			"engines": {
+				"bare": ">=1.28.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-path": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+			"integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/bare-stream": {
+			"version": "2.13.4",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.4.tgz",
+			"integrity": "sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.8.1",
+				"streamx": "^2.25.0",
+				"teex": "^1.0.1"
+			},
+			"peerDependencies": {
+				"bare-abort-controller": "*",
+				"bare-buffer": "*",
+				"bare-events": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				},
+				"bare-buffer": {
+					"optional": true
+				},
+				"bare-events": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-stream/node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-url": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
+			"integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-path": "^3.0.0"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.10.42",
@@ -5319,6 +6131,68 @@
 			},
 			"engines": {
 				"node": ">= 18"
+			}
+		},
+		"node_modules/bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
+		"node_modules/bl/node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/bl/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/boolbase": {
@@ -5398,6 +6272,41 @@
 				"node-int64": "^0.4.0"
 			}
 		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5405,6 +6314,26 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/buildcheck": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+			"integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/byline": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+			"integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
@@ -5530,6 +6459,13 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/ci-info": {
 			"version": "3.9.0",
@@ -5666,7 +6602,6 @@
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -5679,8 +6614,7 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/colorette": {
 			"version": "2.0.20",
@@ -5707,6 +6641,36 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/compress-commons": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+			"integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"crc-32": "^1.2.0",
+				"crc32-stream": "^6.0.0",
+				"is-stream": "^2.0.1",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/compress-commons/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/concat-map": {
@@ -5782,6 +6746,13 @@
 				"url": "https://github.com/sponsors/mesqueeb"
 			}
 		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cosmiconfig": {
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
@@ -5835,6 +6806,48 @@
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/cpu-features": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+			"integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"buildcheck": "~0.0.6",
+				"nan": "^2.19.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"crc32": "bin/crc32.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/crc32-stream": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+			"integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"crc-32": "^1.2.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/create-jest": {
@@ -6147,6 +7160,113 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/docker-compose": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.4.2.tgz",
+			"integrity": "sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yaml": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/docker-modem": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+			"integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"readable-stream": "^3.5.0",
+				"split-ca": "^1.0.1",
+				"ssh2": "^1.15.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
+		},
+		"node_modules/docker-modem/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/dockerode": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.1.tgz",
+			"integrity": "sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@balena/dockerignore": "^1.0.2",
+				"@grpc/grpc-js": "^1.11.1",
+				"@grpc/proto-loader": "^0.7.13",
+				"docker-modem": "^5.0.7",
+				"protobufjs": "^7.3.2",
+				"tar-fs": "^2.1.4"
+			},
+			"engines": {
+				"node": ">= 14.17"
+			}
+		},
+		"node_modules/dockerode/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/dockerode/node_modules/tar-fs": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+			"integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/dockerode/node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/dotenv": {
 			"version": "17.4.2",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -6158,6 +7278,13 @@
 			"funding": {
 				"url": "https://dotenvx.com"
 			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.389",
@@ -6187,6 +7314,16 @@
 			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
 		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.21.6",
@@ -6386,12 +7523,42 @@
 				"@types/estree": "^1.0.0"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/eventemitter3": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
 			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
+		"node_modules/events-universal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.7.0"
+			}
 		},
 		"node_modules/execa": {
 			"version": "8.0.1",
@@ -6468,6 +7635,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6532,6 +7706,23 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/framer-motion": {
 			"version": "11.13.1",
 			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.13.1.tgz",
@@ -6558,6 +7749,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
@@ -6644,6 +7842,19 @@
 			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/get-port": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+			"integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-stream": {
@@ -7150,6 +8361,27 @@
 				"url": "https://github.com/sponsors/typicode"
 			}
 		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/import-fresh": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7227,8 +8459,7 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/ini": {
 			"version": "6.0.0",
@@ -7418,6 +8649,13 @@
 				"url": "https://github.com/sponsors/mesqueeb"
 			}
 		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -7499,6 +8737,22 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
 		"node_modules/jest": {
@@ -8941,6 +10195,52 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/lazystream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+			"integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^2.0.5"
+			},
+			"engines": {
+				"node": ">= 0.6.3"
+			}
+		},
+		"node_modules/lazystream/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/lazystream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lazystream/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -9293,6 +10593,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/lodash": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/log-update": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -9345,6 +10659,13 @@
 			"funding": {
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/longest-streak": {
 			"version": "3.1.0",
@@ -10343,6 +11664,39 @@
 				"node": "*"
 			}
 		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "dist/cjs/src/bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/motion-dom": {
 			"version": "11.18.1",
 			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
@@ -10363,6 +11717,14 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
+		},
+		"node_modules/nan": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+			"integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.15",
@@ -10507,7 +11869,6 @@
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10573,7 +11934,6 @@
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -10652,6 +12012,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
@@ -10767,6 +12134,30 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
@@ -10965,6 +12356,23 @@
 				"@prisma/client": "^3.5.0 || ^4.7.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/prompts": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -10980,6 +12388,43 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/proper-lockfile/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/properties-reader": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+			"integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@kwsites/file-exists": "^1.1.1",
+				"mkdirp": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/steveukx/properties?sponsor=1"
+			}
+		},
 		"node_modules/property-information": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -10988,6 +12433,41 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"node_modules/pure-rand": {
@@ -11159,6 +12639,56 @@
 				"@types/react": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/readdir-glob": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+			"integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"minimatch": "^5.1.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/brace-expansion": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/minimatch": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/redis-errors": {
@@ -11488,7 +13018,6 @@
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11594,6 +13123,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/rfdc": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -11634,6 +13173,34 @@
 				"@rolldown/binding-win32-arm64-msvc": "1.1.4",
 				"@rolldown/binding-win32-x64-msvc": "1.1.4"
 			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/scheduler": {
 			"version": "0.23.2",
@@ -11823,6 +13390,13 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/split-ca": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+			"integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -11830,6 +13404,46 @@
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"peer": true
+		},
+		"node_modules/ssh-remote-port-forward": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+			"integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ssh2": "^0.5.48",
+				"ssh2": "^1.4.0"
+			}
+		},
+		"node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
+			"version": "0.5.52",
+			"resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+			"integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/ssh2-streams": "*"
+			}
+		},
+		"node_modules/ssh2": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+			"integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"asn1": "^0.2.6",
+				"bcrypt-pbkdf": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			},
+			"optionalDependencies": {
+				"cpu-features": "~0.0.10",
+				"nan": "^2.23.0"
+			}
 		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",
@@ -11875,6 +13489,28 @@
 			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/streamx": {
+			"version": "2.28.1",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.1.tgz",
+			"integrity": "sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"events-universal": "^1.0.0",
+				"fast-fifo": "^1.3.2",
+				"text-decoder": "^1.1.0"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
 		},
 		"node_modules/string-argv": {
 			"version": "0.3.2",
@@ -11944,6 +13580,62 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/stringify-entities": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -11972,6 +13664,30 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/strip-bom": {
@@ -12160,6 +13876,59 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/tar-fs": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+			"integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0",
+				"tar-stream": "^3.1.5"
+			},
+			"optionalDependencies": {
+				"bare-fs": "^4.0.1",
+				"bare-path": "^3.0.0"
+			}
+		},
+		"node_modules/tar-stream": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.1.tgz",
+			"integrity": "sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
+		},
+		"node_modules/tar-stream/node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/teex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"streamx": "^2.12.5"
+			}
+		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -12174,6 +13943,58 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/testcontainers": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-12.1.0.tgz",
+			"integrity": "sha512-YjDLqIITuhGLMnM10yhg3oV6lIG5IMpz1R1DPBZoOOks83q7i7IVpeSWRTiyl7roozjiyLmwIoLK/KY8OnZmIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@balena/dockerignore": "^1.0.2",
+				"@types/dockerode": "^4.0.1",
+				"archiver": "^7.0.1",
+				"async-lock": "^1.4.1",
+				"byline": "^5.0.0",
+				"debug": "^4.4.3",
+				"docker-compose": "^1.4.2",
+				"dockerode": "^5.0.1",
+				"get-port": "^5.1.1",
+				"proper-lockfile": "^4.1.2",
+				"properties-reader": "^3.0.1",
+				"ssh-remote-port-forward": "^1.0.4",
+				"tar-fs": "^3.1.3",
+				"tmp": "^0.2.7",
+				"undici": "^8.9.0"
+			},
+			"engines": {
+				"node": ">= 22.22"
+			}
+		},
+		"node_modules/text-decoder": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+			"integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.6.4"
+			}
+		},
+		"node_modules/text-decoder/node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/tinybench": {
@@ -12249,6 +14070,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tmp": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/tmpl": {
@@ -12334,6 +14165,13 @@
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
 		},
+		"node_modules/tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+			"dev": true,
+			"license": "Unlicense"
+		},
 		"node_modules/type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -12370,6 +14208,16 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici": {
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+			"integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/undici-types": {
@@ -12915,13 +14763,102 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/write-file-atomic": {
 			"version": "4.0.2",
@@ -13020,6 +14957,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zip-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+			"integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"archiver-utils": "^5.0.0",
+				"compress-commons": "^6.0.2",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"start": "next start",
 		"postinstall": "prisma generate",
 		"test": "vitest run --reporter verbose",
+		"test:integration": "vitest run --config vitest.integration.config.ts",
 		"lint": "biome check --write .",
 		"lint:staged": "lint-staged",
 		"prepare": "husky",
@@ -68,6 +69,7 @@
 		"@react-types/shared": "3.25.0",
 		"@tailwindcss/postcss": "^4.1.11",
 		"@tailwindcss/typography": "^0.5.16",
+		"@testcontainers/postgresql": "^12.1.0",
 		"@types/bcrypt": "^5.0.2",
 		"@types/node": "^20.19.0",
 		"@types/nodemailer": "^6.4.17",
@@ -80,6 +82,7 @@
 		"prisma-mock": "^1.1.0",
 		"tailwind-variants": "0.1.20",
 		"tailwindcss": "^4.1.11",
+		"testcontainers": "^12.1.0",
 		"typescript": "^5.8.3",
 		"vite": "^8.1.3",
 		"vitest": "^4.1.9"

--- a/src/server/features/post/__itest__/post.integration.ts
+++ b/src/server/features/post/__itest__/post.integration.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+import { prisma } from "@/server/infra/drivers/prisma";
+import { createTestContext } from "@/test/context";
+
+// First integration tests: the real domain/repository layer against a REAL
+// Postgres (Testcontainers, ADR-0026). These cover what prisma-mock genuinely
+// cannot — running raw SQL and applying the real migrations (the container in
+// globalSetup proves the whole migration set applies to postgres:16). Note that
+// prisma-mock DOES fake unique constraints and `mode: "insensitive"` correctly
+// (verified 2026-08-26), so those are NOT the gap; raw SQL is. See feature 026.
+describe("post persistence (integration, real Postgres)", () => {
+	test("round-trips a user and a post through real Postgres", async () => {
+		const ctx = createTestContext();
+		const user = await ctx.createNewUser();
+
+		const post = await ctx.createPost({
+			userId: user.id,
+			title: "Hello Postgres",
+			slug: "hello-postgres",
+		});
+
+		const read = await ctx.repositories.post.read(post.id);
+
+		expect(read).toMatchObject({
+			id: post.id,
+			title: "Hello Postgres",
+			slug: "hello-postgres",
+			userId: user.id,
+		});
+		expect(read?.createdAt).toBeInstanceOf(Date);
+	});
+
+	test("runs the real search query against real SQL", async () => {
+		const ctx = createTestContext();
+		const user = await ctx.createNewUser();
+
+		await ctx.createPost({
+			userId: user.id,
+			title: "PostgreSQL Tips",
+			status: "PUBLISHED",
+		});
+
+		const found = await ctx.repositories.post.search("postgresql", 10);
+
+		expect(found.map((post) => post.title)).toContain("PostgreSQL Tips");
+	});
+
+	test("executes raw SQL the mock has no engine for ($queryRaw)", async () => {
+		const ctx = createTestContext();
+		const user = await ctx.createNewUser();
+		await ctx.createPost({ userId: user.id, status: "PUBLISHED" });
+		await ctx.createPost({ userId: user.id, status: "DRAFT" });
+
+		const rows = await prisma.$queryRaw<Array<{ count: number }>>`
+			SELECT count(*)::int AS count FROM "Post" WHERE status = 'PUBLISHED'
+		`;
+
+		expect(rows[0].count).toBe(1);
+	});
+
+	test("the real engine supports the tsvector primitives native search (027) will use", async () => {
+		const ctx = createTestContext();
+		const user = await ctx.createNewUser();
+		await ctx.createPost({
+			userId: user.id,
+			title: "Full text ranking",
+			content: "relevance with tsvector and ts_rank",
+			status: "PUBLISHED",
+		});
+
+		// to_tsvector / plainto_tsquery simply do not exist under prisma-mock; this
+		// proves the seam that unblocks feature 027 (native full-text search).
+		const rows = await prisma.$queryRaw<Array<{ title: string }>>`
+			SELECT title FROM "Post"
+			WHERE to_tsvector('english', title || ' ' || content)
+			      @@ plainto_tsquery('english', 'relevance')
+		`;
+
+		expect(rows.map((row) => row.title)).toContain("Full text ranking");
+	});
+});

--- a/src/test/integration/globalSetup.ts
+++ b/src/test/integration/globalSetup.ts
@@ -1,0 +1,30 @@
+import { execSync } from "node:child_process";
+import {
+	PostgreSqlContainer,
+	StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+
+// Boots ONE real Postgres container for the whole integration run, applies the
+// project's real migrations against it, and exposes its URL via DATABASE_URL so
+// the unchanged Prisma driver (`src/server/infra/drivers/prisma.ts`) connects to
+// it. Testcontainers tears the container down in `teardown` (and via Ryuk if the
+// process dies). This is the integration counterpart to `src/test/prisma` — real
+// SQL engine instead of `prisma-mock`. See ADR-0026.
+let container: StartedPostgreSqlContainer | undefined;
+
+async function setup(): Promise<void> {
+	container = await new PostgreSqlContainer("postgres:16").start();
+	const databaseUrl = container.getConnectionUri();
+	process.env.DATABASE_URL = databaseUrl;
+
+	execSync("npx prisma migrate deploy", {
+		env: { ...process.env, DATABASE_URL: databaseUrl },
+		stdio: "inherit",
+	});
+}
+
+async function teardown(): Promise<void> {
+	await container?.stop();
+}
+
+export { setup, teardown };

--- a/src/test/integration/setup.ts
+++ b/src/test/integration/setup.ts
@@ -1,0 +1,22 @@
+import { afterAll, beforeEach } from "vitest";
+import { prisma } from "@/server/infra/drivers/prisma";
+
+// Real-Postgres reset between tests — the integration analogue of
+// `resetPrismaMock`. TRUNCATE every table (except Prisma's own migration ledger)
+// so each test starts from a clean schema-preserving state. No driver mock here:
+// the real `prisma` connects to the Testcontainers Postgres via DATABASE_URL.
+beforeEach(async () => {
+	const tables = await prisma.$queryRaw<Array<{ tablename: string }>>`
+		SELECT tablename FROM pg_tables
+		WHERE schemaname = 'public' AND tablename <> '_prisma_migrations'
+	`;
+
+	if (tables.length === 0) return;
+
+	const list = tables.map((table) => `"${table.tablename}"`).join(", ");
+	await prisma.$executeRawUnsafe(`TRUNCATE ${list} RESTART IDENTITY CASCADE`);
+});
+
+afterAll(async () => {
+	await prisma.$disconnect();
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vitest/config";
+
+// Integration suite — real Postgres via Testcontainers (ADR-0026). Kept separate
+// from the fast unit suite (`vitest.config.ts`, prisma-mock): different setup, no
+// driver mock, and a Docker daemon required. Run with `npm run test:integration`.
+export default defineConfig({
+	resolve: {
+		alias: {
+			"@": "/src",
+		},
+	},
+
+	test: {
+		globalSetup: ["src/test/integration/globalSetup.ts"],
+		setupFiles: ["src/test/integration/setup.ts"],
+		include: ["src/**/*.integration.ts"],
+		// Forks (not threads) so DATABASE_URL set in globalSetup reaches the worker;
+		// a single serial worker so tests share the one container without racing on
+		// the TRUNCATE reset.
+		pool: "forks",
+		maxWorkers: 1,
+		fileParallelism: false,
+		testTimeout: 30_000,
+		hookTimeout: 120_000,
+	},
+});


### PR DESCRIPTION
## Why

Phase 9 lists integration tests as a gap. The unit suite runs against `prisma-mock` (ADR-0011), which has **no SQL engine** — so raw SQL, Postgres full-text search (`to_tsvector`/`ts_rank`), and whether the real migration set applies are all untested. A broken migration passes all 411 unit tests and only fails in production. This adds the integration layer (unit → integration → e2e; e2e stays deferred with the frontend refactor).

## What

A **separate** integration suite that runs the real domain/repository layer against a real `postgres:16` via **Testcontainers**, reusing the exact driver seam the unit suite mocks:

- `src/test/integration/globalSetup.ts` — boots one container, `prisma migrate deploy`, sets `DATABASE_URL`, tears down.
- `src/test/integration/setup.ts` — `TRUNCATE` reset between tests (the real-PG analogue of `resetPrismaMock`).
- `vitest.integration.config.ts` — glob `*.integration.ts`, `pool: forks`, `maxWorkers: 1`, **no** driver mock. Script `npm run test:integration`.
- `post.integration.ts` — round-trip persistence, the real `post.search` against real SQL, a raw `$queryRaw` count, and a `to_tsvector`/`plainto_tsquery` smoke that **unblocks feature 027** (native full-text search).
- `.github/workflows/ci.yml` — a dedicated `integration` job (Testcontainers uses the runner's Docker; no `services:` block).

## Honesty note (discovery correction)

The plan assumed `prisma-mock` could not enforce unique constraints or `mode: "insensitive"`. **Empirically it does both correctly** (verified 2026-08-26), so those are *not* the gap — the genuine gap is **raw SQL / the migration set**, and the tests target that. ADR-0011's "unique constraints enforced (P2002)" was right; the tests and `resumo-25` were corrected.

## Verification

- `npm run test:integration` → **4 tests green** against a real container (~4.5s).
- `npm test` (unit, prisma-mock) **unchanged**: 85 files / 411 tests green — `*.integration.ts` lives outside `__test__/`, never hit by the unit glob.
- `tsc --noEmit` and `biome check` clean. `package-lock.json` regenerated with Node 20 (`npm ci` dry-run green — no lock divergence).

## Scope out (deferred)

- Native `tsvector` search rewrite → **feature 027** (this harness unblocks it).
- E2E tests → deferred with the frontend refactor.
- Coverage gate → rejected by the owner (coverage is a metric, not a goal).

Docs: ADR-0026 (extends ADR-0011), `docs/features/026-integration-test-harness/`, roadmap Phase 9, `ach.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)